### PR TITLE
v0.5.1-beta.1: paired tool effectiveness benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1-beta.1] — 2026-07-25
+
 ### Added
 
+- A deterministic paired tool-effectiveness scorer for frozen `C0`, `C1`, and
+  `Cfull` Agent runs, with externally attested outcomes, exact experiment
+  profile matching, and atomic benchmark reports.
+- ADRs that freeze canonical EntityRef identity and the first real-world
+  dogfood evaluation baseline before expanding provider-specific ablations.
 - Built-in `sentrux-native` structural gate engine (`code-intel sentrux --operation
   scan|health|check|gate|save_baseline`): deterministic metrics, structured
   violations with target files, and real resolved-import cycle detection for

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "code-intel"
-version = "0.5.0"
+version = "0.5.1-beta.1"
 dependencies = [
  "serde_json",
 ]

--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ PowerShell 合同测试已迁到 `scripts/tests/`。其余根目录兼容 facade
 
 缺少这些增强工具时，流水线必须明确记录 skipped、manual-required 或 provider failure，不能把它们冒充成功，也不能因此阻断只依赖核心路径的 public beta。详细支持矩阵和已知边界见 [Public beta guide](docs/public-beta.md)。
 
+0.5.1 beta 还提供可重放的工具效果基线评分器。它不会把工具“能运行”误当成“对 Agent 有帮助”；只有冻结任务、配对条件和外部证明完整时才记录基线：
+
+```powershell
+code-intel benchmark tools --corpus <corpus.json> --runs <runs.json> --artifact-root <authority-root> --out <new-directory>
+```
+
+实验边界和当前可证明结论见 [Tool Effectiveness Baseline](docs/tool-effectiveness-baseline.md)。
+
 ## 这是什么
 
 `Code Intel Pipeline` 是一套本地仓库理解工具链。

--- a/crates/code-intel-cli/Cargo.toml
+++ b/crates/code-intel-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "code-intel"
-version = "0.5.0"
+version = "0.5.1-beta.1"
 edition = "2021"
 description = "Local Code Intel Pipeline CLI for artifact resume and contract checks"
 license = "MIT"

--- a/crates/code-intel-cli/src/main.rs
+++ b/crates/code-intel-cli/src/main.rs
@@ -47,11 +47,23 @@ mod snapshot;
 mod stable_artifact;
 mod staged_artifact;
 mod survival_scan;
+mod tool_effectiveness_benchmark;
 
 type Result<T> = std::result::Result<T, Box<dyn Error>>;
 
 fn run_capability(raw: &[String]) -> i32 {
     capability::run_raw(raw, capability_inventory::execute)
+}
+
+fn run_benchmark(raw: &[String]) -> i32 {
+    match raw.first().map(String::as_str) {
+        Some("orientation") => project_orientation_benchmark::run_raw(raw),
+        Some("tools") => tool_effectiveness_benchmark::run_raw(raw),
+        _ => {
+            eprintln!("usage: benchmark <orientation|tools> [benchmark-specific options]");
+            64
+        }
+    }
 }
 
 #[derive(Debug, Default)]
