### PR TITLE
feat(audit): T3 ai-safety and T4 supply-chain departments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Audit departments `ai-safety` (T3) and `supply-chain` (T4): prompts under
+  `orchestration/audit/prompts/`, adapted from
+  [Fuck_My_Shit_Mountain](https://github.com/XiNian-dada/Fuck_My_Shit_Mountain)
+  (MIT) and rewritten to run on pipeline modality evidence. `ai-safety` gates
+  on an AI/LLM surface being present and reports `not_assessed` with evidence
+  when there is none; `supply-chain` parses manifests, lockfiles, and CI
+  workflow permissions as structured facts before judging. Both are flipped to
+  `enabled: true` in `orchestration/audit/departments.v1.json`; the kernel and
+  the `code-intel audit` CLI needed no change.
+
 - Audit kernel (T1): a shared contract for audit departments that run as
   hospital departments over existing modality evidence. Adds the
   `code-intel-audit-report.v1` schema, `orchestration/audit/rubrics/`

--- a/crates/code-intel-cli/src/audit_report/cli_tests.rs
+++ b/crates/code-intel-cli/src/audit_report/cli_tests.rs
@@ -22,11 +22,11 @@ fn fixture_value() -> Value {
     serde_json::from_slice(&fixture_bytes()).unwrap()
 }
 
-/// Mirrors `audit_report::validate_tests::registry()`: independent of the
-/// real, on-disk registry, marks all three departments `enabled: true` so
-/// the unmodified example fixture (security assessed, the other two
-/// not_assessed) validates without touching disk or requiring ai-safety/
-/// supply-chain prompt files that do not exist yet.
+/// Mirrors `audit_report::validate_tests::registry()`: a fixed in-memory
+/// registry with all three departments `enabled: true`, so the tests that
+/// exercise the report-shape rules stay independent of whatever the on-disk
+/// registry grows next. The disk-backed path is covered separately by
+/// `validate_accepts_the_unmodified_fixture_against_the_real_registry`.
 fn synthetic_enabled_registry() -> DepartmentRegistry {
     let value = json!({
         "schema": "code-intel-audit-departments.v1",
@@ -105,23 +105,13 @@ fn validate_report_accepts_the_example_fixture_against_a_synthetic_enabled_regis
 }
 
 #[test]
-fn validate_accepts_a_report_with_security_assessed_against_the_real_registry() {
-    // The on-disk registry now has `security` enabled; adjust a copy of the
-    // fixture so ai-safety/supply-chain are `disabled` (matching their
-    // still-disabled registry entries) and run the full disk-backed
-    // validate pipeline (load + registry.validate + report.validate)
-    // against the REAL repository registry.
-    let mut value = fixture_value();
-    for department in value["departments"].as_array_mut().unwrap() {
-        if matches!(
-            department["id"].as_str(),
-            Some("ai-safety" | "supply-chain")
-        ) {
-            department["status"] = json!("disabled");
-        }
-    }
-    let temp = TempReport::write(&value);
-    let summary = validate(&repo_root(), &temp.0).unwrap();
+fn validate_accepts_the_unmodified_fixture_against_the_real_registry() {
+    // All three departments are now enabled on disk, and the fixture reports
+    // `security` assessed with the other two `not_assessed` — the shape rule
+    // (d) requires of an enabled department that did not run. Exercise the
+    // full disk-backed pipeline (load + registry.validate + report.validate)
+    // against the REAL repository registry, no adjustment needed.
+    let summary = validate(&repo_root(), &fixture_path()).unwrap();
     assert_eq!(summary["ok"], true);
     assert_eq!(summary["findings_total"], 1);
     assert_eq!(summary["overall"], 7.0);
@@ -129,23 +119,32 @@ fn validate_accepts_a_report_with_security_assessed_against_the_real_registry() 
 }
 
 #[test]
-fn validate_rejects_the_unmodified_fixture_against_the_real_registry() {
-    // ai-safety/supply-chain are `not_assessed` in the fixture but the real
-    // registry still has them `enabled: false` (requiring `disabled`) —
-    // rule (d) rejects the mismatch.
-    let error = validate(&repo_root(), &fixture_path()).unwrap_err();
-    assert!(error.contains("disabled in the registry"), "{error}");
+fn validate_rejects_a_disabled_run_status_against_the_real_registry() {
+    // Every registry entry is enabled, so rule (d) rejects a report that
+    // reports any department as `disabled`.
+    let mut value = fixture_value();
+    for department in value["departments"].as_array_mut().unwrap() {
+        if department["id"] == "ai-safety" {
+            department["status"] = json!("disabled");
+        }
+    }
+    let temp = TempReport::write(&value);
+    let error = validate(&repo_root(), &temp.0).unwrap_err();
+    assert!(error.contains("run status is \"disabled\""), "{error}");
 }
 
 #[test]
 fn run_raw_exits_nonzero_on_a_failing_validate() {
+    let mut value = fixture_value();
+    value["score_dashboard"]["overall"] = json!(1.0);
+    let temp = TempReport::write(&value);
     let raw = vec![
         "--operation".to_string(),
         "validate".to_string(),
         "--repo".to_string(),
         repo_root().to_string_lossy().into_owned(),
         "--report".to_string(),
-        fixture_path().to_string_lossy().into_owned(),
+        temp.0.to_string_lossy().into_owned(),
     ];
     assert_eq!(run_raw(&raw), 65);
 }

--- a/crates/code-intel-cli/src/audit_report/validate_tests.rs
+++ b/crates/code-intel-cli/src/audit_report/validate_tests.rs
@@ -29,19 +29,16 @@ fn fixture_value() -> Value {
 /// against this registry must therefore report `security` as `assessed`
 /// or `not_assessed` (never `disabled`) and the other two as `disabled`;
 /// see `registry_loads_and_validates_the_real_departments_file` and
-/// `validates_a_minimal_report_with_security_not_assessed_against_the_real_registry`.
+/// `validates_a_minimal_all_not_assessed_report_against_the_real_registry`.
 fn real_registry() -> DepartmentRegistry {
     DepartmentRegistry::load(&repo_root()).unwrap()
 }
 
-/// A synthetic registry, independent of the real
-/// `orchestration/audit/departments.v1.json` (which now has only
-/// `security` `enabled: true`), that marks `security`, `ai-safety`, and
-/// `supply-chain` all `enabled: true`. The example fixture reports
-/// `security` as `assessed` and the other two as `not_assessed` (see FIX
-/// 2's enabled-consistency rule (d): `not_assessed` requires `enabled:
-/// true`), so every test below that validates the fixture — or a report
-/// shaped like it — needs this all-enabled registry, not the real one.
+/// A synthetic all-enabled registry, independent of the real
+/// `orchestration/audit/departments.v1.json` on disk. The real registry
+/// currently matches it, but keeping the tests on a fixed in-memory
+/// registry means a future department landing on disk cannot silently
+/// change what these rule-level tests assert.
 fn registry() -> DepartmentRegistry {
     let value = json!({
         "schema": "code-intel-audit-departments.v1",
@@ -166,15 +163,12 @@ fn rejects_assessed_status_when_the_registry_entry_is_disabled() {
 }
 
 #[test]
-fn validates_a_minimal_report_with_security_not_assessed_against_the_real_registry() {
-    // The real orchestration/audit/departments.v1.json now registers
-    // `security` with `enabled: true` (T2: its prompt landed) while
-    // `ai-safety` and `supply-chain` stay `enabled: false` pending their
-    // own department tickets. A report that honestly reflects that —
-    // `security` `not_assessed` (rule (d) forbids `disabled` once a
-    // department is enabled), `ai-safety`/`supply-chain` `disabled`, every
-    // score null, every coverage row `not_assessed`, `overall` null — must
-    // validate cleanly against it.
+fn validates_a_minimal_all_not_assessed_report_against_the_real_registry() {
+    // The real orchestration/audit/departments.v1.json registers all three
+    // departments with `enabled: true` (each has a prompt). A report that
+    // ran none of them — every department `not_assessed` (rule (d) forbids
+    // `disabled` for an enabled department), every score null, every
+    // coverage row `not_assessed`, `overall` null — must validate cleanly.
     let value = json!({
         "schema": "code-intel-audit-report.v1",
         "generatedAt": null,
@@ -188,28 +182,28 @@ fn validates_a_minimal_report_with_security_not_assessed_against_the_real_regist
             },
             {
                 "id": "ai-safety",
-                "status": "disabled",
-                "applicability": {"applicable": "unknown", "reason": "ai-safety is disabled in the registry for this run."}
+                "status": "not_assessed",
+                "applicability": {"applicable": "unknown", "reason": "This minimal fixture does not run the ai-safety department; no evidence was gathered."}
             },
             {
                 "id": "supply-chain",
-                "status": "disabled",
-                "applicability": {"applicable": "unknown", "reason": "supply-chain is disabled in the registry for this run."}
+                "status": "not_assessed",
+                "applicability": {"applicable": "unknown", "reason": "This minimal fixture does not run the supply-chain department; no evidence was gathered."}
             }
         ],
         "findings": [],
         "score_dashboard": {
             "entries": [
                 {"department": "security", "score": null, "justification": "Not assessed by this minimal fixture."},
-                {"department": "ai-safety", "score": null, "justification": "Disabled in the registry for this run."},
-                {"department": "supply-chain", "score": null, "justification": "Disabled in the registry for this run."}
+                {"department": "ai-safety", "score": null, "justification": "Not assessed by this minimal fixture."},
+                {"department": "supply-chain", "score": null, "justification": "Not assessed by this minimal fixture."}
             ],
             "overall": null
         },
         "coverage_matrix": [
             {"department": "security", "coverage": "not_assessed", "inspected_evidence": [], "exclusions": ["security was not run by this minimal fixture."]},
-            {"department": "ai-safety", "coverage": "not_assessed", "inspected_evidence": [], "exclusions": ["ai-safety is disabled in the registry for this run."]},
-            {"department": "supply-chain", "coverage": "not_assessed", "inspected_evidence": [], "exclusions": ["supply-chain is disabled in the registry for this run."]}
+            {"department": "ai-safety", "coverage": "not_assessed", "inspected_evidence": [], "exclusions": ["ai-safety was not run by this minimal fixture."]},
+            {"department": "supply-chain", "coverage": "not_assessed", "inspected_evidence": [], "exclusions": ["supply-chain was not run by this minimal fixture."]}
         ]
     });
     let report = AuditReport::parse(&serde_json::to_vec(&value).unwrap()).unwrap();

--- a/crates/code-intel-cli/tests/audit_report.rs
+++ b/crates/code-intel-cli/tests/audit_report.rs
@@ -152,16 +152,15 @@ fn registry_file_has_unique_department_ids_and_existing_rubric_and_finding_contr
         root.join(finding_contract).is_file(),
         "findingContract file must exist on disk: {finding_contract}"
     );
-    // T1 registers exactly these three departments. T2 flips `security` to
-    // `enabled: true` once its prompt lands; `ai-safety` and `supply-chain`
-    // stay `enabled: false` pending their own department tickets (see
+    // T1 registers exactly these three departments; T2 through T4 landed a
+    // prompt for each, so all three are now `enabled: true` (see
     // docs/audit-report.md and CHANGELOG.md). Check each required slot by
     // id rather than the full list, so a future PR can add more departments
     // without this test needing to change.
     for (id, expected_enabled) in [
         ("security", true),
-        ("ai-safety", false),
-        ("supply-chain", false),
+        ("ai-safety", true),
+        ("supply-chain", true),
     ] {
         let department = registry["departments"]
             .as_array()

--- a/docs/audit-report.md
+++ b/docs/audit-report.md
@@ -1,6 +1,6 @@
 # Code Intel Audit Report
 
-The audit layer runs audit dimensions as hospital departments. Each department consumes the modality evidence hospital mode already admits (`xray`, `anatomy`, `ct`, `mri`, `pet`, `chart`, `governance`, see `docs/hospital-mode.md`) plus any targeted reads it takes to resolve a finding, and produces findings, a score dashboard, and a coverage matrix in a shared, fail-closed contract. This is the audit kernel: the artifact contract, the finding contract, and the validation invariants every department's output must satisfy. It does not run departments itself — `orchestration/audit/departments.v1.json` currently registers three (`security`, `ai-safety`, `supply-chain`). `security` is `enabled: true` (its prompt lives at `orchestration/audit/prompts/security.md`); `ai-safety` and `supply-chain` remain `enabled: false` pending their own department tickets.
+The audit layer runs audit dimensions as hospital departments. Each department consumes the modality evidence hospital mode already admits (`xray`, `anatomy`, `ct`, `mri`, `pet`, `chart`, `governance`, see `docs/hospital-mode.md`) plus any targeted reads it takes to resolve a finding, and produces findings, a score dashboard, and a coverage matrix in a shared, fail-closed contract. This is the audit kernel: the artifact contract, the finding contract, and the validation invariants every department's output must satisfy. It does not run departments itself — `orchestration/audit/departments.v1.json` currently registers three (`security`, `ai-safety`, `supply-chain`), all `enabled: true` with prompts under `orchestration/audit/prompts/`.
 
 Methodology adapted from [Fuck_My_Shit_Mountain](https://github.com/XiNian-dada/Fuck_My_Shit_Mountain) (MIT): the rubrics in `orchestration/audit/rubrics/` and the finding contract below are rewritten for this repo's evidence-first context, not copied.
 
@@ -60,7 +60,7 @@ Adding a department never requires a kernel change:
 2. Write the prompt file at the path the entry declares.
 3. Flip `enabled: true` once the prompt is ready to run. `DepartmentRegistry::validate()` will fail closed if the prompt file is still missing.
 
-`security` has completed all three steps (T2). `ai-safety` and `supply-chain` are registered but still `enabled: false`, pending their own department tickets (issues #20 and #21).
+All three registered departments have completed these steps: `security` (T2, issue #19), `ai-safety` (T3, issue #20), and `supply-chain` (T4, issue #21). A department stays `enabled: false` only while its prompt is still being written.
 
 The kernel does not care how a department produces its `audit-report.json` — only that the result satisfies the finding contract and the fail-closed invariants above.
 

--- a/orchestration/audit/departments.v1.json
+++ b/orchestration/audit/departments.v1.json
@@ -22,7 +22,7 @@
     {
       "id": "ai-safety",
       "title": "AI Safety",
-      "enabled": false,
+      "enabled": true,
       "prompt": "orchestration/audit/prompts/ai-safety.md",
       "consumes": ["xray", "anatomy", "governance"],
       "applicabilityCheck": "ai-surface",
@@ -31,7 +31,7 @@
     {
       "id": "supply-chain",
       "title": "Supply Chain",
-      "enabled": false,
+      "enabled": true,
       "prompt": "orchestration/audit/prompts/supply-chain.md",
       "consumes": ["xray", "governance"],
       "applicabilityCheck": "manifests-present",

--- a/orchestration/audit/prompts/ai-safety.md
+++ b/orchestration/audit/prompts/ai-safety.md
@@ -1,0 +1,64 @@
+# AI Safety Department Prompt
+
+Adapted from [Fuck_My_Shit_Mountain](https://github.com/XiNian-dada/Fuck_My_Shit_Mountain) `prompts/ai-safety-audit.md` (MIT). Rewritten for Code Intel Pipeline: evidence comes from pipeline modalities plus targeted reads, and output is the fail-closed `code-intel-audit-report.v1` contract.
+
+This prompt is an operating instruction for an agent running the `ai-safety` audit department against a target repository. Read `docs/audit-report.md` and the rubrics in `orchestration/audit/rubrics/` before producing output.
+
+## Applicability gate — run this first
+
+This department is only meaningful when the target actually has an AI/LLM surface. Detect it before auditing:
+
+- Provider SDK imports or HTTP calls to model endpoints.
+- Prompt assets: `.md`/`.txt`/template files whose content is model instructions, or long string literals that read as instructions.
+- Tool/function definitions exposed to a model: MCP servers, function-calling schemas, agent tool registries.
+- Agent orchestration code: loops that feed model output back as input, or that dispatch on model-chosen actions.
+
+Record what you find as the department's `applicability.surface_evidence`.
+
+- **No surface found** → report the department as `not_assessed` with `applicable: "no"` and a reason naming what you searched. Do not invent findings, and do not score the department. This is the correct, honest outcome for a repository with no model integration.
+- **Surface found** → set `applicable: "yes"`, list the surfaces, and audit them.
+
+## Inputs
+
+- The target repository checkout.
+- Pipeline evidence when available: `xray` (locate provider imports, prompt assets, tool schemas), `anatomy` (paths from untrusted input to model call sites and from model output to effectful code), `governance` (existing Sentrux rules constraining tool boundaries), `chart` (project background).
+- Missing modality: proceed and record the gap in `exclusions`.
+
+## Audit areas
+
+1. **Prompt and instruction boundaries** — untrusted content (repository files, retrieved documents, tool output, web pages) concatenated into the same channel as system or developer instructions, with no isolation or delimiting; templates that let retrieved text redefine policy.
+2. **Tool and action authorization** — model output triggering file writes, network calls, process execution, or spend without a policy check between decision and effect; tool arguments trusted because a model produced them; irreversible or externally visible actions with no confirmation; scopes not least-privilege per task.
+3. **Context and data leakage** — secrets or credentials reaching prompts, logs, caches, or persisted artifacts; retrieval crossing tenant, workspace, or permission boundaries; model responses cached across contexts that should not share them.
+4. **Reliability and output validation** — model output parsed as if well-formed; silent provider/model fallback changing capability, cost, or safety behavior; no timeout, retry bound, or circuit breaker around model calls; model output used as fact where a deterministic check exists.
+5. **Evaluation and abuse cost** — no regression corpus for injection, leakage, or tool-misuse behavior; no token budget, rate limit, or spend visibility; attacker-reachable paths that trigger expensive retrieval or recursive model/tool calls.
+
+## Method
+
+1. Enumerate the surface first (applicability gate) and write the inventory down — it is both the audit scope and the coverage evidence.
+2. For each model call site, trace backwards: what is the most untrusted thing that can reach this prompt? For each effect site, trace backwards: can a model decision reach this effect without a deterministic gate?
+3. A pattern match is a lead. Confirm the data path by reading the code before reporting.
+4. Every finding names the boundary that is crossed (untrusted content → instruction channel; model output → effect; tenant A data → tenant B response) and encodes a realistic path in `failure_scenario`.
+5. Separate `confirmed` from `suspected`; be conservative per `rubrics/confidence.md`.
+6. Score per `rubrics/scoring.md`; state coverage honestly per `rubrics/coverage.md`.
+
+## Secrets red line
+
+Credentials found in prompts, provider configuration, logs, or artifacts are reported with `redacted: true`, identified by path and variable name only, never by value, with rotation advice when exposure is plausible.
+
+## Focus
+
+Do not spend output on:
+
+- Model-quality or accuracy complaints that are not safety or cost boundaries.
+- Injection findings where no untrusted content can reach the prompt.
+- Speculative jailbreak scenarios with no path in this codebase.
+
+## Output contract
+
+Produce one `code-intel-audit-report.v1` JSON document. `departments` must list **every** registered department (kernel rule: exact registry membership); report departments whose registry entry is `enabled: false` as `disabled`. Finding ids are `ai-safety-001`, `ai-safety-002`, … Every listed department needs a coverage row; an `assessed` department also needs a non-null score and non-`not_assessed` coverage.
+
+Validate fail-closed and fix until green:
+
+```bash
+code-intel audit --operation validate --repo <target-root> --report <report-path>
+```

--- a/orchestration/audit/prompts/supply-chain.md
+++ b/orchestration/audit/prompts/supply-chain.md
@@ -1,0 +1,60 @@
+# Supply Chain Department Prompt
+
+Adapted from [Fuck_My_Shit_Mountain](https://github.com/XiNian-dada/Fuck_My_Shit_Mountain) `prompts/supply-chain-audit.md` (MIT). Rewritten for Code Intel Pipeline: manifests and workflows are parsed as structured facts first, the model judges only what the parse cannot decide, and output is the fail-closed `code-intel-audit-report.v1` contract.
+
+This prompt is an operating instruction for an agent running the `supply-chain` audit department against a target repository. Read `docs/audit-report.md` and the rubrics in `orchestration/audit/rubrics/` before producing output.
+
+## Applicability gate
+
+The department applies when the target has dependency manifests, a CI configuration, or a release path. Detect and record:
+
+- Manifests and lockfiles: `Cargo.toml`/`Cargo.lock`, `package.json`/`package-lock.json`, `pyproject.toml`/`uv.lock`/`requirements*.txt`, `go.mod`/`go.sum`, and equivalents.
+- CI definitions: `.github/workflows/*.yml`, other pipeline configuration.
+- Release/packaging surfaces: publish steps, container definitions, install scripts.
+
+No manifests, no CI, and no release path means `not_assessed` with `applicable: "no"` and a reason naming what was searched.
+
+## Structured facts before judgment
+
+Read the files and extract facts; do not infer from names.
+
+- **Manifest ↔ lockfile agreement**: does every declared dependency resolve in the lockfile, and does the lockfile exist at all for an application or service?
+- **Pinning**: dependencies on mutable git branches, wildcard ranges, or unauthenticated URLs; toolchain versions pinned or floating.
+- **CI trigger and permission surface**: `permissions:` blocks (default vs least-privilege), `pull_request_target` and similar triggers that run fork code with repository secrets, third-party actions referenced by tag or branch rather than a commit SHA, secrets exposed to jobs that execute untrusted code.
+- **Execution during install/build**: install hooks, build scripts, `curl … | sh` patterns, native binaries fetched without checksum verification.
+- **Release provenance**: artifact checksums or signatures where users download them, container base images pinned by digest, whether the shipped artifact is produced by the same code path that is tested.
+- **Package hygiene**: files that would ship in a published package but should not (fixtures, local paths, credentials), license notices.
+
+## Method
+
+1. Parse first: the facts above come from the files themselves, and quoting them makes each finding verifiable.
+2. Apply the target's actual risk profile. A private internal tool and a public package with downstream consumers do not get the same severity for the same unpinned action; say which case you are in.
+3. Every finding names the compromise path: who has to do what, at which step, to influence the built or published artifact.
+4. Separate `confirmed` (the file says so) from `suspected` (behavior inferred but not proven); be conservative per `rubrics/confidence.md`.
+5. Score per `rubrics/scoring.md`; report coverage honestly per `rubrics/coverage.md`, including manifests you did not read.
+
+## Boundary with other departments
+
+Code-level injection and secret-handling defects belong to `security`; note the handoff in `exclusions` rather than reporting them here. Model-provider cost and abuse belong to `ai-safety`.
+
+## Secrets red line
+
+A credential found in a manifest, workflow, lockfile, or published package is reported with `redacted: true`, by path and variable name only, with rotation advice.
+
+## Focus
+
+Do not spend output on:
+
+- Advisory-database CVE counts you cannot verify from the tree.
+- SBOM or signing requirements for a repository with no public release path.
+- Version-bump churn that carries no compromise path.
+
+## Output contract
+
+Produce one `code-intel-audit-report.v1` JSON document. `departments` must list **every** registered department (kernel rule: exact registry membership); report departments whose registry entry is `enabled: false` as `disabled`. Finding ids are `supply-chain-001`, `supply-chain-002`, … Every listed department needs a coverage row; an `assessed` department also needs a non-null score and non-`not_assessed` coverage.
+
+Validate fail-closed and fix until green:
+
+```bash
+code-intel audit --operation validate --repo <target-root> --report <report-path>
+```


### PR DESCRIPTION
Closes #20. Closes #21. Part of the audit layer map #17.

**Stacked on #26** (`feat/audit-security-department`) — that PR is still open, so review the last commit only. Both departments are the same shape of change and touch the same registry file, so they ship together rather than as two conflicting parallel branches.

## What

The last two departments. As with #26, the kernel and the CLI needed **no change** — a department is a prompt plus a registry flag.

**`orchestration/audit/prompts/ai-safety.md`** — adapted from [Fuck_My_Shit_Mountain](https://github.com/XiNian-dada/Fuck_My_Shit_Mountain) `prompts/ai-safety-audit.md` (MIT, attributed). The distinguishing piece is the **applicability gate**: the department first enumerates whether an AI/LLM surface exists at all (provider SDK imports, prompt assets, tool/function schemas, agent loops). No surface means `not_assessed` with `applicable: "no"` and a reason naming what was searched — not an empty finding list dressed up as a clean bill of health. When a surface does exist, the method is boundary tracing in both directions: what is the most untrusted thing that can reach this prompt, and can a model decision reach an effect without a deterministic gate.

**`orchestration/audit/prompts/supply-chain.md`** — adapted from `prompts/supply-chain-audit.md` (MIT, attributed). Structured facts before judgment: manifest/lockfile agreement, pinning, CI trigger and permission surface, install-time execution, release provenance, package hygiene — all quoted from the files so each finding is verifiable. Severity is explicitly tied to the target's risk profile, so a private tool and a public package do not get the same grade for the same unpinned action.

**`orchestration/audit/departments.v1.json`** — both flipped to `enabled: true`. All three departments now have prompts.

**Test ripples from the flip** (rule (d): an enabled department may not report `disabled`): the registry slot test now expects all three enabled; the real-registry coherence test reports every department `not_assessed` instead of `disabled`; and the CLI's disk-backed tests were repointed — the T1 example fixture now **validates cleanly** against the real registry, so the test that asserted it must fail became `validate_accepts_the_unmodified_fixture_against_the_real_registry`, with a new negative test covering a `disabled` run status instead.

## Dogfood: both departments audited this repository

Real CLI, real tree, validated against the real registry:

```
{"departments_assessed":2,"findings_total":2,"ok":true,"overall":7.0}
```

**supply-chain — 6.5, coverage `high`** (small enough surface to audit exhaustively):

- `supply-chain-001` (medium, confirmed): **the Rust toolchain is unpinned**. Both CI jobs run `rustup default stable` and there is no `rust-toolchain.toml` or `rust-version`. The release workflow publishes a zip with a `.sha256` sidecar — which proves transport integrity but not reproducibility. Nobody can rebuild a published tag's bytes, so a suspected-tampered artifact cannot be refuted by rebuilding it, and a compiler regression is indistinguishable from a code regression during release triage.
- `supply-chain-002` (low, confirmed): every workflow action is pinned to a mutable major tag (`@v4`/`@v5`), including in `release.yml`, which is the workflow holding `contents: write`. Severity stays low, not high, because all of them are GitHub-owned `actions/*` and `ci.yml` grants only `contents: read` with no `pull_request_target` — the report says exactly that rather than inflating the grade.
- Confirmed healthy: one runtime crate dependency (`serde_json`), one exact-pinned dev dependency, both lockfiles committed, no `curl | sh` anywhere in CI.

**ai-safety — 7.5, coverage `medium`**: the surface is real (the docs lane resolves `CODE_INTEL_ANTHROPIC_API_KEY` and friends into provider constructors; `model_channels.rs` routes model requests). No finding: credentials go from environment into provider constructors with no observed path into artifacts or logs, and the model-channel layer routes rather than dispatching model-chosen effects. The one `Authorization: Bearer` string in the tree was checked and is a `doctor_adapter` test fixture. The score is held at 7.5 rather than a clean 10 because no eval or regression corpus exists for provider-response handling and coverage is honestly medium — provider-internal parsing lives outside this repository and no hostile-repository injection test was run.

## Verification

- `cargo test -p code-intel --bin code-intel audit`: 46 passed, 0 failed.
- `--test audit_report --test hospital_diagnosis --test artifact_ref`: 9 + 5 + 9, 0 failed.
- `cargo fmt --all --check` clean; `cargo test --no-run` compiles every binary.
- `test-atomic-capability-contract.ps1`: `"ok": true`.
- sentrux gate: `Quality 3971 -> 3973`, `Coupling 44.78 -> 44.59`, `Cycles 0 -> 0`, `God files 29 -> 29`, **No degradation detected**.
- CLI against the real registry: the T1 fixture now validates (`ok: true`, exit 0), and the two-department self-audit above validates.
