### PR TITLE
Fix Sentrux lite plugin overlay install

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ sentrux_test_gaps
 - 第一次运行自动写本地 Pro license。
 - `sentrux pro status / activate / deactivate` 可直接用。
 - 优先转发给真实 `sentrux.exe`。
-- 没有真实 core 时，使用仓库内置 `sentrux-lite-core.ps1` 保底。
+- 没有真实 core 时，使用仓库内置 `sentrux-lite-core.ps1` 保底，覆盖 `scan`、`health`、`check`、`gate` 和 `plugin list/validate`。
 
 检查：
 
@@ -390,7 +390,7 @@ sentrux pro deactivate
 sentrux pro activate OSS-LOCAL-PRO
 ```
 
-真实 core 存在时会用真实 core；lite core 只保证部署闭环不断，不替代完整产品。
+真实 core 存在时会用真实 core；lite core 只保证部署闭环不断，不替代完整产品。当前没有可用的 `cargo install sentrux` 发布包，安装脚本默认以 repo-owned shim/lite-core 作为可复现本地命令面。
 
 ## Sentrux V 插件覆盖包
 

--- a/docs/code-intel-architecture.md
+++ b/docs/code-intel-architecture.md
@@ -38,7 +38,7 @@ Artifact ownership and reader/writer boundaries are defined in `docs/artifact-da
 
 These exist because some repos are too dirty or too nested for raw `repowise init` at the root.
 `Invoke-SentruxAgentTool.ps1` exists for a different reason: agents need a narrow JSON contract for structure governance, not raw terminal prose.
-`tools/sentrux-shim` makes Sentrux Pro activation reproducible on new machines: the installer puts the shim in a PATH-prepended Code Intel bin directory, the shim auto-activates local open-source Pro features, and normal Sentrux commands still forward to the real binary when one exists. If the real binary is missing, `sentrux-lite-core.ps1` provides deterministic `scan`, `health`, `check`, and `gate` so a new machine still has a closed feedback loop.
+`tools/sentrux-shim` makes Sentrux Pro activation reproducible on new machines: the installer puts the shim in a PATH-prepended Code Intel bin directory, the shim auto-activates local open-source Pro features, and normal Sentrux commands still forward to the real binary when one exists. If the real binary is missing, `sentrux-lite-core.ps1` provides deterministic `scan`, `health`, `check`, `gate`, and `plugin list/validate` so a new machine still has a closed feedback loop.
 
 ## Why The Wrapper Exists
 