@@ -631,7 +643,7 @@ const RAW_ROUTES: &[RawRoute] = &[
         command: "benchmark",
         subcommand: None,
         argument_offset: 1,
-        runner: project_orientation_benchmark::run_raw,
+        runner: run_benchmark,
     },
     RawRoute {
         command: "snapshot",
@@ -1745,6 +1757,8 @@ Commands:
   run execute --repo <repo-root> --out <run-staging-directory> --authority-root <publication-root> --final-name <name> [--profile default|strict|offline] [--manifest <integrations.json>] [--max-concurrency <n>] [--session-evidence <session-evidence.json>]
   run dag-coordinate --repo <repo-root> --out <run-staging-directory> [--manifest <integrations.json>] [--max-concurrency <n>] [--session-evidence <session-evidence.json>]
   run commit --source-root <A09-artifact-root> --authority-root <publication-root> --manifest-ref <artifact-ref.json> --final-name <name>
+  benchmark orientation --out <directory> [--repetitions <2..10>]
+  benchmark tools --corpus <corpus.json> --runs <runs.json> --artifact-root <directory> --out <directory>
   governance ponytail-gate --request <request.json|->
   orchestrate [--action Validate|List|Plan] [--repo <path>] [--mode lite|normal|full] [--capability <name>] [--manifest <path>] [--json]"#;
 

--- a/crates/code-intel-cli/src/run_commit.rs
+++ b/crates/code-intel-cli/src/run_commit.rs
@@ -842,6 +842,13 @@ fn sync_directory(path: &Path) -> Result<(), CommitError> {
 fn rename_directory_no_replace(source: &Path, destination: &Path) -> Result<(), CommitError> {
     rename_windows_no_replace(source, destination, "promote staged run")
 }
+
+pub(crate) fn publish_directory_no_replace(
+    source: &Path,
+    destination: &Path,
+) -> Result<(), String> {
+    rename_directory_no_replace(source, destination).map_err(|error| error.to_string())
+}
 #[cfg(windows)]
 fn rename_file_no_replace(source: &Path, destination: &Path) -> Result<(), CommitError> {
     rename_windows_no_replace(source, destination, "publish completion marker")

--- a/crates/code-intel-cli/src/tool_effectiveness_benchmark.rs
+++ b/crates/code-intel-cli/src/tool_effectiveness_benchmark.rs
@@ -1,0 +1,822 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde_json::{json, Value};
+
+use crate::artifact_ref::{self, ArtifactContract};
+use crate::capability::{reject_duplicate_json_keys, sha256_hex};
+
+const CONDITIONS: [&str; 3] = ["C0", "C1", "Cfull"];
+const MAX_INPUT_BYTES: u64 = 8 * 1024 * 1024;
+
+pub(crate) fn run_raw(raw: &[String]) -> i32 {
+    match run(raw) {
+        Ok(report) => {
+            println!("{}", serde_json::to_string(&report).unwrap());
+            0
+        }
+        Err((code, message)) => {
+            eprintln!("{message}");
+            code
+        }
+    }
+}
+
+struct Cli {
+    corpus: PathBuf,
+    runs: PathBuf,
+    artifact_root: PathBuf,
+    out: PathBuf,
+}
+
+fn run(raw: &[String]) -> Result<Value, (i32, String)> {
+    let cli = parse_cli(raw)?;
+    let corpus = read_json(&cli.corpus, "corpus")?;
+    let runs = read_json(&cli.runs, "runs")?;
+    let attestations =
+        verify_attestations(&corpus, &runs, &cli.artifact_root).map_err(|message| (65, message))?;
+    let report = evaluate(&corpus, &runs, &attestations).map_err(|message| (65, message))?;
+    publish_reports(&cli.out, &report)?;
+    Ok(report)
+}
+
+fn parse_cli(raw: &[String]) -> Result<Cli, (i32, String)> {
+    if raw.first().map(String::as_str) != Some("tools") {
+        return Err((64, usage()));
+    }
+    let mut corpus = None;
+    let mut runs = None;
+    let mut artifact_root = None;
+    let mut out = None;
+    let mut index = 1;
+    while index < raw.len() {
+        let flag = raw[index].as_str();
+        if !matches!(flag, "--corpus" | "--runs" | "--artifact-root" | "--out") {
+            return Err((64, format!("unknown tool benchmark argument: {flag}")));
+        }
+        let value = raw
+            .get(index + 1)
+            .filter(|value| !value.is_empty() && !value.starts_with("--"))
+            .ok_or_else(|| (64, format!("{flag} requires one value")))?;
+        match flag {
+            "--corpus" if corpus.replace(PathBuf::from(value)).is_some() => {
+                return Err((64, "duplicate --corpus".into()))
+            }
+            "--runs" if runs.replace(PathBuf::from(value)).is_some() => {
+                return Err((64, "duplicate --runs".into()))
+            }
+            "--artifact-root" if artifact_root.replace(PathBuf::from(value)).is_some() => {
+                return Err((64, "duplicate --artifact-root".into()))
+            }
+            "--out" if out.replace(PathBuf::from(value)).is_some() => {
+                return Err((64, "duplicate --out".into()))
+            }
+            _ => {}
+        }
+        index += 2;
+    }
+    Ok(Cli {
+        corpus: corpus.ok_or_else(|| (64, usage()))?,
+        runs: runs.ok_or_else(|| (64, usage()))?,
+        artifact_root: artifact_root.ok_or_else(|| (64, usage()))?,
+        out: out.ok_or_else(|| (64, usage()))?,
+    })
+}
+
+fn usage() -> String {
+    "usage: benchmark tools --corpus <corpus.json> --runs <runs.json> --artifact-root <directory> --out <directory>".into()
+}
+
+fn read_json(path: &Path, label: &str) -> Result<Value, (i32, String)> {
+    let metadata =
+        fs::metadata(path).map_err(|error| (74, format!("read {label} metadata: {error}")))?;
+    if metadata.len() > MAX_INPUT_BYTES {
+        return Err((65, format!("{label} exceeds {MAX_INPUT_BYTES} bytes")));
+    }
+    let bytes = fs::read(path).map_err(|error| (74, format!("read {label}: {error}")))?;
+    let text = std::str::from_utf8(&bytes)
+        .map_err(|error| (65, format!("{label} must be UTF-8 JSON: {error}")))?;
+    reject_duplicate_json_keys(text).map_err(|error| (65, format!("parse {label}: {error}")))?;
+    serde_json::from_slice(&bytes).map_err(|error| (65, format!("parse {label}: {error}")))
+}
+
+fn write_new(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    let mut file = fs::OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(path)
+        .map_err(|error| format!("create {}: {error}", path.display()))?;
+    std::io::Write::write_all(&mut file, bytes)
+        .map_err(|error| format!("write {}: {error}", path.display()))
+}
+
+fn publish_reports(out: &Path, report: &Value) -> Result<(), (i32, String)> {
+    let parent = out
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .ok_or_else(|| {
+            (
+                74,
+                "benchmark output requires a parent directory".to_string(),
+            )
+        })?;
+    let name = out
+        .file_name()
+        .and_then(|value| value.to_str())
+        .ok_or_else(|| {
+            (
+                74,
+                "benchmark output name must be portable UTF-8".to_string(),
+            )
+        })?;
+    let staging = parent.join(format!(".{name}.tmp-{}", std::process::id()));
+    fs::create_dir(&staging)
+        .map_err(|error| (74, format!("create benchmark staging directory: {error}")))?;
+    let report_bytes = serde_json::to_vec(report)
+        .map_err(|error| (74, format!("serialize tool benchmark report: {error}")))?;
+    let markdown_bytes = render_markdown(report).into_bytes();
+    let completion = serde_json::to_vec(&json!({
+        "schema":"code-intel-tool-effectiveness-publication.v1",
+        "reportSha256":sha256_hex(&report_bytes),
+        "markdownSha256":sha256_hex(&markdown_bytes)
+    }))
+    .map_err(|error| {
+        (
+            74,
+            format!("serialize benchmark completion manifest: {error}"),
+        )
+    })?;
+    let staged = (|| -> Result<(), String> {
+        write_new(&staging.join("report.json"), &report_bytes)?;
+        write_new(&staging.join("report.md"), &markdown_bytes)?;
+        write_new(&staging.join("completion.json"), &completion)
+    })();
+    if let Err(message) = staged {
+        let _ = fs::remove_dir_all(&staging);
+        return Err((74, message));
+    }
+    if let Err(error) = crate::run_commit::publish_directory_no_replace(&staging, out) {
+        let _ = fs::remove_dir_all(&staging);
+        return Err((74, format!("commit benchmark output directory: {error}")));
+    }
+    Ok(())
+}
+
+#[derive(Clone)]
+struct Case {
+    snapshot_identity: String,
+    relevant: BTreeSet<String>,
+    root_causes: BTreeSet<String>,
+}
+
+#[derive(Clone)]
+struct ScoredRun {
+    run_id: String,
+    case_id: String,
+    condition: String,
+    repetition: u64,
+    profile_digest: String,
+    treatment_digest: String,
+    context_digest: String,
+    attestation_digest: String,
+    status: String,
+    root_cause_recall: f64,
+    evidence_precision: f64,
+    reciprocal_rank: f64,
+    diagnosis_root_cause_recall: f64,
+    diagnosis_exact: f64,
+    attestation_success: f64,
+    unsupported_claim_rate: f64,
+    wall_time_ms: f64,
+    input_tokens: f64,
+    output_tokens: f64,
+    tool_calls: f64,
+    artifact_bytes: f64,
+}
+
+fn verify_attestations(
+    corpus: &Value,
+    runs: &Value,
+    artifact_root: &Path,
+) -> Result<BTreeMap<String, bool>, String> {
+    require_schema(
+        corpus,
+        "code-intel-tool-effectiveness-corpus.v1",
+        "tool effectiveness corpus",
+    )?;
+    require_schema(
+        runs,
+        "code-intel-tool-effectiveness-runs.v1",
+        "tool effectiveness runs",
+    )?;
+    let cases = parse_cases(corpus)?;
+    let treatments = parse_treatments(corpus)?;
+    let verifier_identity =
+        required_string(corpus, "verifierIdentity", "tool effectiveness corpus")?;
+    let values = runs
+        .get("runs")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "tool effectiveness runs must be an array".to_string())?;
+    let contract = ArtifactContract {
+        artifact_schema: "code-intel-external-attestation.v1",
+        artifact_type: "benchmark.external-attestation",
+        max_bytes: MAX_INPUT_BYTES,
+        validate_payload: validate_attestation_payload,
+    };
+    let mut verified = BTreeMap::new();
+    for value in values {
+        let run_id = required_string(value, "runId", "run")?;
+        let case_id = required_string(value, "caseId", "run")?;
+        let case = cases
+            .get(case_id)
+            .ok_or_else(|| format!("run {run_id} references unknown case {case_id}"))?;
+        let condition = required_string(value, "condition", "run")?;
+        let treatment_digest = treatments
+            .get(condition)
+            .ok_or_else(|| format!("run {run_id} has unsupported condition {condition}"))?;
+        let artifact = value
+            .get("attestationRef")
+            .ok_or_else(|| format!("run {run_id} requires attestationRef"))?;
+        let attestation = artifact_ref::verify_artifact_ref(
+            artifact_root,
+            &case.snapshot_identity,
+            contract,
+            artifact,
+        )
+        .map_err(|error| {
+            format!(
+                "run {run_id} ExternalAttestation verification failed: {}",
+                error.message()
+            )
+        })?;
+        let payload: Value = serde_json::from_slice(attestation.bytes())
+            .map_err(|error| format!("parse run {run_id} ExternalAttestation: {error}"))?;
+        if payload["runId"] != run_id
+            || payload["caseId"] != case_id
+            || payload["snapshotIdentity"] != case.snapshot_identity
+            || payload["condition"] != condition
+            || payload["treatmentDigest"] != treatment_digest.as_str()
+            || payload["contextDigest"] != value["contextDigest"]
+            || payload["experimentProfileDigest"] != value["experimentProfileDigest"]
+            || payload["verifierIdentity"] != verifier_identity
+        {
+            return Err(format!(
+                "run {run_id} ExternalAttestation is not bound to its run, case, snapshot, treatment, context, experiment, and verifier"
+            ));
+        }
+        if verified
+            .insert(
+                run_id.to_string(),
+                required_bool(&payload, "passed", "ExternalAttestation")?,
+            )
+            .is_some()
+        {
+            return Err(format!("duplicate tool effectiveness run: {run_id}"));
+        }
+    }
+    Ok(verified)
+}
+
+fn validate_attestation_payload(bytes: &[u8]) -> Result<(), String> {
+    let text = std::str::from_utf8(bytes)
+        .map_err(|error| format!("ExternalAttestation must be UTF-8 JSON: {error}"))?;
+    reject_duplicate_json_keys(text)?;
+    let value: Value = serde_json::from_str(text)
+        .map_err(|error| format!("parse ExternalAttestation: {error}"))?;
+    require_exact_fields(
+        &value,
+        "ExternalAttestation",
+        &[
+            "schema",
+            "runId",
+            "caseId",
+            "snapshotIdentity",
+            "condition",
+            "treatmentDigest",
+            "contextDigest",
+            "experimentProfileDigest",
+            "passed",
+            "verifierIdentity",
+            "method",
+            "evidenceRefs",
+        ],
+    )?;
+    require_schema(
+        &value,
+        "code-intel-external-attestation.v1",
+        "ExternalAttestation",
+    )?;
+    required_string(&value, "runId", "ExternalAttestation")?;
+    required_string(&value, "caseId", "ExternalAttestation")?;
+    required_digest(&value, "snapshotIdentity", "ExternalAttestation")?;
+    let condition = required_string(&value, "condition", "ExternalAttestation")?;
+    if !CONDITIONS.contains(&condition) {
+        return Err(format!(
+            "ExternalAttestation.condition has unsupported value {condition}"
+        ));
+    }
+    required_digest(&value, "treatmentDigest", "ExternalAttestation")?;
+    required_digest(&value, "contextDigest", "ExternalAttestation")?;
+    required_digest(&value, "experimentProfileDigest", "ExternalAttestation")?;
+    required_bool(&value, "passed", "ExternalAttestation")?;
+    required_string(&value, "verifierIdentity", "ExternalAttestation")?;
+    let method = required_string(&value, "method", "ExternalAttestation")?;
+    if method != "frozen_evidence_replay" {
+        return Err(format!(
+            "ExternalAttestation.method has unsupported value {method}"
+        ));
+    }
+    let evidence_refs = string_array(&value, "evidenceRefs", "ExternalAttestation")?;
+    if evidence_refs.is_empty() {
+        return Err("ExternalAttestation.evidenceRefs must not be empty".into());
+    }
+    for reference in evidence_refs {
+        validate_artifact_entity_ref(reference)?;
+    }
+    Ok(())
+}
+
+fn validate_experiment_profile(run: &Value, case: &Case, run_id: &str) -> Result<String, String> {
+    let experiment = run
+        .get("experiment")
+        .ok_or_else(|| format!("run {run_id} requires experiment"))?;
+    require_exact_fields(
+        experiment,
+        "run.experiment",
+        &[
+            "model",
+            "reasoning",
+            "promptDigest",
+            "budgetDigest",
+            "permissionProfileDigest",
+            "toolSnapshotDigest",
+            "seed",
+        ],
+    )?;
+    let canonical = json!({
+        "snapshotIdentity":case.snapshot_identity,
+        "model":required_string(experiment, "model", "run.experiment")?,
+        "reasoning":required_string(experiment, "reasoning", "run.experiment")?,
+        "promptDigest":required_digest(experiment, "promptDigest", "run.experiment")?,
+        "budgetDigest":required_digest(experiment, "budgetDigest", "run.experiment")?,
+        "permissionProfileDigest":required_digest(experiment, "permissionProfileDigest", "run.experiment")?,
+        "toolSnapshotDigest":required_digest(experiment, "toolSnapshotDigest", "run.experiment")?,
+        "seed":required_u64(experiment, "seed", "run.experiment")?
+    });
+    let actual = sha256_hex(
+        &serde_json::to_vec(&canonical)
+            .map_err(|error| format!("serialize run {run_id} experiment profile: {error}"))?,
+    );
+    let declared = required_digest(run, "experimentProfileDigest", "run")?;
+    if actual != declared {
+        return Err(format!(
+            "run {run_id} experimentProfileDigest does not match its frozen experiment fields"
+        ));
+    }
+    Ok(actual)
+}
+
+pub(crate) fn evaluate(
+    corpus: &Value,
+    runs: &Value,
+    attestations: &BTreeMap<String, bool>,
+) -> Result<Value, String> {
+    require_exact_fields(
+        corpus,
+        "tool effectiveness corpus",
+        &[
+            "schema",
+            "corpusId",
+            "topK",
+            "repetitions",
+            "verifierIdentity",
+            "treatments",
+            "cases",
+        ],
+    )?;
+    require_exact_fields(
+        runs,
+        "tool effectiveness runs",
+        &["schema", "corpusId", "runs"],
+    )?;
+    require_schema(
+        corpus,
+        "code-intel-tool-effectiveness-corpus.v1",
+        "tool effectiveness corpus",
+    )?;
+    require_schema(
+        runs,
+        "code-intel-tool-effectiveness-runs.v1",
+        "tool effectiveness runs",
+    )?;
+    let corpus_id = required_string(corpus, "corpusId", "corpus")?;
+    if required_string(runs, "corpusId", "runs")? != corpus_id {
+        return Err("tool effectiveness runs target a different corpus".into());
+    }
+    let top_k = required_u64(corpus, "topK", "corpus")?;
+    if !(1..=100).contains(&top_k) {
+        return Err("tool effectiveness corpus topK must be 1..100".into());
+    }
+    let repetitions = required_u64(corpus, "repetitions", "corpus")?;
+    if !(1..=10).contains(&repetitions) {
+        return Err("tool effectiveness corpus repetitions must be 1..10".into());
+    }
+    let cases = parse_cases(corpus)?;
+    let treatments = parse_treatments(corpus)?;
+    let scored = parse_runs(runs, &cases, &treatments, attestations, top_k)?;
+    validate_pairing(&cases, &scored, repetitions)?;
+    let valid_pair_count = count_valid_pairs(&cases, &scored, repetitions);
+    let expected_pair_count = cases.len() * repetitions as usize;
+    let verdict = if valid_pair_count == expected_pair_count {
+        "baseline_recorded"
+    } else {
+        "insufficient_evidence"
+    };
+
+    let variants = CONDITIONS
+        .iter()
+        .map(|condition| aggregate(condition, &scored))
+        .collect::<Vec<_>>();
+    let comparisons = ["C1", "Cfull"]
+        .iter()
+        .map(|condition| paired_comparison(condition, &scored))
+        .collect::<Vec<_>>();
+    let case_results = scored.iter().map(scored_run_json).collect::<Vec<_>>();
+
+    Ok(json!({
+        "schema":"code-intel-tool-effectiveness-benchmark.v1",
+        "verdict":verdict,
+        "inputs":{
+            "corpusSha256":document_digest(corpus)?,
+            "runsSha256":document_digest(runs)?,
+            "verifierIdentity":required_string(corpus, "verifierIdentity", "corpus")?,
+            "treatments":treatments
+        },
+        "corpus":{
+            "id":corpus_id,
+            "caseCount":cases.len(),
+            "repetitions":repetitions,
+            "topK":top_k
+        },
+        "method":{
+            "conditions":CONDITIONS,
+            "pairing":"same_case_repetition_and_experiment_profile",
+            "unavailablePolicy":"reported_separately_not_scored_as_incorrect",
+            "oracleVisibility":"external_to_agent_and_capsule_assembler",
+            "compositeScore":false
+        },
+        "evidenceGate":{
+            "validPairCount":valid_pair_count,
+            "expectedPairCount":expected_pair_count,
+            "complete":valid_pair_count == expected_pair_count
+        },
+        "caseResults":case_results,
+        "variants":variants,
+        "pairedComparisons":comparisons,
+        "limitations":[
+            "v0 is a recorded paired baseline, not a population-level statistical claim",
+            "quality aggregates include completed and honest domain-unknown runs; unavailable and process-failed runs remain separate reliability outcomes",
+            "attestation truth depends on the corpus-pinned verifier and authority root; the scorer verifies artifact integrity and complete run/treatment/context binding"
+        ]
+    }))
+}
+
+fn parse_cases(corpus: &Value) -> Result<BTreeMap<String, Case>, String> {
+    let values = corpus
+        .get("cases")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "tool effectiveness corpus cases must be an array".to_string())?;
+    if values.is_empty() {
+        return Err("tool effectiveness corpus must contain at least one case".into());
+    }
+    let mut cases = BTreeMap::new();
+    for value in values {
+        require_exact_fields(
+            value,
+            "case",
+            &[
+                "id",
+                "snapshotIdentity",
+                "relevantEntities",
+                "rootCauseEntities",
+            ],
+        )?;
+        let id = required_string(value, "id", "case")?.to_string();
+        let relevant = string_set(value, "relevantEntities", "case")?;
+        let root_causes = string_set(value, "rootCauseEntities", "case")?;
+        if root_causes.is_empty() || !root_causes.is_subset(&relevant) {
+            return Err(format!(
+                "case {id} rootCauseEntities must be a non-empty subset of relevantEntities"
+            ));
+        }
+        let snapshot_identity = required_digest(value, "snapshotIdentity", "case")?.to_string();
+        if cases
+            .insert(
+                id.clone(),
+                Case {
+                    snapshot_identity,
+                    relevant,
+                    root_causes,
+                },
+            )
+            .is_some()
+        {
+            return Err(format!("duplicate tool effectiveness case: {id}"));
+        }
+    }
+    Ok(cases)
+}
+
+fn parse_treatments(corpus: &Value) -> Result<BTreeMap<String, String>, String> {
+    let treatments = corpus
+        .get("treatments")
+        .ok_or_else(|| "tool effectiveness corpus requires treatments".to_string())?;
+    require_exact_fields(treatments, "corpus.treatments", &CONDITIONS)?;
+    CONDITIONS
+        .iter()
+        .map(|condition| {
+            Ok((
+                (*condition).to_string(),
+                required_digest(treatments, condition, "corpus.treatments")?.to_string(),
+            ))
+        })
+        .collect()
+}
+
+fn parse_runs(
+    document: &Value,
+    cases: &BTreeMap<String, Case>,
+    treatments: &BTreeMap<String, String>,
+    attestations: &BTreeMap<String, bool>,
+    top_k: u64,
+) -> Result<Vec<ScoredRun>, String> {
+    let values = document
+        .get("runs")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "tool effectiveness runs must be an array".to_string())?;
+    let mut ids = BTreeSet::new();
+    let mut scored = Vec::with_capacity(values.len());
+    for value in values {
+        require_exact_fields(
+            value,
+            "run",
+            &[
+                "runId",
+                "caseId",
+                "condition",
+                "repetition",
+                "status",
+                "snapshotIdentity",
+                "experiment",
+                "experimentProfileDigest",
+                "treatmentDigest",
+                "contextDigest",
+                "rankedEntities",
+                "diagnosisEntities",
+                "attestationRef",
+                "unsupportedClaims",
+                "claimCount",
+                "wallTimeMs",
+                "inputTokens",
+                "outputTokens",
+                "toolCalls",
+                "artifactBytes",
+            ],
+        )?;
+        let run_id = required_string(value, "runId", "run")?.to_string();
+        if !ids.insert(run_id.clone()) {
+            return Err(format!("duplicate tool effectiveness run: {run_id}"));
+        }
+        let case_id = required_string(value, "caseId", "run")?.to_string();
+        let case = cases
+            .get(&case_id)
+            .ok_or_else(|| format!("run {run_id} references unknown case {case_id}"))?;
+        if required_digest(value, "snapshotIdentity", "run")? != case.snapshot_identity {
+            return Err(format!(
+                "run {run_id} snapshot identity differs from its case"
+            ));
+        }
+        let condition = required_string(value, "condition", "run")?.to_string();
+        if !CONDITIONS.contains(&condition.as_str()) {
+            return Err(format!(
+                "run {run_id} has unsupported condition {condition}"
+            ));
+        }
+        let treatment_digest = required_digest(value, "treatmentDigest", "run")?.to_string();
+        if treatments.get(&condition) != Some(&treatment_digest) {
+            return Err(format!(
+                "run {run_id} treatmentDigest differs from corpus treatment {condition}"
+            ));
+        }
+        let repetition = required_u64(value, "repetition", "run")?;
+        let status = required_string(value, "status", "run")?.to_string();
+        if ![
+            "completed",
+            "domain_unknown",
+            "unavailable",
+            "process_failed",
+        ]
+        .contains(&status.as_str())
+        {
+            return Err(format!("run {run_id} has unsupported status {status}"));
+        }
+        let profile_digest = validate_experiment_profile(value, case, &run_id)?;
+        let context_digest = required_digest(value, "contextDigest", "run")?.to_string();
+        let attestation_digest = required_digest(
+            value
+                .get("attestationRef")
+                .ok_or_else(|| format!("run {run_id} requires attestationRef"))?,
+            "sha256",
+            "run.attestationRef",
+        )?
+        .to_string();
+        let ranked = string_array(value, "rankedEntities", "run")?;
+        if ranked.iter().copied().collect::<BTreeSet<_>>().len() != ranked.len() {
+            return Err(format!("run {run_id} rankedEntities contains duplicates"));
+        }
+        let diagnosis = string_set(value, "diagnosisEntities", "run")?;
+        let unsupported_claims = required_u64(value, "unsupportedClaims", "run")?;
+        let claim_count = required_u64(value, "claimCount", "run")?;
+        let attestation_passed = *attestations
+            .get(&run_id)
+            .ok_or_else(|| format!("run {run_id} lacks an A03-verified ExternalAttestation"))?;
+        if unsupported_claims > claim_count {
+            return Err(format!("run {run_id} unsupportedClaims exceeds claimCount"));
+        }
+        let ranked_top = ranked
+            .iter()
+            .copied()
+            .take(top_k as usize)
+            .collect::<Vec<_>>();
+        let relevant_hits = ranked_top
+            .iter()
+            .filter(|entity| case.relevant.contains(**entity))
+            .count();
+        let root_hits = ranked_top
+            .iter()
+            .filter(|entity| case.root_causes.contains(**entity))
+            .count();
+        let reciprocal_rank = ranked_top
+            .iter()
+            .position(|entity| case.root_causes.contains(*entity))
+            .map(|index| 1.0 / (index as f64 + 1.0))
+            .unwrap_or(0.0);
+        let quality_observed = status == "completed" || status == "domain_unknown";
+        let denominator = ranked_top.len();
+        scored.push(ScoredRun {
+            run_id,
+            case_id,
+            condition,
+            repetition,
+            profile_digest,
+            treatment_digest,
+            context_digest,
+            attestation_digest,
+            status,
+            root_cause_recall: if quality_observed {
+                root_hits as f64 / case.root_causes.len() as f64
+            } else {
+                0.0
+            },
+            evidence_precision: if quality_observed && denominator > 0 {
+                relevant_hits as f64 / denominator as f64
+            } else {
+                0.0
+            },
+            reciprocal_rank: if quality_observed {
+                reciprocal_rank
+            } else {
+                0.0
+            },
+            diagnosis_root_cause_recall: if quality_observed {
+                diagnosis.intersection(&case.root_causes).count() as f64
+                    / case.root_causes.len() as f64
+            } else {
+                0.0
+            },
+            diagnosis_exact: if quality_observed && diagnosis == case.root_causes {
+                1.0
+            } else {
+                0.0
+            },
+            attestation_success: if quality_observed && attestation_passed {
+                1.0
+            } else {
+                0.0
+            },
+            unsupported_claim_rate: if quality_observed && claim_count > 0 {
+                unsupported_claims as f64 / claim_count as f64
+            } else {
+                0.0
+            },
+            wall_time_ms: required_u64(value, "wallTimeMs", "run")? as f64,
+            input_tokens: required_u64(value, "inputTokens", "run")? as f64,
+            output_tokens: required_u64(value, "outputTokens", "run")? as f64,
+            tool_calls: required_u64(value, "toolCalls", "run")? as f64,
+            artifact_bytes: required_u64(value, "artifactBytes", "run")? as f64,
+        });
+    }
+    Ok(scored)
+}
+
+fn scored_run_json(run: &ScoredRun) -> Value {
+    json!({
+        "runId":run.run_id,
+        "caseId":run.case_id,
+        "condition":run.condition,
+        "repetition":run.repetition,
+        "status":run.status,
+        "provenance":{
+            "experimentProfileDigest":run.profile_digest,
+            "treatmentDigest":run.treatment_digest,
+            "contextDigest":run.context_digest,
+            "attestationSha256":run.attestation_digest
+        },
+        "quality":if quality_observed(run) { json!({
+            "rootCauseRecallAtK":run.root_cause_recall,
+            "relevantEntityPrecisionAtK":run.evidence_precision,
+            "reciprocalRank":run.reciprocal_rank,
+            "diagnosisRootCauseRecall":run.diagnosis_root_cause_recall,
+            "diagnosisExact":run.diagnosis_exact == 1.0,
+            "attestationPassed":run.attestation_success == 1.0,
+            "unsupportedClaimRate":run.unsupported_claim_rate
+        }) } else { Value::Null },
+        "cost":{
+            "wallTimeMs":run.wall_time_ms,
+            "inputTokens":run.input_tokens,
+            "outputTokens":run.output_tokens,
+            "toolCalls":run.tool_calls,
+            "artifactBytes":run.artifact_bytes
+        }
+    })
+}
+
+fn validate_pairing(
+    cases: &BTreeMap<String, Case>,
+    runs: &[ScoredRun],
+    repetitions: u64,
+) -> Result<(), String> {
+    for case_id in cases.keys() {
+        for repetition in 1..=repetitions {
+            let paired = runs
+                .iter()
+                .filter(|run| run.case_id == *case_id && run.repetition == repetition)
+                .collect::<Vec<_>>();
+            if paired.len() != CONDITIONS.len() {
+                return Err(format!(
+                    "case {case_id} repetition {repetition} must have exactly C0, C1, and Cfull"
+                ));
+            }
+            let condition_set = paired
+                .iter()
+                .map(|run| run.condition.as_str())
+                .collect::<BTreeSet<_>>();
+            if condition_set != CONDITIONS.into_iter().collect() {
+                return Err(format!(
+                    "case {case_id} repetition {repetition} has incomplete conditions"
+                ));
+            }
+            let profile_set = paired
+                .iter()
+                .map(|run| run.profile_digest.as_str())
+                .collect::<BTreeSet<_>>();
+            if profile_set.len() != 1 {
+                return Err(format!(
+                    "case {case_id} repetition {repetition} changed the experiment profile"
+                ));
+            }
+        }
+    }
+    if runs.len() != cases.len() * repetitions as usize * CONDITIONS.len() {
+        return Err("tool effectiveness runs contain unexpected case repetitions".into());
+    }
+    Ok(())
+}
+
+fn count_valid_pairs(
+    cases: &BTreeMap<String, Case>,
+    runs: &[ScoredRun],
+    repetitions: u64,
+) -> usize {
+    cases
+        .keys()
+        .flat_map(|case_id| (1..=repetitions).map(move |repetition| (case_id, repetition)))
+        .filter(|(case_id, repetition)| {
+            CONDITIONS.iter().all(|condition| {
+                runs.iter().any(|run| {
+                    run.case_id == case_id.as_str()
+                        && run.repetition == *repetition
+                        && run.condition == **condition
+                        && quality_observed(run)
+                })
+            })
+        })
+        .count()
+}
+
+mod scoring;
+use scoring::*;
+
+#[cfg(test)]
+mod tests;

