### PR TITLE
fix(workflow): force UTF-8 stdout for the -Json contract output

### DIFF
--- a/Invoke-WorkflowRecommendation.ps1
+++ b/Invoke-WorkflowRecommendation.ps1
@@ -9,6 +9,15 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
+if ($Json -and $IsWindows) {
+    # -Json is a machine contract parsed as UTF-8 by the capability adapter.
+    # Windows pwsh encodes redirected stdout with the system codepage (GBK on
+    # zh-CN hosts), so pin it. Unix pwsh is already UTF-8, and touching
+    # [Console]::OutputEncoding there can crash the runtime (macOS assembly
+    # load failure), so the pin is Windows-only. BOM-less explicitly.
+    [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+}
+
 $atom = Join-Path $PSScriptRoot "OpenSpec-Detector.ps1"
 if (-not (Test-Path -LiteralPath $atom -PathType Leaf)) {
     throw "Workflow recommendation atom not found: $atom"


### PR DESCRIPTION
advisory.workflow-recommend parses the facade stdout as UTF-8, but pwsh encodes redirected stdout with the system codepage — GBK bytes on zh-CN hosts, so `capability_exec::advisory_workflow_recommend_runs_through_a01_with_zero_effects_and_facade_parity` failed locally while CI (UTF-8 runners) stayed green. Pin `[Console]::OutputEncoding` to UTF-8 whenever `-Json` is requested.