### PR TITLE
fix(ci): pin the Rust toolchain so release builds are reproducible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,9 @@ jobs:
 
       - name: Setup Rust
         shell: pwsh
-        run: rustup default stable
+        run: |
+          rustup toolchain install
+          rustup show active-toolchain
 
       - name: Install ripgrep
         shell: pwsh
@@ -251,7 +253,9 @@ jobs:
 
       - name: Setup Rust
         shell: pwsh
-        run: rustup default stable
+        run: |
+          rustup toolchain install
+          rustup show active-toolchain
 
       - name: Install ripgrep
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,9 @@ jobs:
 
       - name: Setup Rust
         shell: pwsh
-        run: rustup default stable
+        run: |
+          rustup toolchain install
+          rustup show active-toolchain
 
       - name: Install ripgrep
         shell: pwsh
@@ -137,6 +139,7 @@ jobs:
             tag = $version
             commit = (git rev-parse HEAD).Trim()
             zipSha256 = $hash
+            toolchain = (rustc --version).Trim()
             builtAt = (Get-Date).ToUniversalTime().ToString("o")
           }
           $manifest | ConvertTo-Json | Set-Content -Encoding ascii "$zip.release-manifest.json"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Pinned the Rust toolchain in `rust-toolchain.toml` (1.95.0, `rustfmt`,
+  minimal profile). CI and release jobs now install from that file instead of
+  running `rustup default stable`, and the release manifest records the
+  resolved `rustc --version`. Released binaries were previously built by
+  whatever `stable` happened to be current, so the shipped `.sha256` proved
+  transport integrity but nobody could rebuild a tag's bytes to check them.
+
 ### Added
 
 - Audit kernel (T1): a shared contract for audit departments that run as

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,8 @@
+[toolchain]
+# Pinned so CI, release, and local builds all use one compiler. An unpinned
+# `stable` makes released binaries unreproducible: the release zip ships a
+# .sha256 sidecar, which proves transport integrity but not that the bytes
+# can be rebuilt from this tree.
+channel = "1.95.0"
+components = ["rustfmt"]
+profile = "minimal"


### PR DESCRIPTION
Fixes `supply-chain-001`, the medium-severity finding the supply-chain audit department (#21) raised against this repository.

## Why

CI and release both ran `rustup default stable`, resolving the compiler at job time, and nothing in the tree constrained it — no `rust-toolchain.toml`, no `rust-version`.

The release workflow publishes a zip with a `.sha256` sidecar. That proves the download was not tampered with in transit; it does not let anyone rebuild the same bytes. Two runs weeks apart used different compilers on identical source, so a suspected-tampered artifact could not be refuted by rebuilding it, and during release triage a compiler regression was indistinguishable from a code regression.

## What

- `rust-toolchain.toml` pins `1.95.0` with the `rustfmt` component (CI runs `cargo fmt --all --check`) and the minimal profile.
- All three `Setup Rust` steps (two in `ci.yml`, one in `release.yml`) install from that file and log the resolved toolchain instead of defaulting to `stable`.
- The release manifest records `rustc --version`, so every published artifact names the compiler that produced it — the finding's long-term fix, which is one line here.

## Verification

- `rustup show active-toolchain` → `1.95.0-x86_64-pc-windows-msvc (overridden by rust-toolchain.toml)`; rustup installed the pinned toolchain automatically on first use.
- `cargo fmt --all --check` clean and `cargo check` green under the pinned toolchain (1.95.0 is what this tree was already being built with, so this pins current behaviour rather than changing it).
- Both workflow files re-parsed as valid YAML after editing.
- The `toolchain` field goes into the `release.yml` sidecar manifest (`code-intel-release-manifest.v1`), which no validator asserts key-exactly. The packaged `code-intel-beta-release-manifest.v1` checked by `tools/Test-BetaPackage.ps1` is a different document and is untouched.

Renewal note: pinning trades reproducibility for a manual bump. The version is in one file, and CI failing on a stale pin is not a failure mode — it just keeps building on 1.95.0 until someone raises it.