--- a/crates/code-intel-cli/src/tool_effectiveness_benchmark/scoring.rs
+++ b/crates/code-intel-cli/src/tool_effectiveness_benchmark/scoring.rs
@@ -1,0 +1,304 @@
+use super::*;
+
+pub(super) fn aggregate(condition: &str, runs: &[ScoredRun]) -> Value {
+    let selected = runs
+        .iter()
+        .filter(|run| run.condition == condition)
+        .collect::<Vec<_>>();
+    let quality = selected
+        .iter()
+        .copied()
+        .filter(|run| run.status == "completed" || run.status == "domain_unknown")
+        .collect::<Vec<_>>();
+    let attempted = selected.len();
+    let completed = selected
+        .iter()
+        .filter(|run| run.status == "completed")
+        .count();
+    let unknown = selected
+        .iter()
+        .filter(|run| run.status == "domain_unknown")
+        .count();
+    let unavailable = selected
+        .iter()
+        .filter(|run| run.status == "unavailable")
+        .count();
+    let failed = selected
+        .iter()
+        .filter(|run| run.status == "process_failed")
+        .count();
+    json!({
+        "condition":condition,
+        "attempted":attempted,
+        "completed":completed,
+        "domainUnknown":unknown,
+        "unavailable":unavailable,
+        "processFailed":failed,
+        "availabilityRate":ratio(completed + unknown, attempted),
+        "honestUnknownRate":ratio(unknown, attempted),
+        "unavailableRate":ratio(unavailable, attempted),
+        "processFailureRate":ratio(failed, attempted),
+        "quality":if quality.is_empty() { Value::Null } else { json!({
+            "rootCauseRecallAtK":mean(&quality, |run| run.root_cause_recall),
+            "relevantEntityPrecisionAtK":mean(&quality, |run| run.evidence_precision),
+            "meanReciprocalRank":mean(&quality, |run| run.reciprocal_rank),
+            "diagnosisRootCauseRecall":mean(&quality, |run| run.diagnosis_root_cause_recall),
+            "diagnosisExactRate":mean(&quality, |run| run.diagnosis_exact),
+            "attestationSuccessRate":mean(&quality, |run| run.attestation_success),
+            "unsupportedClaimRate":mean(&quality, |run| run.unsupported_claim_rate)
+        })},
+        "cost":if selected.is_empty() { Value::Null } else { json!({
+            "meanWallTimeMs":mean(&selected, |run| run.wall_time_ms),
+            "meanInputTokens":mean(&selected, |run| run.input_tokens),
+            "meanOutputTokens":mean(&selected, |run| run.output_tokens),
+            "meanToolCalls":mean(&selected, |run| run.tool_calls),
+            "meanArtifactBytes":mean(&selected, |run| run.artifact_bytes)
+        })}
+    })
+}
+
+pub(super) fn paired_comparison(condition: &str, runs: &[ScoredRun]) -> Value {
+    let mut deltas = Vec::new();
+    for candidate in runs.iter().filter(|run| run.condition == condition) {
+        if !quality_observed(candidate) {
+            continue;
+        }
+        if let Some(control) = runs.iter().find(|run| {
+            run.condition == "C0"
+                && run.case_id == candidate.case_id
+                && run.repetition == candidate.repetition
+                && quality_observed(run)
+        }) {
+            deltas.push((
+                candidate.root_cause_recall - control.root_cause_recall,
+                candidate.evidence_precision - control.evidence_precision,
+                candidate.reciprocal_rank - control.reciprocal_rank,
+                candidate.diagnosis_root_cause_recall - control.diagnosis_root_cause_recall,
+                candidate.diagnosis_exact - control.diagnosis_exact,
+                candidate.attestation_success - control.attestation_success,
+                candidate.unsupported_claim_rate - control.unsupported_claim_rate,
+                candidate.wall_time_ms - control.wall_time_ms,
+                candidate.input_tokens - control.input_tokens,
+                candidate.output_tokens - control.output_tokens,
+                candidate.tool_calls - control.tool_calls,
+            ));
+        }
+    }
+    let mean_delta = |index: usize| {
+        if deltas.is_empty() {
+            Value::Null
+        } else {
+            json!(
+                deltas
+                    .iter()
+                    .map(|values| tuple_at(values, index))
+                    .sum::<f64>()
+                    / deltas.len() as f64
+            )
+        }
+    };
+    json!({
+        "baseline":"C0",
+        "condition":condition,
+        "pairedRunCount":deltas.len(),
+        "rootCauseRecallAtKDelta":mean_delta(0),
+        "relevantEntityPrecisionAtKDelta":mean_delta(1),
+        "meanReciprocalRankDelta":mean_delta(2),
+        "diagnosisRootCauseRecallDelta":mean_delta(3),
+        "diagnosisExactRateDelta":mean_delta(4),
+        "attestationSuccessRateDelta":mean_delta(5),
+        "unsupportedClaimRateDelta":mean_delta(6),
+        "wallTimeMsDelta":mean_delta(7),
+        "inputTokensDelta":mean_delta(8),
+        "outputTokensDelta":mean_delta(9),
+        "toolCallsDelta":mean_delta(10)
+    })
+}
+
+pub(super) fn tuple_at(
+    values: &(f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64),
+    index: usize,
+) -> f64 {
+    match index {
+        0 => values.0,
+        1 => values.1,
+        2 => values.2,
+        3 => values.3,
+        4 => values.4,
+        5 => values.5,
+        6 => values.6,
+        7 => values.7,
+        8 => values.8,
+        9 => values.9,
+        _ => values.10,
+    }
+}
+
+pub(super) fn quality_observed(run: &ScoredRun) -> bool {
+    run.status == "completed" || run.status == "domain_unknown"
+}
+
+pub(super) fn mean(runs: &[&ScoredRun], metric: impl Fn(&ScoredRun) -> f64) -> f64 {
+    runs.iter().map(|run| metric(run)).sum::<f64>() / runs.len() as f64
+}
+
+pub(super) fn ratio(numerator: usize, denominator: usize) -> f64 {
+    if denominator == 0 {
+        0.0
+    } else {
+        numerator as f64 / denominator as f64
+    }
+}
+
+pub(super) fn required_string<'a>(
+    value: &'a Value,
+    field: &str,
+    context: &str,
+) -> Result<&'a str, String> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .filter(|text| !text.is_empty())
+        .ok_or_else(|| format!("{context}.{field} must be a non-empty string"))
+}
+
+pub(super) fn required_digest<'a>(
+    value: &'a Value,
+    field: &str,
+    context: &str,
+) -> Result<&'a str, String> {
+    let digest = required_string(value, field, context)?;
+    if digest.len() != 64
+        || !digest
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(format!("{context}.{field} must be 64 lowercase hex"));
+    }
+    Ok(digest)
+}
+
+pub(super) fn required_u64(value: &Value, field: &str, context: &str) -> Result<u64, String> {
+    value
+        .get(field)
+        .and_then(Value::as_u64)
+        .ok_or_else(|| format!("{context}.{field} must be an unsigned integer"))
+}
+
+pub(super) fn required_bool(value: &Value, field: &str, context: &str) -> Result<bool, String> {
+    value
+        .get(field)
+        .and_then(Value::as_bool)
+        .ok_or_else(|| format!("{context}.{field} must be boolean"))
+}
+
+pub(super) fn string_array<'a>(
+    value: &'a Value,
+    field: &str,
+    context: &str,
+) -> Result<Vec<&'a str>, String> {
+    let values = value
+        .get(field)
+        .and_then(Value::as_array)
+        .ok_or_else(|| format!("{context}.{field} must be an array"))?;
+    values
+        .iter()
+        .map(|item| {
+            item.as_str()
+                .filter(|text| !text.is_empty())
+                .ok_or_else(|| format!("{context}.{field} must contain non-empty strings"))
+        })
+        .collect()
+}
+
+pub(super) fn string_set(
+    value: &Value,
+    field: &str,
+    context: &str,
+) -> Result<BTreeSet<String>, String> {
+    Ok(string_array(value, field, context)?
+        .into_iter()
+        .map(str::to_string)
+        .collect())
+}
+
+pub(super) fn require_schema(value: &Value, schema: &str, context: &str) -> Result<(), String> {
+    if value.get("schema").and_then(Value::as_str) != Some(schema) {
+        return Err(format!("{context} schema must be {schema}"));
+    }
+    Ok(())
+}
+
+pub(super) fn document_digest(value: &Value) -> Result<String, String> {
+    serde_json::to_vec(value)
+        .map(|bytes| sha256_hex(&bytes))
+        .map_err(|error| format!("serialize benchmark input for digest: {error}"))
+}
+
+pub(super) fn validate_artifact_entity_ref(reference: &str) -> Result<(), String> {
+    let digest = reference
+        .strip_prefix("artifact://sha256/")
+        .ok_or_else(|| {
+            "ExternalAttestation.evidenceRefs must use artifact://sha256/<digest>".to_string()
+        })?;
+    if digest.len() != 64
+        || !digest
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err("ExternalAttestation.evidenceRefs must use artifact://sha256/<digest>".into());
+    }
+    Ok(())
+}
+
+pub(super) fn require_exact_fields(
+    value: &Value,
+    context: &str,
+    expected: &[&str],
+) -> Result<(), String> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| format!("{context} must be an object"))?;
+    let actual = object.keys().map(String::as_str).collect::<BTreeSet<_>>();
+    let expected = expected.iter().copied().collect::<BTreeSet<_>>();
+    if actual != expected {
+        return Err(format!("{context} fields differ from the closed v1 schema"));
+    }
+    Ok(())
+}
+
+pub(super) fn render_markdown(report: &Value) -> String {
+    let variants = report["variants"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .map(|variant| {
+            format!(
+                "| {} | {} | {} | {} | {} |",
+                variant["condition"].as_str().unwrap_or("unknown"),
+                variant["availabilityRate"].as_f64().unwrap_or(0.0),
+                variant["quality"]["rootCauseRecallAtK"]
+                    .as_f64()
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "n/a".into()),
+                variant["quality"]["relevantEntityPrecisionAtK"]
+                    .as_f64()
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "n/a".into()),
+                variant["quality"]["attestationSuccessRate"]
+                    .as_f64()
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "n/a".into())
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        "# Tool Effectiveness Benchmark\n\n- Verdict: {}\n- Corpus: {}\n- Cases: {}\n- Repetitions: {}\n\n| Condition | Availability | Root-cause recall@K | Relevant-EntityRef precision@K | Authority attestation success |\n| --- | ---: | ---: | ---: | ---: |\n{}\n",
+        report["verdict"].as_str().unwrap_or("unknown"),
+        report["corpus"]["id"].as_str().unwrap_or("unknown"),
+        report["corpus"]["caseCount"].as_u64().unwrap_or(0),
+        report["corpus"]["repetitions"].as_u64().unwrap_or(0),
+        variants
+    )
+}