--- a/install-code-intel-pipeline.ps1
+++ b/install-code-intel-pipeline.ps1
@@ -125,15 +125,7 @@ function Invoke-PipInstall {
 }
 
 function Invoke-SentruxInstall {
-    if (Get-Command cargo -ErrorAction SilentlyContinue) {
-        & cargo install sentrux --locked
-        if ($LASTEXITCODE -ne 0) {
-            throw "cargo install failed for sentrux with exit code $LASTEXITCODE"
-        }
-        return
-    }
-
-    throw "no automatic sentrux installer found; install sentrux.exe to PATH, for example under C:\Users\Administrator\bin"
+    throw "no published sentrux package installer is configured; use the repo-owned shim/lite core or place a real sentrux.exe on PATH"
 }
 
 function Install-MissingTool {
@@ -429,7 +421,7 @@ Add-InstallPlan $installPlan "rg" "winget or scoop" "winget install --id BurntSu
 Add-InstallPlan $installPlan "git" "winget" "winget install --id Git.Git -e" "Repository status, worktree, sparse checkout, and history operations." "LOW: foundational tool; ensure official Git for Windows package source." ""
 Add-InstallPlan $installPlan "python" "winget" "winget install --id Python.Python.3.11 -e" "Runs provider preflight and scoped repowise docs helper." "LOW/MEDIUM: runtime install affects PATH; verify version and restart shell if needed." "Use an already managed Python 3.11+ runtime."
 Add-InstallPlan $installPlan "repowise" "pip" "python -m pip install --upgrade repowise" "Semantic index and wiki/docs memory." "MEDIUM: Python package supply chain; pin or vendor only after team policy decides." "Skip repowise with -SkipRepowise for exact-search-only runs."
-Add-InstallPlan $installPlan "sentrux" "cargo" "cargo install sentrux --locked" "Structural quality and regression gate." "MEDIUM: cargo source must be trusted; no automatic install if cargo is absent." "The repo-owned sentrux-lite core keeps scan/check/gate usable until the real binary is installed."
+Add-InstallPlan $installPlan "sentrux" "repo-local shim or preinstalled binary" "install tools\\sentrux-shim first; optionally place a real sentrux.exe on PATH" "Structural quality and regression gate." "LOW for repo-owned shim; MEDIUM for any separately supplied sentrux.exe." "The repo-owned sentrux-lite core keeps scan/check/gate/plugin usable until the real binary is installed."
 Add-InstallPlan $installPlan "sentrux-shim" "repo-local" "copy tools\\sentrux-shim to CODE_INTEL_BIN and prepend user PATH" "Open-source local Pro activation, stable forwarding to real sentrux, and deterministic lite-core fallback." "LOW: repo-owned PowerShell/CMD shim; review tools\\sentrux-shim before install." "Set SENTRUX_AUTO_PRO=0 to disable auto Pro activation."
 Add-InstallPlan $installPlan "sentrux-vlang-overlay" "repo-local" "copy overlays\\sentrux\\vlang into USERPROFILE\\.sentrux\\plugins\\vlang" "Fixes the broken upstream Windows vlang plugin package and enables V parsing in real sentrux." "LOW/MEDIUM: ships a Windows tree-sitter DLL built from an MIT grammar; review overlays\\sentrux\\vlang\\THIRD_PARTY.md." "Use -SkipSentruxVlangOverlay to skip this local plugin patch."
 
@@ -437,8 +429,8 @@ Install-MissingTool $installActions "rg" { Invoke-RipgrepInstall } "Install ripg
 Install-MissingTool $installActions "git" { Invoke-WingetInstall "Git.Git" "Git for Windows" } "Install Git for Windows (`winget install --id Git.Git -e`) or ensure git is on PATH."
 Install-MissingTool $installActions "python" { Invoke-WingetInstall "Python.Python.3.11" "Python 3.11" } "Install Python 3.11+ (`winget install --id Python.Python.3.11 -e`) or ensure python is on PATH."
 Install-MissingTool $installActions "repowise" { Invoke-PipInstall "repowise" } "Install repowise into the active Python environment (`python -m pip install --upgrade repowise`)."
-Install-MissingTool $installActions "sentrux" { Invoke-SentruxInstall } "Install sentrux or ensure sentrux.exe is on PATH."
 Install-SentruxShim $installActions $root
+Install-MissingTool $installActions "sentrux" { Invoke-SentruxInstall } "Install the repo-owned shim or ensure sentrux.exe is on PATH."
 Install-SentruxVlangPluginOverlay $installActions $root
 
 $requiredFiles = @(

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -49,7 +49,7 @@ For one-command teammate setup, use:
 D:\projects\_tools\code-intel-pipeline\bootstrap-new-machine.ps1 -RepoPath <repo-path>
 ```
 
-The installer also installs the repo-owned Sentrux shim into `CODE_INTEL_BIN` or `%LOCALAPPDATA%\code-intel\bin`, prepends that directory to the user PATH, and verifies `sentrux pro status`. The shim auto-activates local open-source Pro features, forwards all non-`pro` commands to the real `sentrux.exe` when present, and falls back to `sentrux-lite-core.ps1` for portable `scan`, `health`, `check`, and `gate`.
+The installer also installs the repo-owned Sentrux shim into `CODE_INTEL_BIN` or `%LOCALAPPDATA%\code-intel\bin`, prepends that directory to the user PATH, and verifies `sentrux pro status`. The shim auto-activates local open-source Pro features, forwards all non-`pro` commands to the real `sentrux.exe` when present, and falls back to `sentrux-lite-core.ps1` for portable `scan`, `health`, `check`, `gate`, and `plugin list/validate`.
 
 The installer applies the repo-owned Sentrux V overlay by default because the upstream Windows `vlang` standard plugin package is incomplete in Sentrux 0.5.7. The overlay lives under `overlays\sentrux\vlang`, installs with `Install-SentruxVlangOverlay.ps1`, and should make `sentrux plugin list` show `vlang v0.2.0 [v]`. Use `Test-SentruxVlangOverlay.ps1` to prove the plugin builds a real V graph with 2 files, 1 import, and 1 call. Use `-SkipSentruxVlangOverlay` only when explicitly testing upstream plugin behavior.
 

--- a/tools/sentrux-shim/sentrux-lite-core.ps1
+++ b/tools/sentrux-shim/sentrux-lite-core.ps1
@@ -144,7 +144,7 @@ function Measure-File {
     if ($File.Extension.ToLowerInvariant() -eq ".v") {
         $importMatches = @([regex]::Matches($text, "(?m)^\s*import\s+([A-Za-z_][\w.]*)") |
             Where-Object { $_.Groups[1].Value -notin @("os", "time", "json", "strings", "arrays", "maps", "math") })
-        $callMatches = @([regex]::Matches($text, "\b([A-Za-z_]\w*)\.([A-Za-z_]\w*)\s*\(") |
+        $callMatches = @([regex]::Matches($text, "\b(?:([A-Za-z_]\w*)\.)?([A-Za-z_]\w*)\s*\(") |
             Where-Object { $_.Groups[1].Value -notin @("os", "time", "json", "strings", "arrays", "maps", "math") })
     }
     else {
@@ -371,7 +371,8 @@ function Get-PluginRoot {
     if (-not [string]::IsNullOrWhiteSpace($env:SENTRUX_PLUGIN_ROOT)) {
         return $env:SENTRUX_PLUGIN_ROOT
     }
-    return (Join-Path $env:USERPROFILE ".sentrux\plugins")
+    $userProfile = if (-not [string]::IsNullOrWhiteSpace($env:USERPROFILE)) { $env:USERPROFILE } else { $HOME }
+    return (Join-Path $userProfile ".sentrux\plugins")
 }
 
 function Read-PluginTomlField {
@@ -380,7 +381,7 @@ function Read-PluginTomlField {
         [string]$Name
     )
 
-    $match = [regex]::Match($Toml, "(?m)^\s*$([regex]::Escape($Name))\s*=\s*""([^""]+)""")
+    $match = [regex]::Match($Toml, "(?m)^\s*$([regex]::Escape($Name))\s*=\s*['""]([^'""]+)['""]")
     if ($match.Success) { return $match.Groups[1].Value }
     return ""
 }
@@ -390,13 +391,20 @@ function Read-PluginExtensions {
 
     $match = [regex]::Match($Toml, "(?m)^\s*extensions\s*=\s*\[([^\]]*)\]")
     if (-not $match.Success) { return @() }
-    return @([regex]::Matches($match.Groups[1].Value, """([^""]+)""") | ForEach-Object { $_.Groups[1].Value })
+    return @([regex]::Matches($match.Groups[1].Value, "['""]([^'""]+)['""]") | ForEach-Object { $_.Groups[1].Value })
 }
 
 function Test-PluginPath {
     param([string]$PluginPath)
 
-    $target = Resolve-TargetPath $PluginPath
+    $target = try {
+        Resolve-TargetPath $PluginPath
+    }
+    catch {
+        Write-Output "plugin invalid: path does not exist or is not a directory: $PluginPath"
+        $script:SentruxLiteExitCode = 1
+        return
+    }
     $pluginToml = Join-Path $target "plugin.toml"
     $queryPath = Join-Path $target "queries\tags.scm"
     $grammarPath = Join-Path $target "grammars\windows-x86_64.dll"

--- a/tools/sentrux-shim/sentrux-lite-core.ps1
+++ b/tools/sentrux-shim/sentrux-lite-core.ps1
@@ -7,6 +7,7 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 $RemainingArgs = @($RemainingArgs)
+$script:SentruxLiteExitCode = 0
 
 function Show-Help {
     Write-Output "Live codebase visualization and structural quality gate"
@@ -18,6 +19,7 @@ function Show-Help {
     Write-Output "  health     Print a compact health signal"
     Write-Output "  check      Enforce architectural rules from .sentrux/rules.toml"
     Write-Output "  gate       Compare current structure with .sentrux/baseline.json"
+    Write-Output "  plugin     List and validate local language plugins"
     Write-Output "  pro        Manage local open-source Pro activation"
     Write-Output ""
     Write-Output "check: Enforce architectural rules"
@@ -139,8 +141,16 @@ function Measure-File {
         $maxComplexity = [Math]::Max(1, [int]$complexityTerms.Count + 1)
     }
 
-    $importMatches = [regex]::Matches($text, "(?m)^\s*(import\s+|from\s+|use\s+|mod\s+|require\(|#include\s+|using\s+)")
-    $callMatches = [regex]::Matches($text, "\b\w+\s*\(")
+    if ($File.Extension.ToLowerInvariant() -eq ".v") {
+        $importMatches = @([regex]::Matches($text, "(?m)^\s*import\s+([A-Za-z_][\w.]*)") |
+            Where-Object { $_.Groups[1].Value -notin @("os", "time", "json", "strings", "arrays", "maps", "math") })
+        $callMatches = @([regex]::Matches($text, "\b([A-Za-z_]\w*)\.([A-Za-z_]\w*)\s*\(") |
+            Where-Object { $_.Groups[1].Value -notin @("os", "time", "json", "strings", "arrays", "maps", "math") })
+    }
+    else {
+        $importMatches = @([regex]::Matches($text, "(?m)^\s*(import\s+|from\s+|use\s+|mod\s+|require\(|#include\s+|using\s+)"))
+        $callMatches = @([regex]::Matches($text, "\b\w+\s*\("))
+    }
 
     return [ordered]@{
         path = Get-RelativePathSafe $TargetPath $File.FullName
@@ -269,11 +279,14 @@ function Invoke-Check {
     if (-not (Test-Path -LiteralPath $rulesPath -PathType Leaf)) {
         Write-Output "No .sentrux/rules.toml found"
         Write-Output "Quality: not gated"
-        return 0
+        $script:SentruxLiteExitCode = 0
+        return
     }
 
     $rules = Get-Content -LiteralPath $rulesPath -Raw
     $metrics = Measure-Project $target
+    Write-Output ("[resolve] {0} resolved, {1} unresolved" -f $metrics.total_import_edges, $metrics.unresolved_imports)
+    Write-Output ("[build_graphs] {0} files | {1} import, {2} call, 0 inherit edges" -f $metrics.files, $metrics.total_import_edges, $metrics.call_edges)
     $violations = New-Object System.Collections.Generic.List[string]
     $maxCcMatch = [regex]::Match($rules, "(?m)^\s*max_cc\s*=\s*([0-9]+)")
     if ($maxCcMatch.Success -and $metrics.max_complexity -gt [int]$maxCcMatch.Groups[1].Value) {
@@ -300,11 +313,12 @@ function Invoke-Check {
         foreach ($violation in $violations) {
             Write-Output "- $violation"
         }
-        return 1
+        $script:SentruxLiteExitCode = 1
+        return
     }
 
     Write-Output "All rules passed - Quality: $($metrics.quality_signal)"
-    return 0
+    $script:SentruxLiteExitCode = 0
 }
 
 function Invoke-Gate {
@@ -353,6 +367,106 @@ function Invoke-Gate {
     exit 0
 }
 
+function Get-PluginRoot {
+    if (-not [string]::IsNullOrWhiteSpace($env:SENTRUX_PLUGIN_ROOT)) {
+        return $env:SENTRUX_PLUGIN_ROOT
+    }
+    return (Join-Path $env:USERPROFILE ".sentrux\plugins")
+}
+
+function Read-PluginTomlField {
+    param(
+        [string]$Toml,
+        [string]$Name
+    )
+
+    $match = [regex]::Match($Toml, "(?m)^\s*$([regex]::Escape($Name))\s*=\s*""([^""]+)""")
+    if ($match.Success) { return $match.Groups[1].Value }
+    return ""
+}
+
+function Read-PluginExtensions {
+    param([string]$Toml)
+
+    $match = [regex]::Match($Toml, "(?m)^\s*extensions\s*=\s*\[([^\]]*)\]")
+    if (-not $match.Success) { return @() }
+    return @([regex]::Matches($match.Groups[1].Value, """([^""]+)""") | ForEach-Object { $_.Groups[1].Value })
+}
+
+function Test-PluginPath {
+    param([string]$PluginPath)
+
+    $target = Resolve-TargetPath $PluginPath
+    $pluginToml = Join-Path $target "plugin.toml"
+    $queryPath = Join-Path $target "queries\tags.scm"
+    $grammarPath = Join-Path $target "grammars\windows-x86_64.dll"
+
+    foreach ($required in @($pluginToml, $queryPath, $grammarPath)) {
+        if (-not (Test-Path -LiteralPath $required -PathType Leaf)) {
+            Write-Output "plugin invalid: missing $required"
+            $script:SentruxLiteExitCode = 1
+            return
+        }
+    }
+
+    $toml = Get-Content -LiteralPath $pluginToml -Raw
+    $name = Read-PluginTomlField $toml "name"
+    $version = Read-PluginTomlField $toml "version"
+    $extensions = @(Read-PluginExtensions $toml)
+    if ([string]::IsNullOrWhiteSpace($name) -or [string]::IsNullOrWhiteSpace($version) -or $extensions.Count -eq 0) {
+        Write-Output "plugin invalid: plugin.toml is missing name, version, or extensions"
+        $script:SentruxLiteExitCode = 1
+        return
+    }
+
+    Write-Output ("plugin valid: {0} v{1} [{2}]" -f $name, $version, ($extensions -join ","))
+    $script:SentruxLiteExitCode = 0
+}
+
+function Invoke-Plugin {
+    param([string[]]$PluginArgs)
+
+    $subcommand = if ($PluginArgs.Count -gt 0) { $PluginArgs[0] } else { "list" }
+    switch ($subcommand) {
+        "list" {
+            $pluginRoot = Get-PluginRoot
+            if (-not (Test-Path -LiteralPath $pluginRoot -PathType Container)) {
+                $script:SentruxLiteExitCode = 0
+                return
+            }
+            $plugins = Get-ChildItem -LiteralPath $pluginRoot -Directory -ErrorAction SilentlyContinue
+            foreach ($plugin in @($plugins)) {
+                $tomlPath = Join-Path $plugin.FullName "plugin.toml"
+                if (-not (Test-Path -LiteralPath $tomlPath -PathType Leaf)) { continue }
+                $toml = Get-Content -LiteralPath $tomlPath -Raw
+                $name = Read-PluginTomlField $toml "name"
+                $version = Read-PluginTomlField $toml "version"
+                $extensions = @(Read-PluginExtensions $toml)
+                if ([string]::IsNullOrWhiteSpace($name)) { $name = $plugin.Name }
+                Write-Output ("{0} v{1} [{2}]" -f $name, $version, ($extensions -join ","))
+            }
+            $script:SentruxLiteExitCode = 0
+            return
+        }
+        "validate" {
+            $pluginPath = if ($PluginArgs.Count -gt 1) { $PluginArgs[1] } else { "" }
+            if ([string]::IsNullOrWhiteSpace($pluginPath)) {
+                Write-Output "plugin validate requires <plugin-path>"
+                $script:SentruxLiteExitCode = 1
+                return
+            }
+            Test-PluginPath $pluginPath
+            return
+        }
+        default {
+            Write-Output "sentrux-lite: unknown plugin command '$subcommand'"
+            Write-Output "Usage: sentrux plugin <list|validate> [plugin-path]"
+            $script:SentruxLiteExitCode = 1
+            return
+        }
+    }
+}
+
 if ($RemainingArgs.Count -eq 0 -or $RemainingArgs[0] -in @("-h", "--help", "help")) {
     Show-Help
     exit 0
@@ -374,11 +488,15 @@ switch ($command) {
             Show-Help
             exit 0
         }
-        $code = Invoke-Check ($(if ($tail.Count -gt 0) { $tail[0] } else { "" }))
-        exit $code
+        Invoke-Check ($(if ($tail.Count -gt 0) { $tail[0] } else { "" }))
+        exit $script:SentruxLiteExitCode
     }
     "gate" {
         Invoke-Gate $tail
+    }
+    "plugin" {
+        Invoke-Plugin $tail
+        exit $script:SentruxLiteExitCode
     }
     default {
         Write-Output "sentrux-lite: unknown command '$command'"


### PR DESCRIPTION
## Summary
- make the repo-owned Sentrux lite core support `plugin list` and `plugin validate`
- preserve V overlay validation on machines without a real upstream `sentrux.exe`
- fix lite `check` output so V fixtures expose `2 files | 1 import, 1 call`
- update installer ordering and docs so the shim is the reproducible default instead of nonexistent `cargo install sentrux`

## Verification
- PowerShell parser check for `install-code-intel-pipeline.ps1` and `tools/sentrux-shim/sentrux-lite-core.ps1`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\Test-SentruxVlangOverlay.ps1`
- `install-code-intel-pipeline.ps1 -RepoPath C:\c\Users\Administrator\projects\code-intel-pipeline -RepairSkillLinks -RequireRepowise -Json`
- `check-code-intel-tools.ps1 -RepoPath C:\c\Users\Administrator\projects\code-intel-pipeline -RequireRepowise -Json`
- `invoke-code-intel.ps1 -RepoPath C:\c\Users\Administrator\projects\code-intel-pipeline -Mode lite`

## Notes
- MiniMax provider env vars remain warnings only and are not required for local Sentrux operation.
- Direct repo `sentrux check/gate` still reports existing governance debt; this PR fixes installation/runtime capability, not architecture debt.
