### PR TITLE
feat(audit): T2 security department

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gains an optional `audit` summary block and `hospital.md` gains an optional
   `## Audit` section; both are additive and render nothing when no audit ran.
   See `docs/audit-report.md`.
+- Security audit department (T2): `orchestration/audit/prompts/security.md`
+  (adapted from
+  [Fuck_My_Shit_Mountain](https://github.com/XiNian-dada/Fuck_My_Shit_Mountain),
+  MIT) and `orchestration/audit/departments.v1.json`'s `security` entry flips
+  to `enabled: true`; `ai-safety` and `supply-chain` stay pending. New
+  `code-intel audit --operation validate|render` CLI parses a report,
+  validates it against the department registry (`--operation validate
+  --repo <root> --report <path>`), or prints its `## Audit` markdown section
+  (`--operation render --report <path>`, no registry needed). The audit
+  report is now a first-class artifact
+  (`code-intel-audit-report.v1` / `diagnosis.audit`) in `artifact_ref.rs`.
 
 ## [0.5.1-beta.1] — 2026-07-25
 

--- a/crates/code-intel-cli/src/artifact_ref.rs
+++ b/crates/code-intel-cli/src/artifact_ref.rs
@@ -251,6 +251,12 @@ pub(crate) fn registered_contract(artifact: &Value) -> Result<ArtifactContract, 
             max_bytes: 8 * 1024 * 1024,
             validate_payload: validate_hospital_report,
         }),