--- a/crates/code-intel-cli/src/tool_effectiveness_benchmark/tests.rs
+++ b/crates/code-intel-cli/src/tool_effectiveness_benchmark/tests.rs
@@ -1,0 +1,308 @@
+use super::*;
+
+fn run(id: &str, condition: &str, repetition: u64, ranked: Value, diagnosis: Value) -> Value {
+    let snapshot_identity = "c".repeat(64);
+    let treatment_digest = match condition {
+        "C0" => "5".repeat(64),
+        "C1" => "6".repeat(64),
+        _ => "7".repeat(64),
+    };
+    let experiment = json!({
+        "model":"fixture-model",
+        "reasoning":"fixture-reasoning",
+        "promptDigest":"1".repeat(64),
+        "budgetDigest":"2".repeat(64),
+        "permissionProfileDigest":"3".repeat(64),
+        "toolSnapshotDigest":"4".repeat(64),
+        "seed":repetition
+    });
+    let profile = json!({
+        "snapshotIdentity":snapshot_identity,
+        "model":"fixture-model",
+        "reasoning":"fixture-reasoning",
+        "promptDigest":"1".repeat(64),
+        "budgetDigest":"2".repeat(64),
+        "permissionProfileDigest":"3".repeat(64),
+        "toolSnapshotDigest":"4".repeat(64),
+        "seed":repetition
+    });
+    json!({
+        "runId":id,
+        "caseId":"case-1",
+        "condition":condition,
+        "repetition":repetition,
+        "status":"completed",
+        "snapshotIdentity":snapshot_identity,
+        "experiment":experiment,
+        "experimentProfileDigest":sha256_hex(&serde_json::to_vec(&profile).unwrap()),
+        "treatmentDigest":treatment_digest,
+        "contextDigest":"b".repeat(64),
+        "rankedEntities":ranked,
+        "diagnosisEntities":diagnosis,
+        "attestationRef":{
+            "schema":"code-intel-artifact-ref.v1",
+            "artifactSchema":"code-intel-external-attestation.v1",
+            "type":"benchmark.external-attestation",
+            "path":format!("attestations/{id}.json"),
+            "sha256":"e".repeat(64),
+            "consumedSnapshotIdentity":"c".repeat(64)
+        },
+        "unsupportedClaims":0,
+        "claimCount":1,
+        "wallTimeMs":100,
+        "inputTokens":10,
+        "outputTokens":10,
+        "toolCalls":1,
+        "artifactBytes":100
+    })
+}
+
+#[test]
+fn paired_baseline_reports_uplift_without_composite_score() {
+    let root = "repo://fixture/src/root.rs";
+    let noise = "repo://fixture/src/noise.rs";
+    let corpus = json!({
+        "schema":"code-intel-tool-effectiveness-corpus.v1",
+        "corpusId":"fixture-v1",
+        "topK":5,
+        "repetitions":2,
+        "verifierIdentity":"fixture-verifier-v1",
+        "treatments":{
+            "C0":"5".repeat(64),
+            "C1":"6".repeat(64),
+            "Cfull":"7".repeat(64)
+        },
+        "cases":[{
+            "id":"case-1",
+            "snapshotIdentity":"c".repeat(64),
+            "relevantEntities":[root],
+            "rootCauseEntities":[root]
+        }]
+    });
+    let mut values = Vec::new();
+    let mut attestations = BTreeMap::new();
+    for repetition in 1..=2 {
+        values.push(run(
+            &format!("c0-{repetition}"),
+            "C0",
+            repetition,
+            json!([noise]),
+            json!([]),
+        ));
+        attestations.insert(format!("c0-{repetition}"), false);
+        values.push(run(
+            &format!("c1-{repetition}"),
+            "C1",
+            repetition,
+            json!([noise, root]),
+            json!([root]),
+        ));
+        attestations.insert(format!("c1-{repetition}"), true);
+        values.push(run(
+            &format!("full-{repetition}"),
+            "Cfull",
+            repetition,
+            json!([root]),
+            json!([root]),
+        ));
+        attestations.insert(format!("full-{repetition}"), true);
+    }
+    let runs = json!({
+        "schema":"code-intel-tool-effectiveness-runs.v1",
+        "corpusId":"fixture-v1",
+        "runs":values
+    });
+    let report = evaluate(&corpus, &runs, &attestations).unwrap();
+    assert_eq!(report["verdict"], "baseline_recorded");
+    assert_eq!(report["method"]["compositeScore"], false);
+    assert_eq!(
+        report["pairedComparisons"][0]["rootCauseRecallAtKDelta"],
+        1.0
+    );
+    assert_eq!(
+        report["pairedComparisons"][1]["meanReciprocalRankDelta"],
+        1.0
+    );
+
+    let mut insufficient = runs;
+    insufficient["runs"][1]["status"] = json!("unavailable");
+    let report = evaluate(&corpus, &insufficient, &attestations).unwrap();
+    assert_eq!(report["verdict"], "insufficient_evidence");
+}
+
+#[test]
+fn changed_experiment_profile_fails_closed() {
+    let root = "repo://fixture/src/root.rs";
+    let corpus = json!({
+        "schema":"code-intel-tool-effectiveness-corpus.v1",
+        "corpusId":"fixture-v1",
+        "topK":5,
+        "repetitions":1,
+        "verifierIdentity":"fixture-verifier-v1",
+        "treatments":{
+            "C0":"5".repeat(64),
+            "C1":"6".repeat(64),
+            "Cfull":"7".repeat(64)
+        },
+        "cases":[{
+            "id":"case-1",
+            "snapshotIdentity":"c".repeat(64),
+            "relevantEntities":[root],
+            "rootCauseEntities":[root]
+        }]
+    });
+    let mut values = vec![
+        run("c0", "C0", 1, json!([]), json!([])),
+        run("c1", "C1", 1, json!([root]), json!([root])),
+        run("full", "Cfull", 1, json!([root]), json!([root])),
+    ];
+    values[2]["experiment"]["seed"] = json!(2);
+    let changed_profile = json!({
+        "snapshotIdentity":"c".repeat(64),
+        "model":"fixture-model",
+        "reasoning":"fixture-reasoning",
+        "promptDigest":"1".repeat(64),
+        "budgetDigest":"2".repeat(64),
+        "permissionProfileDigest":"3".repeat(64),
+        "toolSnapshotDigest":"4".repeat(64),
+        "seed":2
+    });
+    values[2]["experimentProfileDigest"] =
+        json!(sha256_hex(&serde_json::to_vec(&changed_profile).unwrap()));
+    let attestations = BTreeMap::from([
+        ("c0".to_string(), false),
+        ("c1".to_string(), true),
+        ("full".to_string(), true),
+    ]);
+    let error = evaluate(
+        &corpus,
+        &json!({
+            "schema":"code-intel-tool-effectiveness-runs.v1",
+            "corpusId":"fixture-v1",
+            "runs":values
+        }),
+        &attestations,
+    )
+    .unwrap_err();
+    assert!(error.contains("changed the experiment profile"));
+}
+
+#[test]
+fn duplicate_ranked_entities_fail_closed() {
+    let root = "repo://fixture/src/root.rs";
+    let corpus = json!({
+        "schema":"code-intel-tool-effectiveness-corpus.v1",
+        "corpusId":"fixture-v1",
+        "topK":5,
+        "repetitions":1,
+        "verifierIdentity":"fixture-verifier-v1",
+        "treatments":{
+            "C0":"5".repeat(64),
+            "C1":"6".repeat(64),
+            "Cfull":"7".repeat(64)
+        },
+        "cases":[{
+            "id":"case-1",
+            "snapshotIdentity":"c".repeat(64),
+            "relevantEntities":[root],
+            "rootCauseEntities":[root]
+        }]
+    });
+    let values = vec![
+        run("c0", "C0", 1, json!([root, root]), json!([root])),
+        run("c1", "C1", 1, json!([root]), json!([root])),
+        run("full", "Cfull", 1, json!([root]), json!([root])),
+    ];
+    let attestations = BTreeMap::from([
+        ("c0".to_string(), true),
+        ("c1".to_string(), true),
+        ("full".to_string(), true),
+    ]);
+    let error = evaluate(
+        &corpus,
+        &json!({
+            "schema":"code-intel-tool-effectiveness-runs.v1",
+            "corpusId":"fixture-v1",
+            "runs":values
+        }),
+        &attestations,
+    )
+    .unwrap_err();
+    assert!(error.contains("rankedEntities contains duplicates"));
+}
+
+#[test]
+fn external_attestation_is_digest_and_snapshot_bound() {
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!(
+        "code-intel-tool-attestation-{}-{unique}",
+        std::process::id()
+    ));
+    fs::create_dir(&root).unwrap();
+    let snapshot = "c".repeat(64);
+    let payload = serde_json::to_vec(&json!({
+        "schema":"code-intel-external-attestation.v1",
+        "runId":"run-1",
+        "caseId":"case-1",
+        "snapshotIdentity":snapshot,
+        "condition":"C0",
+        "treatmentDigest":"5".repeat(64),
+        "contextDigest":"b".repeat(64),
+        "experimentProfileDigest":"a".repeat(64),
+        "passed":true,
+        "verifierIdentity":"fixture-verifier-v1",
+        "method":"frozen_evidence_replay",
+        "evidenceRefs":[format!("artifact://sha256/{}", "8".repeat(64))]
+    }))
+    .unwrap();
+    fs::write(root.join("attestation.json"), &payload).unwrap();
+    let corpus = json!({
+        "schema":"code-intel-tool-effectiveness-corpus.v1",
+        "corpusId":"fixture-v1",
+        "topK":5,
+        "repetitions":1,
+        "verifierIdentity":"fixture-verifier-v1",
+        "treatments":{
+            "C0":"5".repeat(64),
+            "C1":"6".repeat(64),
+            "Cfull":"7".repeat(64)
+        },
+        "cases":[{
+            "id":"case-1",
+            "snapshotIdentity":"c".repeat(64),
+            "relevantEntities":["repo://fixture/src/root.rs"],
+            "rootCauseEntities":["repo://fixture/src/root.rs"]
+        }]
+    });
+    let runs = json!({
+        "schema":"code-intel-tool-effectiveness-runs.v1",
+        "corpusId":"fixture-v1",
+        "runs":[{
+            "runId":"run-1",
+            "caseId":"case-1",
+            "condition":"C0",
+            "treatmentDigest":"5".repeat(64),
+            "contextDigest":"b".repeat(64),
+            "experimentProfileDigest":"a".repeat(64),
+            "attestationRef":{
+                "schema":"code-intel-artifact-ref.v1",
+                "artifactSchema":"code-intel-external-attestation.v1",
+                "type":"benchmark.external-attestation",
+                "path":"attestation.json",
+                "sha256":sha256_hex(&payload),
+                "consumedSnapshotIdentity":"c".repeat(64)
+            }
+        }]
+    });
+    let verified = verify_attestations(&corpus, &runs, &root).unwrap();
+    assert_eq!(verified["run-1"], true);
+
+    let mut forged = runs;
+    forged["runs"][0]["attestationRef"]["sha256"] = json!("f".repeat(64));
+    let error = verify_attestations(&corpus, &forged, &root).unwrap_err();
+    assert!(error.contains("SHA-256 mismatch"));
+    fs::remove_dir_all(root).unwrap();
+}

