### PR TITLE
chore(release): 0.6.0 — audit layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] — 2026-07-26
+
+This release adds the **audit layer**: audit dimensions run as hospital
+departments over the modality evidence the pipeline already gathers, and emit
+findings under one fail-closed contract. Three departments ship enabled
+(`security`, `ai-safety`, `supply-chain`), reports render as Markdown or as a
+self-contained HTML document, and an audit can be scoped to a git diff for
+pull-request review.
+
+The layer was pointed at this repository before shipping. It found the
+unpinned toolchain and the mutable CI action tags fixed below; the git config
+hardening came out of the same pass. Methodology adapted from
+[Fuck_My_Shit_Mountain](https://github.com/XiNian-dada/Fuck_My_Shit_Mountain)
+(MIT).
+
 ### Fixed
 
 - Git no longer runs inside a scanned repository with that repository's own

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "code-intel"
-version = "0.5.1-beta.1"
+version = "0.6.0"
 dependencies = [
  "serde_json",
 ]

--- a/crates/code-intel-cli/Cargo.toml
+++ b/crates/code-intel-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "code-intel"
-version = "0.5.1-beta.1"
+version = "0.6.0"
 edition = "2021"
 description = "Local Code Intel Pipeline CLI for artifact resume and contract checks"
 license = "MIT"


### PR DESCRIPTION
Release preparation for **v0.6.0** — the audit layer release. No functional change: version bump plus the closed changelog section.

## Scope of the release

Everything merged since `v0.5.1-beta.1`:

| | |
|---|---|
| #24 | audit kernel — contract, rubrics, department registry, hospital wiring |
| #26 | `security` department + `code-intel audit` CLI + `diagnosis.audit` artifact contract |
| #29 | `ai-safety` and `supply-chain` departments |
| #37 | HTML reports, diff-scoped audits |
| #28 | pinned Rust toolchain |
| #30, #31, #32 | the fixes the layer's own self-audit surfaced |

## What ships

Audit dimensions run as hospital departments over the modality evidence the pipeline already gathers (`xray`, `ct`, `anatomy`, `chart`, `governance`), and emit findings under one fail-closed contract: every finding carries evidence, a realistic failure scenario, a minimal fix, a regression test, and an effort estimate; every dimension declares its coverage honestly, and a clean dimension can only score 10.0 at `high` coverage. Three departments ship enabled. Reports render as Markdown or as a self-contained HTML document, and an audit can be scoped to a git diff for pull-request review.

The differentiator over a prompt-only auditor is that findings are grounded in tool evidence and verified by targeted reads — and the layer says so when it cannot see something, rather than reporting a clean bill of health.

## Dogfood record

The layer was pointed at this repository before shipping, and the release contains what it found:

- **unpinned Rust toolchain** (`supply-chain-001`, medium) — released binaries were not reproducible; the shipped `.sha256` proved transport integrity but nobody could rebuild a tag's bytes. Fixed in #28.
- **mutable CI action tags** (`supply-chain-002`, low) — including in the workflow holding `contents: write`. Severity stayed low because every action is GitHub-owned and CI grants only `contents: read`; the report said so rather than inflating the grade.
- One hypothesis was **refuted by test rather than by argument**: `Command::new("rg")` with `.current_dir(target)` looked like a Windows current-directory program-search hijack, but a scanned repository seeded with `rg.exe`/`rg.bat` decoys did not divert execution. Recorded as inspected evidence, not reported as a finding.

Also worth stating plainly: the security department's self-audit **missed** the git-config execution path that #32 fixes. It swept all 22 `Command::new` sites and confirmed argv arrays with no shell interpolation, but did not consider that Git executes programs named in the scanned repository's own `.git/config` (`core.fsmonitor` runs on ordinary read commands). That gap is recorded in #37 rather than quietly closed.

Methodology adapted from [Fuck_My_Shit_Mountain](https://github.com/XiNian-dada/Fuck_My_Shit_Mountain) (MIT), attributed in every file that borrows from it.

## Verification

- `cargo test -p code-intel`: 193 unit + all integration binaries pass. One pre-existing local-only failure (`ticket_r11_tree_sitter_v_record...`, a stale digest on a `.c` file) — it passes in CI on every run, including on `main`, so it is a local checkout artifact and predates this work.
- `cargo fmt --all --check` clean; release build succeeds and reports the new version.
- sentrux gate: `Cycles 0 -> 0`, `God files 29 -> 29`, **No degradation detected**.
- `test-atomic-capability-contract.ps1`: `"ok": true`.

## After merge

The release workflow triggers on a `v*` tag and refuses to run unless the tag matches the package version, so this bump must land before tagging:

```
git tag v0.6.0 && git push origin v0.6.0
```