+        (Some("code-intel-audit-report.v1"), Some("diagnosis.audit")) => Ok(ArtifactContract {
+            artifact_schema: "code-intel-audit-report.v1",
+            artifact_type: "diagnosis.audit",
+            max_bytes: 8 * 1024 * 1024,
+            validate_payload: validate_audit_report,
+        }),
         (Some("code-intel-hospital-markdown.v1"), Some("diagnosis.hospital-view")) => {
             Ok(ArtifactContract {
                 artifact_schema: "code-intel-hospital-markdown.v1",
@@ -1207,6 +1213,19 @@ fn validate_hospital_audit_block(value: &Value) -> Result<(), String> {
         return Err("hospital report audit block contract is invalid".into());
     }
     Ok(())
+}
+
+/// Structural only: `AuditReport::parse` already enforces UTF-8, rejects
+/// duplicate JSON keys, and applies the closed-object
+/// `code-intel-audit-report.v1` shape. Registry-level validation
+/// (`report.validate(&registry)`, which needs
+/// `orchestration/audit/departments.v1.json` loaded from the repository
+/// root) is deliberately not run here: payload validators receive only the
+/// artifact bytes, no repo context, so that cross-artifact check is the
+/// CLI's job (`code-intel audit --operation validate --repo <root> --report
+/// <path>`), not the persist-time contract's.
+fn validate_audit_report(bytes: &[u8]) -> Result<(), String> {
+    crate::audit_report::AuditReport::parse(bytes).map(|_| ())
 }
 
 fn validate_surgery_plan(bytes: &[u8]) -> Result<(), String> {
@@ -3314,5 +3333,20 @@ mod tests {
         extra_key["audit"]["surprise"] = json!(true);
         let error = validate_hospital_report(&serde_json::to_vec(&extra_key).unwrap()).unwrap_err();
         assert!(error.contains("audit block"));
+    }
+
+    #[test]
+    fn audit_report_contract_accepts_the_fixture_and_rejects_an_unknown_field() {
+        let fixture = fs::read(
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("tests/fixtures/audit/audit-report.v1.example.json"),
+        )
+        .unwrap();
+        validate_audit_report(&fixture).unwrap();
+
+        let mut value: Value = serde_json::from_slice(&fixture).unwrap();
+        value["bogus"] = json!(true);
+        let error = validate_audit_report(&serde_json::to_vec(&value).unwrap()).unwrap_err();
+        assert!(error.contains("unrecognized field"), "{error}");
     }
 }

--- a/crates/code-intel-cli/src/audit_report/cli.rs
+++ b/crates/code-intel-cli/src/audit_report/cli.rs
@@ -1,0 +1,133 @@
+use std::path::{Path, PathBuf};
+
+use serde_json::{json, Value};
+
+use super::{enums::DepartmentRunStatus, model::AuditReport, registry::DepartmentRegistry};
+
+/// `code-intel audit --operation validate --repo <root> --report <path>` or
+/// `code-intel audit --operation render --report <path>`. Mirrors the
+/// least-invasive `RAW_ROUTES` pattern already used by `change_impact`,
+/// `decision_record`, and friends: this module owns its own tiny argument
+/// parser and prints its own JSON, so `main.rs` only ever gains one table
+/// entry (see the `"audit"` route).
+pub(crate) fn run_raw(raw: &[String]) -> i32 {
+    match parse(raw) {
+        Ok(Operation::Validate { repo, report }) => match validate(&repo, &report) {
+            Ok(summary) => {
+                println!("{summary}");
+                0
+            }
+            Err(message) => fail(&message),
+        },
+        Ok(Operation::Render { report }) => match render(&report) {
+            Ok(markdown) => {
+                println!("{markdown}");
+                0
+            }
+            Err(message) => fail(&message),
+        },
+        Err(message) => fail(&message),
+    }
+}
+
+fn fail(message: &str) -> i32 {
+    println!("{}", json!({"ok": false, "error": message}));
+    65
+}
+
+#[derive(Debug)]
+enum Operation {
+    Validate { repo: PathBuf, report: PathBuf },
+    Render { report: PathBuf },
+}
+
+fn parse(raw: &[String]) -> Result<Operation, String> {
+    let mut operation = None;
+    let mut repo = None;
+    let mut report = None;
+    let mut index = 0;
+    while index < raw.len() {
+        let flag = raw[index].as_str();
+        let value = raw
+            .get(index + 1)
+            .filter(|value| !value.is_empty() && !value.starts_with("--"))
+            .ok_or_else(|| format!("{flag} requires one value"))?;
+        match flag {
+            "--operation" => set_once(&mut operation, value, flag)?,
+            "--repo" => set_once(&mut repo, value, flag)?,
+            "--report" => set_once(&mut report, value, flag)?,
+            _ => return Err(format!("unknown audit argument: {flag}")),
+        }
+        index += 2;
+    }
+    let report = report.map(PathBuf::from).ok_or("--report is required")?;
+    match operation.as_deref() {
+        Some("validate") => Ok(Operation::Validate {
+            repo: repo
+                .map(PathBuf::from)
+                .ok_or("--operation validate requires --repo")?,
+            report,
+        }),
+        Some("render") => Ok(Operation::Render { report }),
+        Some(other) => Err(format!(
+            "unknown --operation \"{other}\" (expected validate or render)"
+        )),
+        None => Err("--operation is required (validate or render)".to_string()),
+    }
+}
+
+fn set_once(slot: &mut Option<String>, value: &str, flag: &str) -> Result<(), String> {
+    if slot.replace(value.to_string()).is_some() {
+        Err(format!("duplicate {flag}"))
+    } else {
+        Ok(())
+    }
+}
+
+/// The full validate pipeline the CLI runs against a real repository: read
+/// the report file, parse it structurally, load and self-validate the
+/// on-disk department registry, then check the report against it.
+fn validate(repo: &Path, report_path: &Path) -> Result<Value, String> {
+    let bytes = read_report(report_path)?;
+    let report = AuditReport::parse(&bytes)?;
+    let registry = DepartmentRegistry::load(repo)?;
+    registry.validate(repo)?;
+    validate_report(&report, &registry)
+}
+
+/// The registry-agnostic half of `validate`: runs the fail-closed report
+/// rules against whatever `DepartmentRegistry` it is given (real or
+/// synthetic — see `cli_tests.rs`) and builds the compact success summary.
+fn validate_report(report: &AuditReport, registry: &DepartmentRegistry) -> Result<Value, String> {
+    report.validate(registry)?;
+    Ok(json!({
+        "ok": true,
+        "findings_total": report.findings.len(),
+        "overall": report.score_dashboard.overall,
+        "departments_assessed": count_assessed(report),
+    }))
+}
+
+fn count_assessed(report: &AuditReport) -> usize {
+    report
+        .departments
+        .iter()
+        .filter(|department| department.status == DepartmentRunStatus::Assessed)
+        .count()
+}
+
+/// Registry-independent: `render_markdown_section` only reads the parsed
+/// report, so rendering never needs `--repo`.
+fn render(report_path: &Path) -> Result<String, String> {
+    let bytes = read_report(report_path)?;
+    let report = AuditReport::parse(&bytes)?;
+    Ok(super::render_markdown_section(&report))
+}
+
+fn read_report(path: &Path) -> Result<Vec<u8>, String> {
+    std::fs::read(path).map_err(|error| format!("read report {}: {error}", path.display()))
+}
+
+#[cfg(test)]
+#[path = "cli_tests.rs"]
+mod tests;

--- a/crates/code-intel-cli/src/audit_report/cli_tests.rs
+++ b/crates/code-intel-cli/src/audit_report/cli_tests.rs
@@ -1,0 +1,158 @@
+use super::*;
+use serde_json::json;
+use std::{
+    fs,
+    path::PathBuf,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn fixture_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/audit/audit-report.v1.example.json")
+}
+
+fn fixture_bytes() -> Vec<u8> {
+    fs::read(fixture_path()).unwrap()
+}
+
+fn fixture_value() -> Value {
+    serde_json::from_slice(&fixture_bytes()).unwrap()
+}
+
+/// Mirrors `audit_report::validate_tests::registry()`: independent of the
+/// real, on-disk registry, marks all three departments `enabled: true` so
+/// the unmodified example fixture (security assessed, the other two
+/// not_assessed) validates without touching disk or requiring ai-safety/
+/// supply-chain prompt files that do not exist yet.
+fn synthetic_enabled_registry() -> DepartmentRegistry {
+    let value = json!({
+        "schema": "code-intel-audit-departments.v1",
+        "catalogVersion": "1.0.0",
+        "rubrics": {
+            "severity": "orchestration/audit/rubrics/severity.md",
+            "confidence": "orchestration/audit/rubrics/confidence.md",
+            "evidence": "orchestration/audit/rubrics/evidence.md",
+            "coverage": "orchestration/audit/rubrics/coverage.md",
+            "scoring": "orchestration/audit/rubrics/scoring.md"
+        },
+        "findingContract": "docs/audit-report.md",
+        "departments": [
+            {"id":"security","title":"Security","enabled":true,"prompt":"orchestration/audit/prompts/security.md","consumes":[],"applicabilityCheck":"always","trackingIssue":"t"},
+            {"id":"ai-safety","title":"AI Safety","enabled":true,"prompt":"orchestration/audit/prompts/ai-safety.md","consumes":[],"applicabilityCheck":"ai-surface","trackingIssue":"t"},
+            {"id":"supply-chain","title":"Supply Chain","enabled":true,"prompt":"orchestration/audit/prompts/supply-chain.md","consumes":[],"applicabilityCheck":"manifests-present","trackingIssue":"t"}
+        ]
+    });
+    DepartmentRegistry::from_value(&value).unwrap()
+}
+
+struct TempReport(PathBuf);
+
+impl TempReport {
+    fn write(value: &Value) -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "code-intel-audit-cli-test-{}-{nonce}.json",
+            std::process::id()
+        ));
+        fs::write(&path, serde_json::to_vec(value).unwrap()).unwrap();
+        Self(path)
+    }
+}
+
+impl Drop for TempReport {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.0);
+    }
+}
+
+#[test]
+fn parse_requires_repo_for_validate_but_not_for_render() {
+    let validate_without_repo = vec![
+        "--operation".to_string(),
+        "validate".to_string(),
+        "--report".to_string(),
+        "report.json".to_string(),
+    ];
+    let error = parse(&validate_without_repo).unwrap_err();
+    assert!(error.contains("requires --repo"), "{error}");
+
+    let render_without_repo = vec![
+        "--operation".to_string(),
+        "render".to_string(),
+        "--report".to_string(),
+        "report.json".to_string(),
+    ];
+    assert!(matches!(
+        parse(&render_without_repo),
+        Ok(Operation::Render { .. })
+    ));
+}
+
+#[test]
+fn validate_report_accepts_the_example_fixture_against_a_synthetic_enabled_registry() {
+    let report = AuditReport::parse(&fixture_bytes()).unwrap();
+    let summary = validate_report(&report, &synthetic_enabled_registry()).unwrap();
+    assert_eq!(summary["ok"], true);
+    assert_eq!(summary["findings_total"], 1);
+    assert_eq!(summary["overall"], 7.0);
+    assert_eq!(summary["departments_assessed"], 1);
+}
+
+#[test]
+fn validate_accepts_a_report_with_security_assessed_against_the_real_registry() {
+    // The on-disk registry now has `security` enabled; adjust a copy of the
+    // fixture so ai-safety/supply-chain are `disabled` (matching their
+    // still-disabled registry entries) and run the full disk-backed
+    // validate pipeline (load + registry.validate + report.validate)
+    // against the REAL repository registry.
+    let mut value = fixture_value();
+    for department in value["departments"].as_array_mut().unwrap() {
+        if matches!(
+            department["id"].as_str(),
+            Some("ai-safety" | "supply-chain")
+        ) {
+            department["status"] = json!("disabled");
+        }
+    }
+    let temp = TempReport::write(&value);
+    let summary = validate(&repo_root(), &temp.0).unwrap();
+    assert_eq!(summary["ok"], true);
+    assert_eq!(summary["findings_total"], 1);
+    assert_eq!(summary["overall"], 7.0);
+    assert_eq!(summary["departments_assessed"], 1);
+}
+
+#[test]
+fn validate_rejects_the_unmodified_fixture_against_the_real_registry() {
+    // ai-safety/supply-chain are `not_assessed` in the fixture but the real
+    // registry still has them `enabled: false` (requiring `disabled`) —
+    // rule (d) rejects the mismatch.
+    let error = validate(&repo_root(), &fixture_path()).unwrap_err();
+    assert!(error.contains("disabled in the registry"), "{error}");
+}
+
+#[test]
+fn run_raw_exits_nonzero_on_a_failing_validate() {
+    let raw = vec![
+        "--operation".to_string(),
+        "validate".to_string(),
+        "--repo".to_string(),
+        repo_root().to_string_lossy().into_owned(),
+        "--report".to_string(),
+        fixture_path().to_string_lossy().into_owned(),
+    ];
+    assert_eq!(run_raw(&raw), 65);
+}
+
+#[test]
+fn render_prints_the_audit_markdown_section() {
+    let markdown = render(&fixture_path()).unwrap();
+    assert!(markdown.contains("## Audit"));
+    assert!(markdown.contains("| security |"));
+}