--- a/docs/adr/0012-entity-ref-format-and-parsing.md
+++ b/docs/adr/0012-entity-ref-format-and-parsing.md
@@ -1,0 +1,247 @@
+---
+status: proposed
+date: 2026-07-25
+---
+
+# Define canonical EntityRef format and parsing
+
+This is ADR-001 of the context-and-evidence model and ADR-0012 in the
+repository-wide sequence.
+
+Code Intel needs one portable identifier for repository entities and immutable
+artifacts. Graph nodes, evidence, claims, capsules, and attestations must be able
+to refer to the same entity without embedding machine paths, provider-specific
+objects, or live-checkout state.
+
+EntityRef identifies an entity. It does not prove that the entity exists, that
+an observation is current, or that an artifact is trusted. SnapshotSet supplies
+observation time, a resolver supplies authorized location, and Evidence Ledger
+events supply claims and relations.
+
+## Decision
+
+EntityRef v1 is a canonical ASCII URI string with two supported schemes:
+
+```text
+repo://<repository-namespace>/<repository-digest>[/<repository-path>][#symbol=<opaque-key>]
+artifact://sha256/<content-digest>
+```
+
+The supported repository namespaces are the existing
+`git-lineage-v1` and `content-v1` identities:
+
+```text
+repo://git-lineage-v1/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+repo://git-lineage-v1/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/src/parser.rs
+repo://git-lineage-v1/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/src/parser.rs#symbol=function%3Aparse
+artifact://sha256/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+```
+
+`git-lineage-v1` is stable across snapshots in the same consumed lineage.
+`content-v1` remains supported for unborn or unversioned repositories, but its
+digest may change with repository content and therefore does not imply durable
+cross-snapshot continuity.
+
+`service://` and `contract://` are reserved names. EntityRef v1 rejects them and
+all other schemes until a later ADR defines their identity semantics. Parsers
+must not accept unknown schemes merely to preserve strings.
+
+## Canonical grammar
+
+```abnf
+entity-ref      = repo-ref / artifact-ref
+repo-ref        = "repo://" repo-namespace "/" digest
+                  [ "/" repo-path ]
+                  [ "#symbol=" symbol-key ]
+artifact-ref    = "artifact://sha256/" digest
+repo-namespace  = "git-lineage-v1" / "content-v1"
+digest          = 64lower-hex
+repo-path       = path-segment *( "/" path-segment )
+path-segment    = 1*( unreserved / pct-encoded )
+symbol-key      = 1*( unreserved / pct-encoded )
+unreserved      = ALPHA / DIGIT / "-" / "." / "_" / "~"
+pct-encoded     = "%" HEXUPPER HEXUPPER
+```
+
+Repository paths use canonical repository-relative `/` separators and preserve
+case. Each decoded segment must be valid UTF-8, non-empty, and neither `.` nor
+`..`. A segment must not contain `/`, `\`, NUL, or control characters.
+
+Percent-encoded bytes use uppercase hex. Unreserved ASCII characters must not
+be percent-encoded. Raw non-ASCII input is rejected rather than normalized;
+callers must encode its UTF-8 bytes before parsing. This gives every EntityRef
+exactly one accepted spelling without imposing Unicode normalization on
+repository paths.
+
+Queries, user information, ports, empty path segments, and fragments other than
+the repo symbol selector are invalid. A symbol selector requires a repository
+path. The symbol key is provider-neutral and opaque to EntityRef; line and
+column coordinates are observations, not identity.
+
+## Interface boundary
+
+The EntityRef module exposes a small deterministic interface:
+
+```text
+parse(text) -> EntityRef | typed parse error
+canonical(EntityRef) -> canonical string
+kind(EntityRef) -> repo_root | repo_path | repo_symbol | artifact
+```
+
+Parsing and canonical rendering perform no filesystem, Git, index, clock, or
+network access. For every accepted string `s`:
+
+```text
+canonical(parse(s)) == s
+parse(canonical(ref)) == ref
+```
+
+Equality, ordering, hashing, JSON representation, and ledger endpoints use the
+parsed structure's canonical string. Implementations keep scheme-specific
+fields private and use standard parsing/display conventions where the language
+supports them.
+
+Resolution is a separate adapter boundary:
+
+```text
+resolve(EntityRef, SnapshotSet, authority) -> concrete location | typed resolution error
+```
+
+Parse success does not imply existence. Resolution must use the supplied
+SnapshotSet and explicit repository or artifact authority; it must not silently
+fall back to the live checkout, an ambient artifact root, or a network request.
+Parse errors and resolution errors are separate domains.
+
+Stable parse error codes are:
+
+- `empty`
+- `unsupported_scheme`
+- `unsupported_namespace`
+- `invalid_digest`
+- `invalid_repo_path`
+- `symbol_requires_path`
+- `invalid_symbol_key`
+- `unexpected_query`
+- `unexpected_fragment`
+- `non_canonical_encoding`
+- `input_too_long`
+
+The concrete byte limit is an implementation constant covered by tests, not
+part of the durable identifier semantics.
+
+## Relations
+
+Relationships are not nested fields on EntityRef and are not a seventh core
+object. They are immutable Evidence Ledger events whose endpoints are canonical
+EntityRefs:
+
+```json
+{
+  "schema": "code-intel-ledger-event.v1",
+  "type": "RelationAsserted",
+  "from": "repo://git-lineage-v1/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/src/parser.rs#symbol=function%3Aparse",
+  "to": "artifact://sha256/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "relation": "supported_by",
+  "evidenceRef": "artifact://sha256/cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "validFrom": "snapshot-set-12",
+  "validUntil": null
+}
+```
+
+The event owns the relation label, evidence, and validity interval. Retraction
+or invalidation appends another event; historical endpoints are never rewritten.
+Graphs and adjacency indexes are rebuildable Materialized Views over the ledger.
+The complete ledger event contract and schema evolution rules belong to ADR-002.
+
+## Versioning
+
+`repo` and `artifact` are stable scheme names. Identity-algorithm versions live
+in their namespaces, such as `git-lineage-v1`. The serialized profile is
+`code-intel-entity-ref.v1`.
+
+Adding a scheme or namespace requires an ADR and is additive only when old
+strings keep exactly the same meaning. Breaking grammar or interpretation
+requires a new EntityRef profile or namespace. Historical refs are never
+silently reinterpreted or mass-rewritten.
+
+Existing Artifact Ref remains the trust envelope carrying schema, type,
+location, digest, and consumed Snapshot Identity. EntityRef does not replace
+that envelope: `artifact://sha256/<digest>` is only its portable content
+identity.
+
+## V1 scope
+
+V1 implements:
+
+- repository roots, repository-relative paths, and opaque symbol selectors;
+- immutable artifact identities;
+- strict parsing, canonical rendering, and typed errors;
+- relation endpoints that reuse canonical EntityRefs.
+
+V1 does not implement:
+
+- service or contract identities;
+- line/column identities;
+- existence checks inside parsing;
+- remote dereferencing;
+- a public plugin ABI or dynamic scheme registry;
+- automatic equivalence across renames, forks, or `content-v1` revisions.
+
+## Alternatives considered
+
+### Repository-only identity
+
+`repo://<namespace>/<digest>` is smaller, but cannot name the files and symbols
+needed by capsules and relation events. Adding those coordinates in every
+consumer would recreate incompatible identity formats.
+
+### Snapshot digest inside every repository EntityRef
+
+This makes each ref an immutable observation coordinate, but duplicates
+SnapshotSet and makes unchanged logical entities acquire new identities at
+every snapshot. Snapshot membership therefore remains explicit context.
+
+### Generic parsing of unknown schemes
+
+Round-tripping future schemes appears extensible, but it admits identifiers
+whose canonicalization and security rules are undefined. V1 fails closed;
+adding a scheme is cheap compared with repairing ambiguous ledger identity.
+
+### Artifact Ref as EntityRef
+
+Artifact Ref already carries trust and location metadata, but those fields are
+not artifact identity. Reusing the whole envelope would make relocation change
+an entity reference and would couple graph identity to capability transport.
+
+## Consequences
+
+- One canonical identifier can be used by graph nodes, ledger endpoints,
+  capsule references, cache keys, and external attestations.
+- Identity, observation time, existence, and trust remain independently
+  testable boundaries.
+- Provider adapters must translate their path and symbol identifiers at
+  admission instead of leaking provider-specific objects downstream.
+- Renames and semantic equivalence require evidence-backed relation events;
+  EntityRef does not guess them.
+- The strict parser rejects superficially equivalent spellings, reducing
+  duplicate nodes and ambiguous lookups.
+
+## Verification before implementation
+
+Before writing collectors, the first golden scenario must manually author:
+
+1. one single-repository SnapshotSet;
+2. five to ten EntityRefs covering root, paths, symbols, and artifacts;
+3. relation events including support, contradiction, and structural relations;
+4. one ProblemFrame reframe;
+5. one agent CapsuleRequest and manually assembled CapsuleResult;
+6. test or merged-PR ExternalAttestation.
+
+The fixture must prove canonical round trips, reject every non-canonical form
+listed above, rebuild its relation view deterministically, and let a fresh agent
+identify the known root cause without repository-wide search. Failure means the
+schema is revised before collectors are implemented.
+
+This follows two engineering rules: claims must be falsifiable by replayable
+evidence, and the system boundary must expose feedback rather than hide it.
+Names and authority are not substitutes for a passing experiment.

