### PR TITLE
feat(audit): HTML reports, diff-scoped audits, and hardened git invocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Audit report HTML rendering and incremental (diff-scoped) audits.
+  `code-intel audit --operation render --report <path> --format html` prints
+  one self-contained HTML document — inline styles only, no external CSS/JS/
+  fonts/images or other network reference, generated directly from the
+  parsed, validated `AuditReport` model so there is no placeholder-
+  substitution failure mode for a separate linter to catch; `--format
+  markdown` stays the default and existing invocations are unchanged.
+  Separately, the report contract gains an optional top-level `scope` block
+  (`{"kind": "full" | "diff", "since", "files"}`); a new fail-closed rule in
+  `validate()` requires a `"diff"` scope's `since`/`files` to be present and
+  bounds every finding's file evidence to a path in `scope.files` (normalising
+  `\`/`/` before comparing) — a finding outside the declared diff is a
+  contract violation. `code-intel audit --operation scope --repo <root>
+  --since <git-ref>` computes that file set (`git diff --name-only
+  <since>...HEAD`, filtered to files still on disk) and prints a
+  ready-to-embed scope block. See `docs/audit-report.md`.
 - Audit departments `ai-safety` (T3) and `supply-chain` (T4): prompts under
   `orchestration/audit/prompts/`, adapted from
   [Fuck_My_Shit_Mountain](https://github.com/XiNian-dada/Fuck_My_Shit_Mountain)

--- a/crates/code-intel-cli/src/audit_report/cli.rs
+++ b/crates/code-intel-cli/src/audit_report/cli.rs
@@ -19,9 +19,16 @@ pub(crate) fn run_raw(raw: &[String]) -> i32 {
             }
             Err(message) => fail(&message),
         },
-        Ok(Operation::Render { report }) => match render(&report) {
-            Ok(markdown) => {
-                println!("{markdown}");
+        Ok(Operation::Render { report, format }) => match render(&report, format) {
+            Ok(text) => {
+                println!("{text}");
+                0
+            }
+            Err(message) => fail(&message),
+        },
+        Ok(Operation::Scope { repo, since }) => match scope(&repo, &since) {
+            Ok(value) => {
+                println!("{value}");
                 0
             }
             Err(message) => fail(&message),
@@ -37,14 +44,45 @@ fn fail(message: &str) -> i32 {
 
 #[derive(Debug)]
 enum Operation {
-    Validate { repo: PathBuf, report: PathBuf },
-    Render { report: PathBuf },
+    Validate {
+        repo: PathBuf,
+        report: PathBuf,
+    },
+    Render {
+        report: PathBuf,
+        format: RenderFormat,
+    },
+    Scope {
+        repo: PathBuf,
+        since: String,
+    },
+}
+
+/// `--format` on `--operation render`; defaults to `Markdown` when absent so
+/// the existing `--operation render --report <path>` invocation (no
+/// `--format`) keeps behaving exactly as before.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RenderFormat {
+    Markdown,
+    Html,
+}
+
+impl RenderFormat {
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "markdown" => Some(Self::Markdown),
+            "html" => Some(Self::Html),
+            _ => None,
+        }
+    }
 }
 
 fn parse(raw: &[String]) -> Result<Operation, String> {
     let mut operation = None;
     let mut repo = None;
     let mut report = None;
+    let mut format_flag = None;
+    let mut since = None;
     let mut index = 0;
     while index < raw.len() {
         let flag = raw[index].as_str();
@@ -56,23 +94,41 @@ fn parse(raw: &[String]) -> Result<Operation, String> {
             "--operation" => set_once(&mut operation, value, flag)?,
             "--repo" => set_once(&mut repo, value, flag)?,
             "--report" => set_once(&mut report, value, flag)?,
+            "--format" => set_once(&mut format_flag, value, flag)?,
+            "--since" => set_once(&mut since, value, flag)?,
             _ => return Err(format!("unknown audit argument: {flag}")),
         }
         index += 2;
     }
-    let report = report.map(PathBuf::from).ok_or("--report is required")?;
     match operation.as_deref() {
         Some("validate") => Ok(Operation::Validate {
+            report: report.map(PathBuf::from).ok_or("--report is required")?,
             repo: repo
                 .map(PathBuf::from)
                 .ok_or("--operation validate requires --repo")?,
-            report,
         }),
-        Some("render") => Ok(Operation::Render { report }),
+        Some("render") => {
+            let format = match format_flag.as_deref() {
+                None => RenderFormat::Markdown,
+                Some(raw_format) => RenderFormat::parse(raw_format).ok_or_else(|| {
+                    format!("unknown --format \"{raw_format}\" (expected markdown or html)")
+                })?,
+            };
+            Ok(Operation::Render {
+                report: report.map(PathBuf::from).ok_or("--report is required")?,
+                format,
+            })
+        }
+        Some("scope") => Ok(Operation::Scope {
+            repo: repo
+                .map(PathBuf::from)
+                .ok_or("--operation scope requires --repo")?,
+            since: since.ok_or("--operation scope requires --since")?,
+        }),
         Some(other) => Err(format!(
-            "unknown --operation \"{other}\" (expected validate or render)"
+            "unknown --operation \"{other}\" (expected validate, render, or scope)"
         )),
-        None => Err("--operation is required (validate or render)".to_string()),
+        None => Err("--operation is required (validate, render, or scope)".to_string()),
     }
 }
 
@@ -119,17 +175,60 @@ fn count_assessed(report: &AuditReport) -> usize {
         .count()
 }
 
-/// Registry-independent: `render_markdown_section` only reads the parsed
-/// report, so rendering never needs `--repo`.
-fn render(report_path: &Path) -> Result<String, String> {
+/// Registry-independent: both renderers only read the parsed report, so
+/// rendering never needs `--repo`.
+fn render(report_path: &Path, format: RenderFormat) -> Result<String, String> {
     let bytes = read_report(report_path)?;
     let report = AuditReport::parse(&bytes)?;
-    Ok(super::render_markdown_section(&report))
+    Ok(match format {
+        RenderFormat::Markdown => super::render_markdown_section(&report),
+        RenderFormat::Html => super::render_html_document(&report),
+    })
 }
 
 fn read_report(path: &Path) -> Result<Vec<u8>, String> {
     std::fs::read(path).map_err(|error| format!("read report {}: {error}", path.display()))
 }
+
+/// `--operation scope --repo <root> --since <git-ref>`: the changed-file set
+/// on HEAD since `since`'s merge base (`git diff --name-only
+/// <since>...HEAD`, three-dot), printed as a ready-to-embed `scope` block.
+/// Runs through `hardened_git::command` — `--repo` is a target repository an
+/// operator pointed the CLI at, not one this process owns, and that is
+/// exactly the threat model that wrapper disarms config-driven program
+/// execution for. Filters out paths that no longer exist in the working
+/// tree: a deleted file cannot carry file evidence. Never falls back to
+/// "assume everything changed" — any git failure is a hard error.
+fn scope(repo: &Path, since: &str) -> Result<Value, String> {
+    let range = format!("{since}...HEAD");
+    let output = hardened_git::command(repo)
+        .arg("diff")
+        .arg("--name-only")
+        .arg(&range)
+        .output()
+        .map_err(|error| format!("failed to run git diff --name-only {range}: {error}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "git diff --name-only {range} exited with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    let stdout = String::from_utf8(output.stdout)
+        .map_err(|error| format!("git diff output is not UTF-8: {error}"))?;
+    let mut files = stdout
+        .lines()
+        .map(|line| line.replace('\\', "/"))
+        .filter(|line| !line.is_empty())
+        .filter(|relative| repo.join(relative).is_file())
+        .collect::<Vec<_>>();
+    files.sort();
+    files.dedup();
+    Ok(json!({"kind": "diff", "since": since, "files": files}))
+}
+
+#[path = "../hardened_git.rs"]
+mod hardened_git;
 
 #[cfg(test)]
 #[path = "cli_tests.rs"]

--- a/crates/code-intel-cli/src/audit_report/cli_tests.rs
+++ b/crates/code-intel-cli/src/audit_report/cli_tests.rs
@@ -151,7 +151,118 @@ fn run_raw_exits_nonzero_on_a_failing_validate() {
 
 #[test]
 fn render_prints_the_audit_markdown_section() {
-    let markdown = render(&fixture_path()).unwrap();
+    let markdown = render(&fixture_path(), RenderFormat::Markdown).unwrap();
     assert!(markdown.contains("## Audit"));
     assert!(markdown.contains("| security |"));
+}
+
+#[test]
+fn render_with_html_format_produces_a_self_contained_document() {
+    let html = render(&fixture_path(), RenderFormat::Html).unwrap();
+    assert!(html.starts_with("<!doctype html>"), "{html}");
+    assert!(html.contains("code-intel-pipeline"), "{html}");
+}
+
+#[test]
+fn parse_format_defaults_to_markdown_and_accepts_html() {
+    let without_format = vec![
+        "--operation".to_string(),
+        "render".to_string(),
+        "--report".to_string(),
+        "report.json".to_string(),
+    ];
+    assert!(matches!(
+        parse(&without_format),
+        Ok(Operation::Render {
+            format: RenderFormat::Markdown,
+            ..
+        })
+    ));
+
+    let with_html = vec![
+        "--operation".to_string(),
+        "render".to_string(),
+        "--report".to_string(),
+        "report.json".to_string(),
+        "--format".to_string(),
+        "html".to_string(),
+    ];
+    assert!(matches!(
+        parse(&with_html),
+        Ok(Operation::Render {
+            format: RenderFormat::Html,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn parse_rejects_unknown_format() {
+    let raw = vec![
+        "--operation".to_string(),
+        "render".to_string(),
+        "--report".to_string(),
+        "report.json".to_string(),
+        "--format".to_string(),
+        "pdf".to_string(),
+    ];
+    let error = parse(&raw).unwrap_err();
+    assert!(error.contains("unknown --format"), "{error}");
+}
+
+#[test]
+fn parse_scope_requires_repo_and_since() {
+    let missing_repo = vec![
+        "--operation".to_string(),
+        "scope".to_string(),
+        "--since".to_string(),
+        "HEAD~1".to_string(),
+    ];
+    let error = parse(&missing_repo).unwrap_err();
+    assert!(error.contains("requires --repo"), "{error}");
+
+    let missing_since = vec![
+        "--operation".to_string(),
+        "scope".to_string(),
+        "--repo".to_string(),
+        ".".to_string(),
+    ];
+    let error = parse(&missing_since).unwrap_err();
+    assert!(error.contains("requires --since"), "{error}");
+}
+
+#[test]
+fn scope_against_head_tilde_1_lists_only_existing_changed_files() {
+    let repo = repo_root();
+    let value = scope(&repo, "HEAD~1").unwrap();
+    assert_eq!(value["kind"], "diff");
+    assert_eq!(value["since"], "HEAD~1");
+    let files = value["files"].as_array().unwrap();
+    assert!(!files.is_empty(), "{value}");
+    for file in files {
+        let relative = file.as_str().unwrap();
+        assert!(
+            repo.join(relative).is_file(),
+            "{relative} should exist on disk"
+        );
+    }
+}
+
+#[test]
+fn scope_rejects_a_bogus_since_ref() {
+    let error = scope(&repo_root(), "not-a-real-ref-xyz").unwrap_err();
+    assert!(!error.is_empty());
+}
+
+#[test]
+fn run_raw_exits_nonzero_on_a_bogus_scope_ref() {
+    let raw = vec![
+        "--operation".to_string(),
+        "scope".to_string(),
+        "--repo".to_string(),
+        repo_root().to_string_lossy().into_owned(),
+        "--since".to_string(),
+        "not-a-real-ref-xyz".to_string(),
+    ];
+    assert_eq!(run_raw(&raw), 65);
 }

--- a/crates/code-intel-cli/src/audit_report/enums.rs
+++ b/crates/code-intel-cli/src/audit_report/enums.rs
@@ -54,6 +54,14 @@ pub(crate) enum Confidence {
 }
 
 impl Confidence {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::High => "high",
+            Self::Medium => "medium",
+            Self::Low => "low",
+        }
+    }
+
     pub(super) fn parse(value: &str) -> Option<Self> {
         match value {
             "high" => Some(Self::High),
@@ -115,6 +123,13 @@ pub(crate) enum FindingStatus {
 }
 
 impl FindingStatus {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::Confirmed => "confirmed",
+            Self::Suspected => "suspected",
+        }
+    }
+
     pub(super) fn parse(value: &str) -> Option<Self> {
         match value {
             "confirmed" => Some(Self::Confirmed),
@@ -132,6 +147,14 @@ pub(crate) enum EstimatedEffort {
 }
 
 impl EstimatedEffort {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::Minutes => "minutes",
+            Self::Hours => "hours",
+            Self::Days => "days",
+        }
+    }
+
     pub(super) fn parse(value: &str) -> Option<Self> {
         match value {
             "minutes" => Some(Self::Minutes),
@@ -151,6 +174,15 @@ pub(crate) enum EvidenceKind {
 }
 
 impl EvidenceKind {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::File => "file",
+            Self::ModalitySignal => "modality_signal",
+            Self::Command => "command",
+            Self::ManualRead => "manual_read",
+        }
+    }
+
     pub(super) fn parse(value: &str) -> Option<Self> {
         match value {
             "file" => Some(Self::File),
@@ -174,6 +206,18 @@ pub(crate) enum Modality {
 }
 
 impl Modality {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::Xray => "xray",
+            Self::Anatomy => "anatomy",
+            Self::Ct => "ct",
+            Self::Mri => "mri",
+            Self::Pet => "pet",
+            Self::Chart => "chart",
+            Self::Governance => "governance",
+        }
+    }
+
     pub(super) fn parse(value: &str) -> Option<Self> {
         match value {
             "xray" => Some(Self::Xray),
@@ -212,6 +256,33 @@ impl Coverage {
             "medium" => Some(Self::Medium),
             "low" => Some(Self::Low),
             "not_assessed" => Some(Self::NotAssessed),
+            _ => None,
+        }
+    }
+}
+
+/// The `scope.kind` discriminator (see `docs/audit-report.md`'s incremental
+/// audits section): `full` sweeps the whole tree with no path restriction;
+/// `diff` is bounded to `scope.files`, enforced by `AuditReport::validate()`
+/// rule (j).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ScopeKind {
+    Full,
+    Diff,
+}
+
+impl ScopeKind {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::Full => "full",
+            Self::Diff => "diff",
+        }
+    }
+
+    pub(super) fn parse(value: &str) -> Option<Self> {
+        match value {
+            "full" => Some(Self::Full),
+            "diff" => Some(Self::Diff),
             _ => None,
         }
     }

--- a/crates/code-intel-cli/src/audit_report/json_helpers.rs
+++ b/crates/code-intel-cli/src/audit_report/json_helpers.rs
@@ -57,6 +57,20 @@ pub(super) fn optional_str(
     }
 }
 
+/// An optional nested object: `None` when the key is absent or JSON `null`,
+/// otherwise the raw `Value` for the caller to parse further (e.g. via
+/// another `*_from_value` constructor, which enforces its own shape with
+/// `closed_object`).
+pub(super) fn optional_object<'a>(
+    object: &'a Map<String, Value>,
+    key: &str,
+) -> Result<Option<&'a Value>, String> {
+    match object.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(value) => Ok(Some(value)),
+    }
+}
+
 pub(super) fn required_nullable_string(
     object: &Map<String, Value>,
     key: &str,

--- a/crates/code-intel-cli/src/audit_report/mod.rs
+++ b/crates/code-intel-cli/src/audit_report/mod.rs
@@ -7,8 +7,10 @@ mod json_helpers;
 mod model;
 mod registry;
 mod render;
+mod render_html;
 mod validate;
 
 pub(crate) use cli::run_raw;
 pub(crate) use model::AuditReport;
 pub(crate) use render::render_markdown_section;
+pub(crate) use render_html::render_html_document;

--- a/crates/code-intel-cli/src/audit_report/model.rs
+++ b/crates/code-intel-cli/src/audit_report/model.rs
@@ -3,12 +3,12 @@ use serde_json::Value;
 use super::{
     enums::{
         Applicable, Confidence, Coverage, DepartmentRunStatus, EstimatedEffort, EvidenceKind,
-        FindingStatus, Modality, Severity,
+        FindingStatus, Modality, ScopeKind, Severity,
     },
     json_helpers::{
-        closed_object, optional_nullable_enum, optional_nullable_uint_min, optional_str,
-        optional_string_array, required_bool, required_enum, required_nullable_number,
-        required_nullable_string, required_str, required_string_array,
+        closed_object, optional_nullable_enum, optional_nullable_uint_min, optional_object,
+        optional_str, optional_string_array, required_bool, required_enum,
+        required_nullable_number, required_nullable_string, required_str, required_string_array,
     },
 };
 
@@ -288,6 +288,30 @@ impl CoverageRow {
     }
 }
 
+/// The optional incremental-audit scope block (`docs/audit-report.md`'s
+/// incremental audits section). `since`/`files` are plain optional keys, not
+/// required-nullable like `generatedAt`: a `full` scope (or an absent one)
+/// legitimately never carries them. `AuditReport::validate()` rule (j) is
+/// what actually requires them to be present and non-empty when
+/// `kind == diff` — the schema only requires `kind`.
+#[derive(Debug)]
+pub(crate) struct Scope {
+    pub(crate) kind: ScopeKind,
+    pub(crate) since: Option<String>,
+    pub(crate) files: Vec<String>,
+}
+
+impl Scope {
+    fn from_value(value: &Value) -> Result<Self, String> {
+        let object = closed_object(value, &["kind"], &["since", "files"], "scope")?;
+        Ok(Self {
+            kind: required_enum(object, "kind", "scope", ScopeKind::parse)?,
+            since: optional_str(object, "since")?,
+            files: optional_string_array(object, "files", "scope")?,
+        })
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct AuditReport {
     pub(crate) generated_at: Option<String>,
@@ -296,6 +320,7 @@ pub(crate) struct AuditReport {
     pub(crate) findings: Vec<Finding>,
     pub(crate) score_dashboard: ScoreDashboard,
     pub(crate) coverage_matrix: Vec<CoverageRow>,
+    pub(crate) scope: Option<Scope>,
 }
 
 impl AuditReport {
@@ -321,7 +346,7 @@ impl AuditReport {
                 "score_dashboard",
                 "coverage_matrix",
             ],
-            &[],
+            &["scope"],
             "audit report",
         )?;
         let schema = required_str(object, "schema", "audit report")?;
@@ -359,6 +384,9 @@ impl AuditReport {
             .iter()
             .map(CoverageRow::from_value)
             .collect::<Result<Vec<_>, _>>()?;
+        let scope = optional_object(object, "scope")?
+            .map(Scope::from_value)
+            .transpose()?;
         Ok(Self {
             generated_at: required_nullable_string(object, "generatedAt", "audit report")?,
             repo: required_str(object, "repo", "audit report")?,
@@ -366,6 +394,7 @@ impl AuditReport {
             findings,
             score_dashboard,
             coverage_matrix,
+            scope,
         })
     }
 }

--- a/crates/code-intel-cli/src/audit_report/render.rs
+++ b/crates/code-intel-cli/src/audit_report/render.rs
@@ -103,7 +103,7 @@ impl AuditSummary {
     }
 }
 
-fn format_score(score: Option<f64>) -> String {
+pub(super) fn format_score(score: Option<f64>) -> String {
     match score {
         Some(value) => format!("{value:.1}"),
         None => "n/a".to_string(),

--- a/crates/code-intel-cli/src/audit_report/render_html.rs
+++ b/crates/code-intel-cli/src/audit_report/render_html.rs
@@ -1,0 +1,363 @@
+//! `--operation render --format html`: one self-contained HTML document
+//! rendered directly from the parsed, validated `AuditReport` model — never
+//! from a raw template string. There is therefore no placeholder-substitution
+//! failure mode to lint for separately (see `docs/audit-report.md`): every
+//! value that reaches the page went through `escape_html`, the single
+//! escaping helper below, and nothing here does string-splicing of report
+//! text into markup ahead of that call.
+//!
+//! No external CSS, JS, fonts, or images, and no network references of any
+//! kind — the `<style>` block is inlined and hand-written so the report
+//! opens correctly from a `file://` path with no other resource to fetch.
+
+use super::{
+    enums::Severity,
+    model::{AuditReport, EvidenceRef, Finding, Scope},
+    render::format_score,
+};
+
+const STYLE: &str = r#"
+body { font-family: -apple-system, "Segoe UI", Roboto, Arial, sans-serif; line-height: 1.5; margin: 0; padding: 2rem; max-width: 960px; margin-inline: auto; color: #1a1a1a; background: #ffffff; }
+* { box-sizing: border-box; }
+h1, h2, h3, h4, h5 { line-height: 1.25; }
+h1 { font-size: 1.6rem; margin-bottom: 0.25rem; }
+h2 { font-size: 1.3rem; margin-top: 2rem; border-bottom: 2px solid #ddd; padding-bottom: 0.25rem; }
+h3 { font-size: 1.1rem; margin-top: 1.5rem; }
+h4 { font-size: 1rem; margin-bottom: 0.25rem; }
+h5 { font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.03em; color: #555; margin: 0.75rem 0 0.15rem; }
+header { border-bottom: 1px solid #ddd; padding-bottom: 1rem; }
+table { border-collapse: collapse; width: 100%; margin: 0.75rem 0 1.25rem; font-size: 0.92rem; }
+th, td { border: 1px solid #ccc; padding: 0.4rem 0.6rem; text-align: left; vertical-align: top; }
+th { background: #f2f2f2; }
+code { background: #f2f2f2; padding: 0.1rem 0.3rem; border-radius: 3px; font-size: 0.9em; }
+.finding { border: 1px solid #ddd; border-left-width: 6px; border-radius: 4px; padding: 0.75rem 1rem; margin: 0.75rem 0; }
+.finding-meta { display: flex; flex-wrap: wrap; gap: 0.25rem 1.5rem; margin: 0.35rem 0; padding: 0; }
+.finding-meta dt { font-weight: 600; margin: 0; }
+.finding-meta dt::after { content: ":"; }
+.finding-meta dd { margin: 0 0 0 0.35rem; }
+.evidence-list { padding-left: 1.25rem; }
+.redacted-notice { font-weight: 700; color: #7a0000; background: #fdeaea; border: 1px solid #f2b8b8; padding: 0.4rem 0.6rem; border-radius: 4px; display: inline-block; }
+.severity-critical { border-left-color: #8b0000; }
+.severity-high { border-left-color: #d9534f; }
+.severity-medium { border-left-color: #e0a800; }
+.severity-low { border-left-color: #5b8def; }
+.severity-info { border-left-color: #6c757d; }
+td.severity-critical, td.severity-high, td.severity-medium, td.severity-low, td.severity-info { font-weight: 600; }
+h3.severity-heading { padding: 0.15rem 0.5rem; border-radius: 4px; display: inline-block; }
+h3.severity-critical { background: #f8d7da; }
+h3.severity-high { background: #fde2cf; }
+h3.severity-medium { background: #fff3cd; }
+h3.severity-low { background: #dbe9ff; }
+h3.severity-info { background: #e2e3e5; }
+@media (prefers-color-scheme: dark) {
+  body { background: #121212; color: #e6e6e6; }
+  h2 { border-bottom-color: #444; }
+  h5 { color: #aaa; }
+  th, td { border-color: #444; }
+  th { background: #1e1e1e; }
+  code { background: #1e1e1e; }
+  .finding { border-color: #444; }
+  .redacted-notice { background: #3a1111; color: #ffb3b3; border-color: #6b1f1f; }
+}
+"#;
+
+const SEVERITIES: [Severity; 5] = [
+    Severity::Critical,
+    Severity::High,
+    Severity::Medium,
+    Severity::Low,
+    Severity::Info,
+];
+
+/// The single HTML-escaping helper: every interpolated value in this module
+/// passes through here, whether it is department-authored free text (title,
+/// problem, evidence note, …) or this module's own enum wire strings — the
+/// latter never contain special characters, but escaping them too keeps the
+/// rule exceptionless rather than "escape it unless you're sure".
+fn escape_html(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    for ch in text.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#39;"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+/// The full self-contained document: header, score dashboard, coverage
+/// matrix, findings grouped by severity (critical to info), and a fix-order
+/// section — in that order.
+pub(crate) fn render_html_document(report: &AuditReport) -> String {
+    let mut html = String::from("<!doctype html>\n<html lang=\"en\">\n<head>\n");
+    html.push_str("<meta charset=\"utf-8\">\n");
+    html.push_str("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n");
+    html.push_str(&format!(
+        "<title>Audit Report: {}</title>\n",
+        escape_html(&report.repo)
+    ));
+    html.push_str("<style>");
+    html.push_str(STYLE);
+    html.push_str("</style>\n</head>\n<body>\n");
+    html.push_str(&render_header(report));
+    html.push_str(&render_score_dashboard(report));
+    html.push_str(&render_coverage_matrix(report));
+    html.push_str(&render_findings_by_severity(report));
+    html.push_str(&render_fix_order(report));
+    html.push_str("</body>\n</html>\n");
+    html
+}
+
+/// Repo name, overall score, rubric version, and (when present) the scope
+/// line. `rubric_version` is hardcoded to the literal "v1": the schema pins
+/// it to `const: "v1"` and `AuditReport::parse` already rejects any other
+/// value, so the model has nothing else to store there.
+fn render_header(report: &AuditReport) -> String {
+    let mut header = String::from("<header>\n");
+    header.push_str(&format!(
+        "<h1>Audit Report: {}</h1>\n",
+        escape_html(&report.repo)
+    ));
+    header.push_str(&format!(
+        "<p>Overall score: <strong>{}</strong> &middot; Rubric version: <strong>v1</strong></p>\n",
+        escape_html(&format_score(report.score_dashboard.overall))
+    ));
+    if let Some(scope) = &report.scope {
+        header.push_str(&render_scope_line(scope));
+    }
+    header.push_str("</header>\n");
+    header
+}
+
+fn render_scope_line(scope: &Scope) -> String {
+    let mut line = format!(
+        "<p class=\"scope-line\">Scope: <strong>{}</strong>",
+        escape_html(scope.kind.as_str())
+    );
+    if let Some(since) = &scope.since {
+        line.push_str(&format!(" since <code>{}</code>", escape_html(since)));
+    }
+    if !scope.files.is_empty() {
+        let files = scope
+            .files
+            .iter()
+            .map(|file| escape_html(file))
+            .collect::<Vec<_>>()
+            .join(", ");
+        line.push_str(&format!(
+            " &mdash; {} file(s): <code>{files}</code>",
+            scope.files.len()
+        ));
+    }
+    line.push_str("</p>\n");
+    line
+}
+
+fn render_score_dashboard(report: &AuditReport) -> String {
+    let mut section = String::from(
+        "<section id=\"score-dashboard\">\n<h2>Score Dashboard</h2>\n<table>\n\
+         <thead><tr><th>Department</th><th>Score</th><th>Justification</th></tr></thead>\n<tbody>\n",
+    );
+    for entry in &report.score_dashboard.entries {
+        section.push_str(&format!(
+            "<tr><td>{}</td><td>{}</td><td>{}</td></tr>\n",
+            escape_html(&entry.department),
+            escape_html(&format_score(entry.score)),
+            escape_html(&entry.justification)
+        ));
+    }
+    section.push_str("</tbody>\n</table>\n</section>\n");
+    section
+}
+
+fn render_coverage_matrix(report: &AuditReport) -> String {
+    let mut section = String::from(
+        "<section id=\"coverage-matrix\">\n<h2>Coverage Matrix</h2>\n<table>\n\
+         <thead><tr><th>Department</th><th>Coverage</th><th>Inspected Evidence</th><th>Exclusions</th></tr></thead>\n<tbody>\n",
+    );
+    for row in &report.coverage_matrix {
+        let coverage = escape_html(row.coverage.as_str());
+        section.push_str(&format!(
+            "<tr><td>{}</td><td class=\"severity-{coverage}\">{coverage}</td><td>{}</td><td>{}</td></tr>\n",
+            escape_html(&row.department),
+            escape_html(&row.inspected_evidence.join(", ")),
+            escape_html(&row.exclusions.join(", "))
+        ));
+    }
+    section.push_str("</tbody>\n</table>\n</section>\n");
+    section
+}
+
+/// Shared total order for both the "grouped by severity" and "fix order"
+/// sections, so the two sections agree on ordering wherever they overlap:
+/// severity rank first (critical .. info), then department, then id.
+fn sorted_findings(report: &AuditReport) -> Vec<&Finding> {
+    let mut findings = report.findings.iter().collect::<Vec<_>>();
+    findings.sort_by(|a, b| {
+        a.severity
+            .rank()
+            .cmp(&b.severity.rank())
+            .then_with(|| a.department.cmp(&b.department))
+            .then_with(|| a.id.cmp(&b.id))
+    });
+    findings
+}
+
+fn severity_title(severity: Severity) -> &'static str {
+    match severity {
+        Severity::Critical => "Critical",
+        Severity::High => "High",
+        Severity::Medium => "Medium",
+        Severity::Low => "Low",
+        Severity::Info => "Info",
+    }
+}
+
+fn render_findings_by_severity(report: &AuditReport) -> String {
+    let findings = sorted_findings(report);
+    let mut section = String::from("<section id=\"findings\">\n<h2>Findings</h2>\n");
+    if findings.is_empty() {
+        section.push_str("<p>No findings recorded.</p>\n</section>\n");
+        return section;
+    }
+    for severity in SEVERITIES {
+        let bucket = findings
+            .iter()
+            .filter(|finding| finding.severity == severity)
+            .collect::<Vec<_>>();
+        if bucket.is_empty() {
+            continue;
+        }
+        section.push_str(&format!(
+            "<h3 class=\"severity-heading severity-{sev}\">{title} ({count})</h3>\n",
+            sev = severity.as_str(),
+            title = severity_title(severity),
+            count = bucket.len()
+        ));
+        for finding in bucket {
+            section.push_str(&render_finding_block(finding));
+        }
+    }
+    section.push_str("</section>\n");
+    section
+}
+
+/// One finding's full contract: id, title, severity, confidence, status,
+/// affected area, evidence, problem, failure scenario, minimal fix,
+/// long-term fix when present, regression test, estimated effort — plus a
+/// visible marker when `redacted` is true.
+fn render_finding_block(finding: &Finding) -> String {
+    let id = escape_html(&finding.id);
+    let mut block = format!(
+        "<article class=\"finding severity-{}\" id=\"{id}\">\n<h4>{id} &mdash; {}</h4>\n",
+        finding.severity.as_str(),
+        escape_html(&finding.title)
+    );
+    block.push_str("<dl class=\"finding-meta\">\n");
+    block.push_str(&format!(
+        "<dt>Severity</dt><dd>{}</dd><dt>Confidence</dt><dd>{}</dd><dt>Status</dt><dd>{}</dd><dt>Estimated effort</dt><dd>{}</dd>\n",
+        escape_html(finding.severity.as_str()),
+        escape_html(finding.confidence.as_str()),
+        escape_html(finding.status.as_str()),
+        escape_html(finding.estimated_effort.as_str())
+    ));
+    if let Some(area) = &finding.affected_area {
+        block.push_str(&format!(
+            "<dt>Affected area</dt><dd>{}</dd>\n",
+            escape_html(area)
+        ));
+    }
+    block.push_str("</dl>\n");
+    if finding.redacted {
+        block.push_str(
+            "<p class=\"redacted-notice\">REDACTED &mdash; this finding's evidence has been withheld from the report.</p>\n",
+        );
+    }
+    block.push_str("<h5>Evidence</h5>\n<ul class=\"evidence-list\">\n");
+    for entry in &finding.evidence {
+        block.push_str(&render_evidence_entry(entry));
+    }
+    block.push_str("</ul>\n");
+    for (label, text) in [
+        ("Problem", &finding.problem),
+        ("Failure scenario", &finding.failure_scenario),
+        ("Minimal fix", &finding.minimal_fix),
+    ] {
+        block.push_str(&format!("<h5>{label}</h5>\n<p>{}</p>\n", escape_html(text)));
+    }
+    if let Some(long_term) = &finding.long_term_fix {
+        block.push_str(&format!(
+            "<h5>Long-term fix</h5>\n<p>{}</p>\n",
+            escape_html(long_term)
+        ));
+    }
+    block.push_str(&format!(
+        "<h5>Regression test</h5>\n<p>{}</p>\n",
+        escape_html(&finding.regression_test)
+    ));
+    block.push_str("</article>\n");
+    block
+}
+
+/// One evidence entry: path with line range when present, modality/source,
+/// note.
+fn render_evidence_entry(entry: &EvidenceRef) -> String {
+    let mut item = format!(
+        "<li><span class=\"evidence-kind\">{}</span> ",
+        escape_html(entry.kind.as_str())
+    );
+    if let Some(path) = &entry.path {
+        item.push_str(&format!("<code>{}</code>", escape_html(path)));
+        if let Some(start) = entry.line_start {
+            let end = entry.line_end.unwrap_or(start);
+            item.push_str(&format!(" (lines {start}-{end})"));
+        }
+        item.push(' ');
+    }
+    if let Some(modality) = entry.modality {
+        item.push_str(&format!("[{}] ", escape_html(modality.as_str())));
+    }
+    item.push_str(&format!("&mdash; {}", escape_html(&entry.source)));
+    if let Some(note) = &entry.note {
+        item.push_str(&format!(": {}", escape_html(note)));
+    }
+    item.push_str("</li>\n");
+    item
+}
+
+/// Findings ordered by severity then department (the same total order as
+/// `render_findings_by_severity`, unbucketed) — a compact work queue that
+/// links back to each finding's full detail above.
+fn render_fix_order(report: &AuditReport) -> String {
+    let findings = sorted_findings(report);
+    let mut section = String::from(
+        "<section id=\"fix-order\">\n<h2>Fix Order</h2>\n<p>Findings ordered by severity, then department.</p>\n",
+    );
+    if findings.is_empty() {
+        section.push_str("<p>No findings recorded.</p>\n</section>\n");
+        return section;
+    }
+    section.push_str(
+        "<table>\n<thead><tr><th>#</th><th>ID</th><th>Severity</th><th>Department</th><th>Title</th></tr></thead>\n<tbody>\n",
+    );
+    for (index, finding) in findings.iter().enumerate() {
+        let id = escape_html(&finding.id);
+        let severity = escape_html(finding.severity.as_str());
+        section.push_str(&format!(
+            "<tr><td>{order}</td><td><a href=\"#{id}\">{id}</a></td><td class=\"severity-{severity}\">{severity}</td><td>{dept}</td><td>{title}</td></tr>\n",
+            order = index + 1,
+            dept = escape_html(&finding.department),
+            title = escape_html(&finding.title)
+        ));
+    }
+    section.push_str("</tbody>\n</table>\n</section>\n");
+    section
+}
+
+#[cfg(test)]
+#[path = "render_html_tests.rs"]
+mod tests;

--- a/crates/code-intel-cli/src/audit_report/render_html_tests.rs
+++ b/crates/code-intel-cli/src/audit_report/render_html_tests.rs
@@ -1,0 +1,116 @@
+use super::*;
+use serde_json::{json, Value};
+use std::{fs, path::Path};
+
+fn fixture_value() -> Value {
+    serde_json::from_slice(
+        &fs::read(
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("tests/fixtures/audit/audit-report.v1.example.json"),
+        )
+        .unwrap(),
+    )
+    .unwrap()
+}
+
+fn render(value: &Value) -> String {
+    let report = AuditReport::parse(&serde_json::to_vec(value).unwrap()).unwrap();
+    render_html_document(&report)
+}
+
+#[test]
+fn escape_html_escapes_all_five_special_characters() {
+    assert_eq!(
+        escape_html(r#"a & b < c > d " e ' f"#),
+        "a &amp; b &lt; c &gt; d &quot; e &#39; f"
+    );
+}
+
+#[test]
+fn renders_a_complete_self_contained_document_with_sections_in_order() {
+    let html = render(&fixture_value());
+    assert!(html.starts_with("<!doctype html>"), "{html}");
+    assert!(!html.contains("http://"), "{html}");
+    assert!(!html.contains("https://"), "{html}");
+    assert!(!html.contains("<script"), "{html}");
+    assert!(!html.contains("<link "), "{html}");
+
+    let header_pos = html.find("<header>").unwrap();
+    let dashboard_pos = html.find("Score Dashboard").unwrap();
+    let coverage_pos = html.find("Coverage Matrix").unwrap();
+    let findings_pos = html.find("id=\"findings\"").unwrap();
+    let fix_order_pos = html.find("id=\"fix-order\"").unwrap();
+    assert!(header_pos < dashboard_pos);
+    assert!(dashboard_pos < coverage_pos);
+    assert!(coverage_pos < findings_pos);
+    assert!(findings_pos < fix_order_pos);
+}
+
+/// The required regression test: a finding title carrying a live `<script>`
+/// tag must appear only in its escaped form, never as markup the browser
+/// would execute.
+#[test]
+fn escapes_a_finding_title_containing_a_script_tag() {
+    let mut value = fixture_value();
+    value["findings"][0]["title"] = json!("<script>alert(1)</script>");
+    let html = render(&value);
+    assert!(!html.contains("<script>alert(1)</script>"), "{html}");
+    assert!(
+        html.contains("&lt;script&gt;alert(1)&lt;/script&gt;"),
+        "{html}"
+    );
+}
+
+#[test]
+fn redacted_finding_shows_a_visible_marker() {
+    let mut value = fixture_value();
+    value["findings"][0]["redacted"] = json!(true);
+    let html = render(&value);
+    assert!(html.contains("REDACTED"), "{html}");
+    assert!(html.contains("redacted-notice"), "{html}");
+}
+
+#[test]
+fn scope_line_is_absent_without_a_scope_block_and_present_with_one() {
+    let base = fixture_value();
+    let without_scope = render(&base);
+    assert!(!without_scope.contains("scope-line"), "{without_scope}");
+
+    let mut with_scope = base;
+    with_scope["scope"] = json!({
+        "kind": "diff",
+        "since": "HEAD~3",
+        "files": ["crates/code-intel-cli/src/capability_inventory.rs"]
+    });
+    let html = render(&with_scope);
+    assert!(html.contains("scope-line"), "{html}");
+    assert!(html.contains("HEAD~3"), "{html}");
+}
+
+#[test]
+fn evidence_entry_renders_path_with_line_range() {
+    let html = render(&fixture_value());
+    assert!(html.contains("capability_inventory.rs"), "{html}");
+    assert!(html.contains("(lines 156-165)"), "{html}");
+}
+
+#[test]
+fn fix_order_links_to_the_finding_anchor() {
+    let html = render(&fixture_value());
+    assert!(html.contains("href=\"#security-001\""), "{html}");
+    assert!(html.contains("id=\"security-001\""), "{html}");
+}
+
+#[test]
+fn findings_grouped_by_severity_shows_a_heading_with_count() {
+    let html = render(&fixture_value());
+    assert!(html.contains("Medium (1)"), "{html}");
+}
+
+#[test]
+fn renders_cleanly_with_zero_findings() {
+    let mut value = fixture_value();
+    value["findings"] = json!([]);
+    let html = render(&value);
+    assert!(html.contains("No findings recorded."), "{html}");
+}

--- a/crates/code-intel-cli/src/audit_report/validate.rs
+++ b/crates/code-intel-cli/src/audit_report/validate.rs
@@ -1,7 +1,7 @@
-use std::{fs, path::Path};
+use std::{collections::BTreeSet, fs, path::Path};
 
 use super::{
-    enums::{Coverage, DepartmentRunStatus, EvidenceKind, FindingStatus},
+    enums::{Coverage, DepartmentRunStatus, EvidenceKind, FindingStatus, ScopeKind},
     model::AuditReport,
     registry::{repo_relative_path, DepartmentRegistry},
 };
@@ -20,6 +20,13 @@ fn nullable_f64_eq(left: Option<f64>, right: Option<f64>) -> bool {
 
 fn is_perfect_score(score: f64) -> bool {
     (score - 10.0).abs() < 1e-9
+}
+
+/// Path comparison for rule (j) must be robust to separator style (a scope
+/// block built on Windows vs. evidence authored assuming `/`) and nothing
+/// else: no case-folding, no `.`/`..` resolution, no drive-letter handling.
+fn normalize_path_separators(path: &str) -> String {
+    path.replace('\\', "/")
 }
 
 impl AuditReport {
@@ -50,7 +57,16 @@ impl AuditReport {
     ///     at most one `score_dashboard` entry;
     /// (i) an `assessed` department actually moves the health score: it has
     ///     a non-null `score_dashboard` entry and its coverage row is not
-    ///     `not_assessed`.
+    ///     `not_assessed`;
+    /// (j) an incremental (`scope.kind: "diff"`) report is bounded to its
+    ///     declared diff: `scope.since` must be present and non-empty,
+    ///     `scope.files` must be non-empty, and every finding's `file`-kind
+    ///     evidence entry that carries a `path` must name a path present in
+    ///     `scope.files` (compared after normalising `\` to `/` on both
+    ///     sides). A `full` scope, or no `scope` block at all, carries no
+    ///     such restriction. A finding outside the declared diff scope is a
+    ///     contract violation — that is the whole guarantee an incremental
+    ///     audit makes.
     pub(crate) fn validate(&self, registry: &DepartmentRegistry) -> Result<(), String> {
         // (a) every finding has evidence (structural, enforced at parse time
         // via minItems); a confirmed finding also needs a file+path entry.
@@ -310,6 +326,49 @@ impl AuditReport {
             }
         }
 
+        // (j) an incremental (`scope.kind: "diff"`) report is bounded to its
+        // declared diff. `full`/absent scope: no restriction.
+        if let Some(scope) = &self.scope {
+            if scope.kind == ScopeKind::Diff {
+                let since_present = scope
+                    .since
+                    .as_deref()
+                    .is_some_and(|value| !value.is_empty());
+                if !since_present {
+                    return Err(
+                        "scope.since must be present and non-empty when scope.kind is \"diff\""
+                            .to_string(),
+                    );
+                }
+                if scope.files.is_empty() {
+                    return Err(
+                        "scope.files must be non-empty when scope.kind is \"diff\"".to_string()
+                    );
+                }
+                let scoped_files = scope
+                    .files
+                    .iter()
+                    .map(|file| normalize_path_separators(file))
+                    .collect::<BTreeSet<_>>();
+                for finding in &self.findings {
+                    for entry in &finding.evidence {
+                        if entry.kind != EvidenceKind::File {
+                            continue;
+                        }
+                        let Some(path) = &entry.path else {
+                            continue;
+                        };
+                        if !scoped_files.contains(&normalize_path_separators(path)) {
+                            return Err(format!(
+                                "finding \"{}\" evidence path \"{path}\" is outside the declared diff scope (scope.files)",
+                                finding.id
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+
         Ok(())
     }
 
@@ -364,3 +423,7 @@ impl AuditReport {
 #[cfg(test)]
 #[path = "validate_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "validate_scope_tests.rs"]
+mod scope_tests;

--- a/crates/code-intel-cli/src/audit_report/validate_scope_tests.rs
+++ b/crates/code-intel-cli/src/audit_report/validate_scope_tests.rs
@@ -1,0 +1,108 @@
+use super::*;
+use serde_json::{json, Value};
+use std::{fs, path::Path};
+
+/// The path this fixture's only finding cites as `file` evidence
+/// (`tests/fixtures/audit/audit-report.v1.example.json`).
+const EVIDENCE_PATH: &str = "crates/code-intel-cli/src/capability_inventory.rs";
+
+fn fixture_value() -> Value {
+    serde_json::from_slice(
+        &fs::read(
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("tests/fixtures/audit/audit-report.v1.example.json"),
+        )
+        .unwrap(),
+    )
+    .unwrap()
+}
+
+/// A synthetic all-enabled registry, independent of whatever
+/// `orchestration/audit/departments.v1.json` grows next. Duplicated from
+/// `validate_tests::registry()` rather than shared: sibling test modules
+/// (`tests` and this one, both attached to `validate.rs`) do not see each
+/// other's private items, only their common ancestor's.
+fn registry() -> DepartmentRegistry {
+    let value = json!({
+        "schema": "code-intel-audit-departments.v1",
+        "catalogVersion": "1.0.0",
+        "rubrics": {
+            "severity": "orchestration/audit/rubrics/severity.md",
+            "confidence": "orchestration/audit/rubrics/confidence.md",
+            "evidence": "orchestration/audit/rubrics/evidence.md",
+            "coverage": "orchestration/audit/rubrics/coverage.md",
+            "scoring": "orchestration/audit/rubrics/scoring.md"
+        },
+        "findingContract": "docs/audit-report.md",
+        "departments": [
+            {"id":"security","title":"Security","enabled":true,"prompt":"orchestration/audit/prompts/security.md","consumes":[],"applicabilityCheck":"always","trackingIssue":"t"},
+            {"id":"ai-safety","title":"AI Safety","enabled":true,"prompt":"orchestration/audit/prompts/ai-safety.md","consumes":[],"applicabilityCheck":"ai-surface","trackingIssue":"t"},
+            {"id":"supply-chain","title":"Supply Chain","enabled":true,"prompt":"orchestration/audit/prompts/supply-chain.md","consumes":[],"applicabilityCheck":"manifests-present","trackingIssue":"t"}
+        ]
+    });
+    DepartmentRegistry::from_value(&value).unwrap()
+}
+
+#[test]
+fn rejects_diff_scope_missing_since() {
+    let mut value = fixture_value();
+    value["scope"] = json!({"kind": "diff", "files": [EVIDENCE_PATH]});
+    let report = AuditReport::parse(&serde_json::to_vec(&value).unwrap()).unwrap();
+    let error = report.validate(&registry()).unwrap_err();
+    assert!(error.contains("scope.since must be present"), "{error}");
+}
+
+#[test]
+fn rejects_diff_scope_with_empty_since() {
+    let mut value = fixture_value();
+    value["scope"] = json!({"kind": "diff", "since": "", "files": [EVIDENCE_PATH]});
+    let report = AuditReport::parse(&serde_json::to_vec(&value).unwrap()).unwrap();
+    let error = report.validate(&registry()).unwrap_err();
+    assert!(error.contains("scope.since must be present"), "{error}");
+}
+
+#[test]
+fn rejects_diff_scope_missing_files() {
+    let mut value = fixture_value();
+    value["scope"] = json!({"kind": "diff", "since": "HEAD~1"});
+    let report = AuditReport::parse(&serde_json::to_vec(&value).unwrap()).unwrap();
+    let error = report.validate(&registry()).unwrap_err();
+    assert!(error.contains("scope.files must be non-empty"), "{error}");
+}
+
+#[test]
+fn rejects_finding_evidence_path_outside_diff_scope() {
+    let mut value = fixture_value();
+    value["scope"] = json!({
+        "kind": "diff",
+        "since": "HEAD~1",
+        "files": ["some/other/file.rs"]
+    });
+    let report = AuditReport::parse(&serde_json::to_vec(&value).unwrap()).unwrap();
+    let error = report.validate(&registry()).unwrap_err();
+    assert!(error.contains("outside the declared diff scope"), "{error}");
+}
+
+#[test]
+fn accepts_finding_evidence_path_inside_diff_scope_with_backslash_normalization() {
+    let mut value = fixture_value();
+    // scope.files spelled with backslashes; the fixture's evidence path
+    // already uses forward slashes — rule (j) must normalise both sides,
+    // not just the scope side or just the evidence side.
+    let windows_style = EVIDENCE_PATH.replace('/', "\\");
+    value["scope"] = json!({
+        "kind": "diff",
+        "since": "HEAD~1",
+        "files": [windows_style]
+    });
+    let report = AuditReport::parse(&serde_json::to_vec(&value).unwrap()).unwrap();
+    report.validate(&registry()).unwrap();
+}
+
+#[test]
+fn full_scope_carries_no_path_restriction() {
+    let mut value = fixture_value();
+    value["scope"] = json!({"kind": "full"});
+    let report = AuditReport::parse(&serde_json::to_vec(&value).unwrap()).unwrap();
+    report.validate(&registry()).unwrap();
+}

--- a/docs/audit-report.md
+++ b/docs/audit-report.md
@@ -49,6 +49,7 @@ Findings must never write secret material in plaintext. A finding about a leaked
 7. A department that scores `10.0` with zero findings must have `coverage: high` — see `orchestration/audit/rubrics/scoring.md`.
 8. Every department listed in the report has exactly one `coverage_matrix` row and at most one `score_dashboard` entry.
 9. A department whose `status` is `assessed` actually moves the health score: it has a non-null `score_dashboard` entry, and its `coverage_matrix` row is not `not_assessed`.
+10. When the optional top-level `scope.kind` is `"diff"`, `scope.since` must be present and non-empty, `scope.files` must be non-empty, and every finding's `file`-kind evidence entry that carries a `path` must name a path present in `scope.files` (compared after normalising `\` to `/` on both sides) — a finding outside the declared diff scope is a contract violation. A `full` scope, or no `scope` block at all, carries no such restriction. See "Incremental Audits" below.
 
 `validate()` is filesystem-free: it can see that a confirmed finding *has* a `path`, not that the path names a real file. Because a department is an agent, an unresolvable or drifted citation is the expected failure mode, so `validate_evidence_grounding(repo_root)` is a second pass that grounds every `file` evidence entry in the tree it claims to cite: the `path` must be portable repo-relative syntax, must resolve to a file under the repository root, and any `line_start`/`line_end` must be ordered and within that file. `code-intel audit --operation validate --repo <root>` runs it — that operation holds the repository the report cites. `--operation render` does not, and does not claim to.
 
@@ -68,7 +69,8 @@ The kernel does not care how a department produces its `audit-report.json` — o
 
 ## Validating a Report
 
-`code-intel audit` exposes two operations; both read the report from `--report <path>`.
+`code-intel audit` exposes three operations; `validate` and `render` read the report from
+`--report <path>`.
 
 - `--operation validate --repo <root> --report <path>` — parses the report structurally
   (`AuditReport::parse`, closed-object shape, no unknown fields), loads and self-validates
@@ -77,7 +79,37 @@ The kernel does not care how a department produces its `audit-report.json` — o
   one-line JSON summary — `{"ok":true,"findings_total":<n>,"overall":<score-or-null>,
   "departments_assessed":<n>}` — and exits `0`. On any failure it prints
   `{"ok":false,"error":"<message>"}` to stdout and exits nonzero.
-- `--operation render --report <path>` — parses the report and prints the same `## Audit`
-  markdown section `hospital.md` renders, so a department (or a person) can eyeball the result
-  without a full pipeline run. It does not need `--repo`: `render_markdown_section` only reads
-  the parsed report, never the registry.
+- `--operation render --report <path> [--format markdown|html]` — parses the report and prints
+  it either as the same `## Audit` markdown section `hospital.md` renders (`--format markdown`,
+  the default — existing invocations with no `--format` are unchanged), or as one self-contained
+  HTML document (`--format html`): a header (repo, overall score, rubric version, and the scope
+  line when a `scope` block is present), the score dashboard, the coverage matrix, findings
+  grouped by severity (critical to info), and a fix-order section ordering findings by severity
+  then department. The HTML has inline `<style>` only — no external CSS, JS, fonts, images, or
+  any other network reference — so it opens correctly from a `file://` path. It is rendered
+  directly from the parsed, validated `AuditReport` model, never from a raw template string, so
+  there is no placeholder-substitution failure mode for a separate report linter to catch;
+  every interpolated value passes through one escaping helper (`escape_html`) before it reaches
+  the page. Neither format needs `--repo`: both renderers only read the parsed report, never the
+  registry.
+
+## Incremental Audits
+
+A report may carry an optional top-level `scope` block: `{"kind": "full" | "diff", "since":
+<git-ref-or-null>, "files": [<path>, ...]}`. `kind: "full"` — or no `scope` block at all — means
+the run swept the whole tree and carries no path restriction. `kind: "diff"` declares that the
+run scoped itself to a set of changed files; fail-closed rule 10 above then requires `since` and
+`files` to both be present and non-empty, and every finding's `file`-kind evidence to cite a path
+listed in `files`.
+
+`code-intel audit --operation scope --repo <root> --since <git-ref>` computes that file set:
+`git diff --name-only <since>...HEAD` (three-dot — everything HEAD changed since it diverged
+from `since`) against `--repo`, run through the hardened git wrapper since `--repo` is a
+repository the operator pointed at, not one this process owns. It normalises paths to forward
+slashes, drops paths that no longer exist in the working tree (a deleted file cannot carry file
+evidence), sorts and dedups, and prints a ready-to-embed scope block as one-line JSON —
+`{"kind":"diff","since":"<ref>","files":[...]}`. A department (or a person) copies that block
+verbatim into the report's `scope` field, restricts its findings to files in it, and notes the
+diff limitation in every coverage row's `exclusions`. A non-zero git exit, or a git that cannot
+run at all, is a hard error — `{"ok":false,"error":"<message>"}` and a nonzero exit, exactly like
+`--operation validate` — this command never falls back to assuming everything changed.

--- a/orchestration/audit/prompts/ai-safety.md
+++ b/orchestration/audit/prompts/ai-safety.md
@@ -53,6 +53,16 @@ Do not spend output on:
 - Injection findings where no untrusted content can reach the prompt.
 - Speculative jailbreak scenarios with no path in this codebase.
 
+## Incremental runs
+
+When this run is scoped to a diff, get the scope block first — do not hand-roll the changed-file list:
+
+```bash
+code-intel audit --operation scope --repo <target-root> --since <git-ref>
+```
+
+Embed the printed block verbatim as the report's top-level `scope` field. Restrict every finding to evidence within `scope.files` — the kernel fails closed on a finding outside the declared diff. Name the diff limitation in every coverage row's `exclusions` (e.g. "incremental run scoped to N changed files; the rest of the tree was not swept this pass").
+
 ## Output contract
 
 Produce one `code-intel-audit-report.v1` JSON document. `departments` must list **every** registered department (kernel rule: exact registry membership); report departments whose registry entry is `enabled: false` as `disabled`. Finding ids are `ai-safety-001`, `ai-safety-002`, … Every listed department needs a coverage row; an `assessed` department also needs a non-null score and non-`not_assessed` coverage.

--- a/orchestration/audit/prompts/security.md
+++ b/orchestration/audit/prompts/security.md
@@ -50,6 +50,16 @@ If you discover a real secret (key, token, password, connection string):
 - Set `redacted: true` on the finding, and never place the secret value in the report, evidence excerpts, logs, or conversation output.
 - Identify it by path, variable/key name, secret type, and blast radius; recommend rotation when exposure is plausible.
 
+## Incremental runs
+
+When this run is scoped to a diff, get the scope block first — do not hand-roll the changed-file list:
+
+```bash
+code-intel audit --operation scope --repo <target-root> --since <git-ref>
+```
+
+Embed the printed block verbatim as the report's top-level `scope` field. Restrict every finding to evidence within `scope.files` — the kernel fails closed on a finding outside the declared diff. Name the diff limitation in every coverage row's `exclusions` (e.g. "incremental run scoped to N changed files; the rest of the tree was not swept this pass").
+
 ## Output contract
 
 Produce one `code-intel-audit-report.v1` JSON document (see `orchestration/schemas/code-intel-audit-report.v1.schema.json`):

--- a/orchestration/audit/prompts/supply-chain.md
+++ b/orchestration/audit/prompts/supply-chain.md
@@ -49,6 +49,16 @@ Do not spend output on:
 - SBOM or signing requirements for a repository with no public release path.
 - Version-bump churn that carries no compromise path.
 
+## Incremental runs
+
+When this run is scoped to a diff, get the scope block first — do not hand-roll the changed-file list:
+
+```bash
+code-intel audit --operation scope --repo <target-root> --since <git-ref>
+```
+
+Embed the printed block verbatim as the report's top-level `scope` field. Restrict every finding to evidence within `scope.files` — the kernel fails closed on a finding outside the declared diff. Name the diff limitation in every coverage row's `exclusions` (e.g. "incremental run scoped to N changed files; the rest of the tree was not swept this pass").
+
 ## Output contract
 
 Produce one `code-intel-audit-report.v1` JSON document. `departments` must list **every** registered department (kernel rule: exact registry membership); report departments whose registry entry is `enabled: false` as `disabled`. Finding ids are `supply-chain-001`, `supply-chain-002`, … Every listed department needs a coverage row; an `assessed` department also needs a non-null score and non-`not_assessed` coverage.

--- a/orchestration/schemas/code-intel-audit-report.v1.schema.json
+++ b/orchestration/schemas/code-intel-audit-report.v1.schema.json
@@ -21,7 +21,8 @@
     "coverage_matrix": {
       "type": "array",
       "items": { "$ref": "#/$defs/coverageRow" }
-    }
+    },
+    "scope": { "$ref": "#/$defs/scope" }
   },
   "$defs": {
     "departmentRun": {
@@ -121,6 +122,19 @@
           "items": { "type": "string", "minLength": 1 }
         },
         "exclusions": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind"],
+      "properties": {
+        "kind": { "enum": ["full", "diff"] },
+        "since": { "type": ["string", "null"] },
+        "files": {
           "type": "array",
           "items": { "type": "string", "minLength": 1 }
         }


### PR DESCRIPTION
Closes #22. Closes #23. Completes the audit layer map #17.

## What

**#22 — HTML reports.** `code-intel audit --operation render --format html` emits one self-contained document: inline CSS, no external stylesheet, script, font, or image reference, so it opens from a `file://` path. Sections are header (with the scope line when a diff-scoped report carries one), score dashboard, coverage matrix, findings grouped by severity, and fix order. Every interpolated value is HTML-escaped — report text is untrusted output from a department run, and a test proves a finding titled `<script>alert(1)</script>` renders escaped rather than live. `--format markdown` stays the default, so existing callers are unaffected.

**#23 — diff-scoped audits.** The report contract gains an optional `scope` block (`{kind, since, files}`, additive — absent means a full-repository audit, and every existing report stays valid). New fail-closed rule (j): a `diff`-scoped report must name a non-empty `since` ref and file set, and **every file-evidence path must fall inside that set**. That is the whole guarantee of an incremental audit — a finding outside the declared diff is a contract violation, not a bonus. `code-intel audit --operation scope --repo <root> --since <ref>` computes the set from `git diff --name-only <ref>...HEAD` (three-dot: what this branch changed since the merge base), drops paths that no longer exist, and prints a ready-to-embed block. A git failure is an error, never a silent fall back to "assume everything changed". All three department prompts document the incremental workflow.

**Git hardening.** `hardened_git::command` disarms the git config keys that name a program git will execute — `core.fsmonitor` is the sharp one, since git runs it on ordinary read commands like `git status`. Every git call site in this pipeline runs *inside* the scanned tree, so that tree's own `.git/config` is live before any gate has inspected it; `git clone` does not carry config across, so the precondition is a repository that arrived with its `.git` intact (an archive, a backup, a copied directory) — exactly the shape a scanned target can have. The pipeline already strips `RIPGREP_CONFIG_PATH` at every ripgrep call site; this applies the same rule to the tool that can start a process rather than merely change a file list. All git call sites in `sentrux_analysis`, `sentrux_gate`, `snapshot`, and the new scope operation route through it.

Worth noting against the security department's own self-audit earlier in this series: that pass swept all 22 `Command::new` sites and confirmed argv arrays with no shell interpolation, but it did **not** consider that git executes programs named in the scanned repository's config. The audit found the call sites; it missed the config-driven execution path. Recorded here rather than quietly fixed.

## Verification

- `cargo test -p code-intel --bin code-intel audit`: 76 passed, 0 failed (46 before this PR).
- Integration binaries: `audit_report` 9, `artifact_ref` 9, `hospital_diagnosis` 5, `artifact_index` 132, `decision_record` 137 — 0 failed.
- `cargo test -p code-intel --no-run` compiles every test binary, exit 0. This caught a real ripple: the hardening's call sites used `crate::hardened_git`, which does not resolve inside this repo's `#[path]`-included test crate roots. Fixed by declaring the module locally in each file that uses it.
- `cargo fmt --all --check` clean.
- `test-atomic-capability-contract.ps1`: `"ok": true` (the `sentrux_gate.rs` toolchain digest in `integrations.json` was refreshed surgically — 1 line).
- sentrux gate: `Cycles 0 -> 0`, `God files 29 -> 29`, **No degradation detected**.
- Smoke, release build, this repository:
  - `--operation scope --repo . --since HEAD~1` → `{"files":["CHANGELOG.md","orchestration/audit/prompts/ai-safety.md"],"kind":"diff","since":"HEAD~1"}`
  - `--format html` on the example fixture → 7030 bytes, zero matches for `http://`, `https://`, `<script src`, or `<link `
  - a diff-scoped report whose finding sits outside `scope.files` → rejected with the rule-(j) message, exit 65; the same report with that path added → accepted, exit 0

## Deviation from the ticket

#22 asked to adopt FMSM's `scripts/report_lint.py` rather than rewrite it. That linter checks a *rendered document* for missing sections, placeholder variables, and score-direction errors. Here the HTML is generated from an already-parsed and `validate()`-checked model, so those defects are unrepresentable by construction — there is no template to leave a placeholder in, and score direction is enforced by the schema. Adding a Python linter would also cut against AGENTS.md's Rust-only rule for production surfaces. The linting role is served by `--operation validate`; this is documented in `docs/audit-report.md`.