--- a/crates/code-intel-cli/src/audit_report/mod.rs
+++ b/crates/code-intel-cli/src/audit_report/mod.rs
@@ -1,6 +1,7 @@
 #[path = "../content_contract.rs"]
 mod content_contract;
 
+mod cli;
 mod enums;
 mod json_helpers;
 mod model;
@@ -8,5 +9,6 @@ mod registry;
 mod render;
 mod validate;
 
+pub(crate) use cli::run_raw;
 pub(crate) use model::AuditReport;
 pub(crate) use render::render_markdown_section;

--- a/crates/code-intel-cli/src/audit_report/validate_tests.rs
+++ b/crates/code-intel-cli/src/audit_report/validate_tests.rs
@@ -21,24 +21,27 @@ fn fixture_value() -> Value {
     serde_json::from_slice(&fixture_bytes()).unwrap()
 }
 
-/// The real, on-disk `orchestration/audit/departments.v1.json`. Every
-/// department in it is `enabled: false` (T1 registers departments but
-/// does not yet run any of them — see FIX 2's enabled-consistency rule),
-/// so this registry is only usable directly against a report where every
-/// department run is `status: disabled`; see
-/// `registry_loads_and_validates_the_real_departments_file` and
-/// `validates_a_minimal_all_disabled_report_against_the_real_registry`.
+/// The real, on-disk `orchestration/audit/departments.v1.json`. `security`
+/// is `enabled: true` (T2: its prompt landed at
+/// `orchestration/audit/prompts/security.md`); `ai-safety` and
+/// `supply-chain` stay `enabled: false` pending their own department
+/// tickets (see FIX 2's enabled-consistency rule). A report validated
+/// against this registry must therefore report `security` as `assessed`
+/// or `not_assessed` (never `disabled`) and the other two as `disabled`;
+/// see `registry_loads_and_validates_the_real_departments_file` and
+/// `validates_a_minimal_report_with_security_not_assessed_against_the_real_registry`.
 fn real_registry() -> DepartmentRegistry {
     DepartmentRegistry::load(&repo_root()).unwrap()
 }
 