--- a/docs/adr/0013-paired-tool-effectiveness-dogfood-benchmark.md
+++ b/docs/adr/0013-paired-tool-effectiveness-dogfood-benchmark.md
@@ -1,0 +1,174 @@
+---
+status: proposed
+date: 2026-07-25
+---
+
+# Measure tool effectiveness with paired dogfood tasks
+
+Adapter health, schema conformance, and successful execution do not establish
+that a tool helps an Agent understand or debug a repository. Code Intel already
+tests those operational properties well, but its tools do not share a task-level
+effectiveness baseline.
+
+The prior Design Pipeline dogfood loop is retained as a useful evidence intake
+pattern: observe locally, normalize, redact, deduplicate, draft, and require
+separate authority before remote publication. It is not reused as an evaluator.
+Its observations contain no counterfactual control, blinded task corpus, or
+external root-cause oracle.
+
+## Decision
+
+Code Intel will measure tool effectiveness with paired, replayable dogfood
+tasks. The same frozen task is executed under three initial conditions:
+
+- `C0`: no Code Intel context;
+- `C1`: built-in deterministic core only;
+- `Cfull`: normal automatic routing with every admitted available provider.
+
+Model, reasoning configuration, prompt, task budget, repository snapshot, and
+execution permissions remain equal within each pair. Condition labels are hidden
+from the task Agent. Run identifiers are randomized before scoring.
+
+The corpus pins one treatment-manifest digest for each condition and one
+verifier identity. Every run carries the matching treatment digest. Its
+authority-root ExternalAttestation binds run, case, snapshot, condition,
+treatment, context, experiment profile, and verifier before any success metric
+is accepted. V0 permits only `frozen_evidence_replay`; free-form human assertions
+are not a scoring source.
+
+V0 uses eight real historical tasks and two repetitions:
+
+```text
+8 tasks × 3 conditions × 2 repetitions = 48 Agent sessions
+```
+
+Single-adapter ablation is deferred until C1 or Cfull shows useful paired uplift.
+It then runs only on the most discriminating cases. This avoids paying for every
+provider permutation before the Pipeline has proved aggregate value.
+
+## Evaluation lanes
+
+The benchmark reports three lanes separately:
+
+1. **Operational** — execution status, admission, deterministic replay, latency,
+   artifact size, and failure classification.
+2. **Evidence quality** — root-cause recall, evidence precision, rank quality,
+   unsupported-claim rate, and whether known gaps are explicit.
+3. **Agent outcome** — diagnosis correctness, external-attestation success,
+   time to first valid hypothesis, tool calls, tokens, wall time, and cost.
+
+No single composite score is authoritative. A provider is evaluated by paired
+quality uplift and cost Pareto position. A fast tool with no root-cause evidence
+does not outrank a slower useful tool, and an unavailable optional provider is
+reported as `unavailable`, not scored as incorrect.
+
+## Golden task contract
+
+Each accepted case freezes:
+
+- pre-fix repository commit and SnapshotSet;
+- original issue text and allowed execution effects;
+- task type and difficulty;
+- root-cause EntityRefs;
+- required and distracting evidence;
+- known wrong hypotheses;
+- failing test, merged PR, or reviewed human decision as ExternalAttestation;
+- corpus and oracle digests.
+
+The first corpus covers:
+
+- 30-second project orientation;
+- symbol or relationship retrieval;
+- change-impact analysis;
+- local bug localization;
+- cross-module implicit coupling;
+- runtime or test evidence;
+- stale evidence detection;
+- an unknown-unknown case whose root cause is outside the initial error path.
+
+The Agent and Capsule Assembler cannot read the oracle. The scorer receives
+frozen output artifacts and independently recomputes metrics. Agent-reported
+scores, confidence, or success never become the oracle.
+
+## Run bundle
+
+Every run records:
+
+```text
+case identity
+condition identity
+repository and tool snapshots
+model and reasoning configuration
+prompt and budgets
+provided context digest
+actual tool calls and context consumed
+hypothesis transitions
+diagnosis EntityRefs
+validation and ExternalAttestation refs
+timing, token, CPU, and cost observations
+```
+
+Events use stable IDs, a monotonic sequence within the run, and idempotent
+append semantics. Wall-clock timestamps are metadata and do not determine event
+order.
+
+## Metrics
+
+The V0 deterministic scorer reports:
+
+- root-cause EntityRef recall@K at capsule and diagnosis stages;
+- relevant-EntityRef precision@K at the configured context budget;
+- reciprocal rank of the first root-cause entity;
+- diagnosis exactness;
+- ExternalAttestation success;
+- unsupported-claim rate;
+- end-to-end wall time;
+- input/output tokens and tool-call count;
+- artifact bytes;
+- availability, process-failure, and honest-unknown rates.
+
+Results are reported per task and condition before aggregation. Paired deltas use
+the same task and repetition seed. V0 is a recorded baseline, not a statistical
+claim about all repositories.
+
+`baseline_recorded` requires a quality-observed C0/C1/Cfull triple for every
+case and repetition. Otherwise the report is retained with
+`insufficient_evidence`.
+
+Confidence calibration, time to first externally valid hypothesis, evidence-item
+precision, CPU time, and monetary cost are collector extensions. They are added
+only after the V0 run bundle can obtain those observations without self-report or
+platform-specific guesswork.
+
+## Dogfood feedback loop
+
+Any real Code Intel run may emit a local evaluation candidate when it reveals a
+missed root cause, stale capsule, provider failure, contradictory evidence, or
+unexpectedly useful context. Candidates reuse the prior dogfood properties:
+redaction, stable fingerprint, occurrence count, local draft, and explicit
+remote-publication authority.
+
+A candidate enters the golden corpus only after:
+
+1. the root cause is externally attested;
+2. the pre-fix snapshot remains reproducible;
+3. the oracle is separated from Agent-visible inputs;
+4. the case has a counterexample or known wrong direction;
+5. a reviewer confirms that it measures product value rather than fixture trivia.
+
+## Existing benchmarks
+
+Existing orientation, native retrieval, multilingual extraction, parity, and
+CCC slice benchmarks remain focused smoke or contract checks. They may provide
+operational observations to this benchmark, but none alone is evidence of Agent
+outcome uplift.
+
+## Consequences
+
+- Code Intel can distinguish tool readiness from tool usefulness.
+- The built-in core and optional adapters compete on the same frozen tasks.
+- Weak or costly adapters can remain optional, be demoted, or be retired with
+  evidence rather than preference.
+- External providers are not required for deterministic CI; scheduled or
+  release evaluation records their absence explicitly.
+- Corpus growth comes from reviewed real failures, not synthetic case inflation.

--- a/docs/tool-effectiveness-baseline.md
+++ b/docs/tool-effectiveness-baseline.md
@@ -1,0 +1,87 @@
+# Tool Effectiveness Baseline
+
+Status: initial evidence inventory, 2026-07-25.
+
+This baseline separates what Code Intel can currently prove from what its
+adapters merely expose. The governing experiment design is
+[ADR-0013](adr/0013-paired-tool-effectiveness-dogfood-benchmark.md).
+
+## Current evidence
+
+| Tool or layer | What current evidence proves | Current measured result | Product-effect status |
+| --- | --- | --- | --- |
+| Repository snapshot and Artifact Ref | portable identity, replay, digest and snapshot binding | contract and negative tests pass | necessary infrastructure; no standalone Agent uplift claim |
+| `rg` inventory | deterministic repository inventory when snapshot consumption succeeds | covered by parity and orientation fixtures | exact inventory baseline; real self-run currently exposed a `.git` path-set failure |
+| Native code evidence | heuristic structural extraction for seven declared languages | 12 labeled samples; precision `0.75`, recall `0.75`, declared coverage `0.833333`, 10 stable replays | candidate structural baseline only |
+| Native retrieval slice | query-term and one-hop import selection can reduce a synthetic JavaScript repository | recall `1.0` for four expected files in one fixture | promising smoke test; precision, ranking, symbol and root-cause quality unmeasured |
+| Project orientation | fixed corpus output is deterministic, provenance-complete, bounded, and honest about missing providers | representative Rust benchmark passes; typical p95 target is at most 60 seconds | strong contract/cost evidence; no downstream Agent task comparison |
+| Sentrux | command output is normalized, admitted, and fail-closed across complete, partial, crash, and unknown cases | adapter and gate tests pass | architecture-detection precision and diagnosis uplift unknown |
+| Internal/Understand graph | current, complete graph evidence can cross one provider-neutral port | adapter, snapshot, freshness, and fallback tests pass | edge precision, completeness, and task uplift unknown |
+| Repowise | semantic-memory provider status and failures are classified without corrupting core results | availability/config/quota/local-error fixtures pass | retrieval hit rate, rank quality, and task uplift unknown |
+| CodeNexus | full and lite implementations share an admitted provider port | translation, stale/wrong-snapshot, and fallback tests pass | localization and impact accuracy unknown |
+| CCC/CocoIndex | command, index, search lifecycle and slice costs can be observed | benchmark accepts measured or explicit unavailable state | no shared semantic oracle; effectiveness unknown |
+
+## Fresh dogfood observation
+
+A normal compiled-CLI run against this repository on 2026-07-25 did not complete:
+
+```text
+inventory.rg:
+inventory baseline path set differs from snapshot manifest;
+extra_count=1; extra_samples=[".git"]
+```
+
+`repo.snapshot`, Sentrux evidence, and graph evidence succeeded. Native code
+evidence was dependency-blocked by inventory, and doctor/hospital returned
+failure. This is a session observation, not yet a golden benchmark case because
+the root cause and fix attestation have not been reviewed.
+
+It nevertheless demonstrates the evaluation gap: individual adapters can pass
+their contract tests while the user-visible Pipeline fails to produce usable
+core context.
+
+## What can be claimed today
+
+- The Pipeline has strong contract, provenance, determinism, and failure-state
+  coverage.
+- Native extraction has a small quantitative structural baseline.
+- Native retrieval succeeds on one narrow synthetic task.
+- Optional providers are replaceable and fail closed at their adapter boundaries.
+
+The Pipeline cannot yet claim that any optional provider improves root-cause
+recall, diagnosis correctness, completion time, or cost for a real Agent task.
+
+## V0 benchmark
+
+The first effectiveness run uses eight externally attested historical tasks
+under `C0`, `C1`, and `Cfull`, twice each. It records per-task results rather
+than hiding trade-offs in one score.
+
+The deterministic scorer is available as:
+
+```powershell
+code-intel benchmark tools `
+  --corpus <code-intel-tool-effectiveness-corpus.v1.json> `
+  --runs <code-intel-tool-effectiveness-runs.v1.json> `
+  --artifact-root <A03-authority-root> `
+  --out <new-output-directory>
+```
+
+The scorer fails closed when cases, repetitions, conditions, or paired experiment
+profile digests differ. The profile digest is recomputed from the frozen
+snapshot, model, reasoning, prompt, budget, permissions, tool snapshot, and
+seed. Corpus-pinned treatment manifests and the authority-root
+ExternalAttestation bind the actual condition, context, experiment, and verifier
+before a success observation can affect a score. The report preserves corpus,
+run, context, treatment, profile, and attestation digests. Publication atomically
+commits `report.json`, the rebuildable `report.md`, and `completion.json` without
+replacing an existing result.
+
+The authority root remains a trust boundary: Artifact Ref verification proves
+integrity and binding, while the pinned external verifier owns replaying the
+frozen test or PR evidence. Runs from an operator-controlled substitute root are
+not comparable to the official baseline.
+
+Initial release criteria are evidence completeness, oracle isolation, replayable
+snapshots, and valid paired runs. Quality thresholds are ratcheted only after the
+first baseline exists; they are not invented in advance.


### PR DESCRIPTION
## What changed

- adds the deterministic paired `benchmark tools` scorer and atomic reports
- freezes EntityRef and dogfood evaluation decisions in ADR-0012/0013
- records the current tool-effectiveness claim boundary and V0 experiment
- prepares package version `0.5.1-beta.1`
- splits the scorer, scoring logic, and tests so the self-governance gate does not regress

## Why

Operational adapter checks do not prove that Code Intel improves Agent outcomes. This release adds the fail-closed measurement harness without fabricating a baseline before 48 paired runs exist.

## Verification

- `cargo test -p code-intel` passed before the behavior-preserving split
- targeted tool benchmark tests: 4 passed
- project orientation benchmark: 2 passed
- repository layout: 4 passed
- Skill package: 12 passed
- Sentrux gate: quality 3971 -> 3972, coupling 44.78 -> 44.71, cycles 0, god files 29
- `cargo fmt --check` and `git diff --check` passed

Release target: `v0.5.1-beta.1` prerelease.