-/// A synthetic registry, independent of the real (all `enabled: false`)
-/// `orchestration/audit/departments.v1.json`, that marks `security`,
-/// `ai-safety`, and `supply-chain` `enabled: true`. The example fixture
-/// reports `security` as `assessed` and the other two as `not_assessed`
-/// (see FIX 2's enabled-consistency rule (d): `not_assessed` requires
-/// `enabled: true`), so every test below that validates the fixture — or
-/// a report shaped like it — needs this registry, not the real one.
+/// A synthetic registry, independent of the real
+/// `orchestration/audit/departments.v1.json` (which now has only
+/// `security` `enabled: true`), that marks `security`, `ai-safety`, and
+/// `supply-chain` all `enabled: true`. The example fixture reports
+/// `security` as `assessed` and the other two as `not_assessed` (see FIX
+/// 2's enabled-consistency rule (d): `not_assessed` requires `enabled:
+/// true`), so every test below that validates the fixture — or a report
+/// shaped like it — needs this all-enabled registry, not the real one.
 fn registry() -> DepartmentRegistry {
     let value = json!({
         "schema": "code-intel-audit-departments.v1",
@@ -163,12 +166,15 @@ fn rejects_assessed_status_when_the_registry_entry_is_disabled() {
 }
 
 #[test]
-fn validates_a_minimal_all_disabled_report_against_the_real_registry() {
-    // The real orchestration/audit/departments.v1.json registers all
-    // three departments with `enabled: false` (T1 scope: registered but
-    // not yet run). A report that honestly reflects that — every
-    // department `disabled`, every score null, every coverage row
-    // `not_assessed`, `overall` null — must validate cleanly against it.
+fn validates_a_minimal_report_with_security_not_assessed_against_the_real_registry() {
+    // The real orchestration/audit/departments.v1.json now registers
+    // `security` with `enabled: true` (T2: its prompt landed) while
+    // `ai-safety` and `supply-chain` stay `enabled: false` pending their
+    // own department tickets. A report that honestly reflects that —
+    // `security` `not_assessed` (rule (d) forbids `disabled` once a
+    // department is enabled), `ai-safety`/`supply-chain` `disabled`, every
+    // score null, every coverage row `not_assessed`, `overall` null — must
+    // validate cleanly against it.
     let value = json!({
         "schema": "code-intel-audit-report.v1",
         "generatedAt": null,
@@ -177,8 +183,8 @@ fn validates_a_minimal_all_disabled_report_against_the_real_registry() {
         "departments": [
             {
                 "id": "security",
-                "status": "disabled",
-                "applicability": {"applicable": "unknown", "reason": "security is disabled in the registry for this run."}
+                "status": "not_assessed",
+                "applicability": {"applicable": "unknown", "reason": "This minimal fixture does not run the security department; no evidence was gathered."}
             },
             {
                 "id": "ai-safety",
@@ -194,14 +200,14 @@ fn validates_a_minimal_all_disabled_report_against_the_real_registry() {
         "findings": [],
         "score_dashboard": {
             "entries": [
-                {"department": "security", "score": null, "justification": "Disabled in the registry for this run."},
+                {"department": "security", "score": null, "justification": "Not assessed by this minimal fixture."},
                 {"department": "ai-safety", "score": null, "justification": "Disabled in the registry for this run."},
                 {"department": "supply-chain", "score": null, "justification": "Disabled in the registry for this run."}
             ],
             "overall": null
         },
         "coverage_matrix": [
-            {"department": "security", "coverage": "not_assessed", "inspected_evidence": [], "exclusions": ["security is disabled in the registry for this run."]},
+            {"department": "security", "coverage": "not_assessed", "inspected_evidence": [], "exclusions": ["security was not run by this minimal fixture."]},
             {"department": "ai-safety", "coverage": "not_assessed", "inspected_evidence": [], "exclusions": ["ai-safety is disabled in the registry for this run."]},
             {"department": "supply-chain", "coverage": "not_assessed", "inspected_evidence": [], "exclusions": ["supply-chain is disabled in the registry for this run."]}
         ]

--- a/crates/code-intel-cli/src/main.rs
+++ b/crates/code-intel-cli/src/main.rs
@@ -593,6 +593,12 @@ const RAW_ROUTES: &[RawRoute] = &[
         runner: survival_scan::run_raw,
     },
     RawRoute {
+        command: "audit",
+        subcommand: None,
+        argument_offset: 1,
+        runner: audit_report::run_raw,
+    },
+    RawRoute {
         command: "artifact",
         subcommand: Some("index"),
         argument_offset: 1,

--- a/crates/code-intel-cli/tests/audit_report.rs
+++ b/crates/code-intel-cli/tests/audit_report.rs
@@ -152,11 +152,17 @@ fn registry_file_has_unique_department_ids_and_existing_rubric_and_finding_contr
         root.join(finding_contract).is_file(),
         "findingContract file must exist on disk: {finding_contract}"
     );
-    // T1 registers exactly these three departments and does not yet run any
-    // of them (see docs/audit-report.md and CHANGELOG.md). Check each
-    // required slot by id rather than the full list, so a future PR can add
-    // more departments without this test needing to change.
-    for id in ["security", "ai-safety", "supply-chain"] {
+    // T1 registers exactly these three departments. T2 flips `security` to
+    // `enabled: true` once its prompt lands; `ai-safety` and `supply-chain`
+    // stay `enabled: false` pending their own department tickets (see
+    // docs/audit-report.md and CHANGELOG.md). Check each required slot by
+    // id rather than the full list, so a future PR can add more departments
+    // without this test needing to change.
+    for (id, expected_enabled) in [
+        ("security", true),
+        ("ai-safety", false),
+        ("supply-chain", false),
+    ] {
         let department = registry["departments"]
             .as_array()
             .unwrap()
@@ -165,8 +171,8 @@ fn registry_file_has_unique_department_ids_and_existing_rubric_and_finding_contr
             .unwrap_or_else(|| panic!("registry must contain a department with id \"{id}\""));
         assert_eq!(
             department["enabled"],
-            json!(false),
-            "department \"{id}\" must currently be enabled: false"
+            json!(expected_enabled),
+            "department \"{id}\" enabled flag does not match the expected registration state"
         );
     }
 }

--- a/docs/audit-report.md
+++ b/docs/audit-report.md
@@ -1,6 +1,6 @@
 # Code Intel Audit Report
 
-The audit layer runs audit dimensions as hospital departments. Each department consumes the modality evidence hospital mode already admits (`xray`, `anatomy`, `ct`, `mri`, `pet`, `chart`, `governance`, see `docs/hospital-mode.md`) plus any targeted reads it takes to resolve a finding, and produces findings, a score dashboard, and a coverage matrix in a shared, fail-closed contract. This is the audit kernel: the artifact contract, the finding contract, and the validation invariants every department's output must satisfy. It does not run departments itself — `orchestration/audit/departments.v1.json` currently registers three (`security`, `ai-safety`, `supply-chain`), all `enabled: false`.
+The audit layer runs audit dimensions as hospital departments. Each department consumes the modality evidence hospital mode already admits (`xray`, `anatomy`, `ct`, `mri`, `pet`, `chart`, `governance`, see `docs/hospital-mode.md`) plus any targeted reads it takes to resolve a finding, and produces findings, a score dashboard, and a coverage matrix in a shared, fail-closed contract. This is the audit kernel: the artifact contract, the finding contract, and the validation invariants every department's output must satisfy. It does not run departments itself — `orchestration/audit/departments.v1.json` currently registers three (`security`, `ai-safety`, `supply-chain`). `security` is `enabled: true` (its prompt lives at `orchestration/audit/prompts/security.md`); `ai-safety` and `supply-chain` remain `enabled: false` pending their own department tickets.
 
 Methodology adapted from [Fuck_My_Shit_Mountain](https://github.com/XiNian-dada/Fuck_My_Shit_Mountain) (MIT): the rubrics in `orchestration/audit/rubrics/` and the finding contract below are rewritten for this repo's evidence-first context, not copied.
 
@@ -60,4 +60,22 @@ Adding a department never requires a kernel change:
 2. Write the prompt file at the path the entry declares.
 3. Flip `enabled: true` once the prompt is ready to run. `DepartmentRegistry::validate()` will fail closed if the prompt file is still missing.
 
+`security` has completed all three steps (T2). `ai-safety` and `supply-chain` are registered but still `enabled: false`, pending their own department tickets (issues #20 and #21).
+
 The kernel does not care how a department produces its `audit-report.json` — only that the result satisfies the finding contract and the fail-closed invariants above.
+
+## Validating a Report
+
+`code-intel audit` exposes two operations; both read the report from `--report <path>`.
+
+- `--operation validate --repo <root> --report <path>` — parses the report structurally
+  (`AuditReport::parse`, closed-object shape, no unknown fields), loads and self-validates
+  `orchestration/audit/departments.v1.json` from `--repo`, then checks the report against it
+  (`report.validate(&registry)`, the fail-closed rules above). On success it prints a compact
+  one-line JSON summary — `{"ok":true,"findings_total":<n>,"overall":<score-or-null>,
+  "departments_assessed":<n>}` — and exits `0`. On any failure it prints
+  `{"ok":false,"error":"<message>"}` to stdout and exits nonzero.
+- `--operation render --report <path>` — parses the report and prints the same `## Audit`
+  markdown section `hospital.md` renders, so a department (or a person) can eyeball the result
+  without a full pipeline run. It does not need `--repo`: `render_markdown_section` only reads
+  the parsed report, never the registry.

--- a/orchestration/audit/departments.v1.json
+++ b/orchestration/audit/departments.v1.json
@@ -13,7 +13,7 @@
     {
       "id": "security",
       "title": "Security",
-      "enabled": false,
+      "enabled": true,
       "prompt": "orchestration/audit/prompts/security.md",
       "consumes": ["xray", "ct", "anatomy", "chart"],
       "applicabilityCheck": "always",

--- a/orchestration/audit/prompts/security.md
+++ b/orchestration/audit/prompts/security.md
@@ -1,0 +1,67 @@
+# Security Department Prompt
+
+Adapted from [Fuck_My_Shit_Mountain](https://github.com/XiNian-dada/Fuck_My_Shit_Mountain) `prompts/security-audit.md` (MIT). Rewritten for Code Intel Pipeline: evidence comes from pipeline modalities plus targeted reads, and output is the fail-closed `code-intel-audit-report.v1` contract instead of a prose report.
+
+This prompt is an operating instruction for an agent running the `security` audit department against a target repository. Read `docs/audit-report.md` (finding contract, fail-closed rules) and the rubrics in `orchestration/audit/rubrics/` before producing output.
+
+## Inputs
+
+- The target repository checkout (`--repo` root).
+- Pipeline evidence for that repository when available, in this priority order:
+  - `xray` (rg file inventory + text signals) — cheapest sweep surface.
+  - `ct` (Sentrux hotspots, complexity, coupling) — ordering: audit hot, tangled files first.
+  - `anatomy` (Understand Anything graph) — entry points and trust boundaries.
+  - `chart` (Repowise semantic memory) — project background; use it to kill false positives, never to manufacture findings.
+- If a modality is missing, proceed without it and say so in the coverage matrix `exclusions` — never guess what it would have said.
+
+## Threat model first
+
+Before sweeping, write down (for yourself) what the target actually is, because it decides which findings are real:
+
+- Network service / web app: full FMSM surface applies (authn/authz, injection, SSRF, CSRF, transport).
+- Local CLI or pipeline tool: the primary attackers are (1) untrusted repositories and files the tool parses, (2) untrusted process output the tool consumes, (3) the environment (keys, tokens) the tool can leak into artifacts, logs, or committed files. HTTPS/CSP/session findings are usually noise here.
+- Library: its callers are the boundary; audit exported-surface input handling.
+
+Do not report findings the target's threat model cannot exercise (FMSM "Focus" rule). A local-only tool with no listener does not get a TLS finding.
+
+## Audit areas
+
+1. **Untrusted input handling** — command/SQL/template injection, path traversal in file operations (joins with `..`, symlink following, archive extraction), deserialization of untrusted data, SSRF in any URL fetching.
+2. **Authentication & authorization** — identity checks, privilege boundaries, hardcoded credentials or tokens, session/token lifecycle. Mark Not applicable in your notes when the target has no such surface.
+3. **Secrets & configuration** — hardcoded secrets in code/tests/config, secrets read from env and written into logs, error messages, artifacts, or version control; unsafe default configuration.
+4. **Process & filesystem effects** — child process invocation with attacker-influenced arguments, world-writable or predictable temp paths, file writes outside declared output roots.
+5. **Operational leakage** — sensitive data in logs or debug output, error handling that leaks internal state.
+
+Dependency and CI provenance risks belong to the `supply-chain` department — do not duplicate them here; note the handoff in `exclusions` if you spot one in passing.
+
+## Method
+
+1. Build the sweep from evidence: rg signal patterns (secret-shaped strings, `Command`/`spawn`/`exec`, path joins near user input, URL fetches, `unsafe`), Sentrux hotspot ranking, graph entry points.
+2. A tool hit is a lead, never a finding. Every finding requires a targeted read of the code that confirms the behavior.
+3. Trace at least one realistic attack path per finding: precondition → attacker input → mechanism → impact. Encode it in the finding's `failure_scenario`. No realistic path, no finding — park it as `suspected` only if the precondition is plausible but unverified.
+4. Separate `confirmed` (behavior directly observed in code, file evidence with path required by the kernel) from `suspected` (pattern-inferred). Be conservative with confidence per `rubrics/confidence.md`.
+5. Score per `rubrics/scoring.md`: a clean sweep may score 10.0 only with `high` coverage; state the strongest evidence in the justification.
+6. Fill the coverage matrix honestly: what was swept, what was read, what was excluded and why. Absence of findings under `low` coverage is weak evidence — say so.
+
+## Secrets red line
+
+If you discover a real secret (key, token, password, connection string):
+
+- Set `redacted: true` on the finding, and never place the secret value in the report, evidence excerpts, logs, or conversation output.
+- Identify it by path, variable/key name, secret type, and blast radius; recommend rotation when exposure is plausible.
+
+## Output contract
+
+Produce one `code-intel-audit-report.v1` JSON document (see `orchestration/schemas/code-intel-audit-report.v1.schema.json`):
+
+- `departments` must list **every** registered department (kernel rule: exact registry membership). Run `security` as `assessed` (or `not_assessed` with an applicability reason if the target is out of scope); report departments whose registry entry is `enabled: false` as `disabled`.
+- Findings follow the finding contract: id (`security-001`, `security-002`, …), severity/confidence/status per rubrics, evidence refs naming the modality or file (with `line_start`/`line_end` for reads), problem, failure scenario, minimal fix, regression test, estimated effort, redacted flag.
+- Score dashboard and coverage matrix rows for every department you list; `assessed` requires a non-null score and non-`not_assessed` coverage.
+
+Then validate fail-closed and fix until green:
+
+```bash
+code-intel audit --operation validate --repo <target-root> --report <report-path>
+```
+
+`--operation render` prints the human-readable audit section for hospital.md if you need to eyeball the result.

--- a/orchestration/integrations.json
+++ b/orchestration/integrations.json
@@ -824,7 +824,7 @@
           "toolchainDigests": [
             "3ba256f4ca0bf62aca08f688f7ecf31800dd10e68371054e2f1605eff197ea81",
             "f8af3e1acf11023f51e4a21c1d7e31575c55f332cc310713a1ec1be7ba6ef175",
-            "b637cf067ffd19686fcd1931c7f8690dd02606adbffef2958bb8112fe7afec20",
+            "687d30408f14b31117771b126b1400483d3b73a25011b83ee6f5fa39c7af3522",
             "b118ba78ff3ef4a189525c642184cbd320a268d2885681ab153544db554c5965",
             "e3072b6b01a4f692c2ac75c7c4995747f9a0fd1ce4f32e1ab1599f348661f570",
             "40c532ed3aa52144bdc8bb4422e04b23c54196d352ac9cb0f3e93a5a059af120"
@@ -885,7 +885,7 @@
           "version": "1.0.0",
           "toolchainDigests": [
             "13968a5e5da8923b00ab8495b5b848e0f41514e7c004c183ae2311d35d5ff2a3",
-            "b637cf067ffd19686fcd1931c7f8690dd02606adbffef2958bb8112fe7afec20",
+            "687d30408f14b31117771b126b1400483d3b73a25011b83ee6f5fa39c7af3522",
             "f8af3e1acf11023f51e4a21c1d7e31575c55f332cc310713a1ec1be7ba6ef175"
           ]
         },
@@ -936,7 +936,7 @@
           "version": "1.0.0",
           "toolchainDigests": [
             "a6da84444e815dd94c15887190c7d6bd48c7bca5975fb5d493eb77ab39f27d80",
-            "b637cf067ffd19686fcd1931c7f8690dd02606adbffef2958bb8112fe7afec20",
+            "687d30408f14b31117771b126b1400483d3b73a25011b83ee6f5fa39c7af3522",
             "f8af3e1acf11023f51e4a21c1d7e31575c55f332cc310713a1ec1be7ba6ef175"
           ]
         },


### PR DESCRIPTION
## Summary
- Flips `security` to `enabled: true` in `orchestration/audit/departments.v1.json`, with its prompt at `orchestration/audit/prompts/security.md` (adapted from Fuck_My_Shit_Mountain, MIT)
- New `code-intel audit --operation validate|render` CLI (`audit_report/cli.rs`): validates a report against the department registry, or renders its markdown section
- Audit reports registered as a first-class artifact (`code-intel-audit-report.v1` / `diagnosis.audit`) in `artifact_ref.rs`
- Toolchain digest refreshed in `integrations.json` for the changed prompt

Closes #19.

## Test plan
- [x] `cargo test -p code-intel audit_report` — 72 passed, 0 failed
- [x] Dogfood self-scan (`code-intel run execute` against this branch) — exit 0, hospital diagnosis clean/green