### PR TITLE
fix(run-commit): preserve caller's manifest bytes and digest through A07 publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,14 +274,8 @@ jobs:
           .\scripts/tests/test-codenexus-adapter-contract.ps1
           .\scripts/tests/test-transactional-publication.ps1
 
-      - name: Run commit contract tests (known-failing, non-blocking)
+      - name: Run commit contract tests
         shell: pwsh
-        # continue-on-error: this suite fails at HEAD -- the run-commit
-        # facade publishes an incoherent A07 marker
-        # (test-run-commit-contract.ps1:73). Wired in non-blocking so the
-        # failure stays visible instead of the suite running in no workflow
-        # at all; drop continue-on-error once the facade is fixed.
-        continue-on-error: true
         run: .\scripts/tests/test-run-commit-contract.ps1
 
       - name: Package

--- a/crates/code-intel-cli/src/run_commit.rs
+++ b/crates/code-intel-cli/src/run_commit.rs
@@ -206,8 +206,17 @@ pub(crate) fn publish_existing(
     }
     let mut published_manifest = manifest;
     replace_manifest_artifact_refs(&mut published_manifest, &published_refs)?;
-    let manifest_bytes = serde_json::to_vec(&published_manifest)
-        .map_err(|error| CommitError::Contract(format!("serialize published manifest: {error}")))?;
+    // When publication changed no Artifact Ref (the canonical content-addressed
+    // case), commit the caller's manifest bytes verbatim: the published marker
+    // must bind the same digest the caller's manifest Artifact Ref vouches for.
+    // Re-serialization is reserved for runs whose refs were genuinely rewritten.
+    let manifest_bytes = if published_refs == source_refs {
+        read_manifest_stable(source_root, &source_manifest_ref)?.1
+    } else {
+        serde_json::to_vec(&published_manifest).map_err(|error| {
+            CommitError::Contract(format!("serialize published manifest: {error}"))
+        })?
+    };
     let staged_manifest_ref = writer
         .stage(
             &manifest_bytes,
@@ -410,6 +419,13 @@ fn prevalidate_refs(
 }
 
 fn read_manifest(root: &Path, manifest_ref: &Value) -> Result<Value, CommitError> {
+    Ok(read_manifest_stable(root, manifest_ref)?.0)
+}
+
+fn read_manifest_stable(
+    root: &Path,
+    manifest_ref: &Value,
+) -> Result<(Value, Vec<u8>), CommitError> {
     validate_artifact_ref_shape(manifest_ref).map_err(CommitError::Contract)?;
     let path = manifest_ref["path"]
         .as_str()
@@ -424,8 +440,9 @@ fn read_manifest(root: &Path, manifest_ref: &Value) -> Result<Value, CommitError
         ));
     }
     validate_run_manifest_bytes(&stable.bytes).map_err(CommitError::Contract)?;
-    serde_json::from_slice(&stable.bytes)
-        .map_err(|_| CommitError::Contract("run manifest is invalid JSON".to_string()))
+    let manifest = serde_json::from_slice(&stable.bytes)
+        .map_err(|_| CommitError::Contract("run manifest is invalid JSON".to_string()))?;
+    Ok((manifest, stable.bytes))
 }
 
 fn validate_run_manifest(value: &Value) -> Result<(), String> {

--- a/crates/code-intel-cli/tests/run_commit.rs
+++ b/crates/code-intel-cli/tests/run_commit.rs
@@ -284,3 +284,77 @@ fn production_run_commit_cli_restages_a09_refs_through_a06_and_publishes() {
         "committed"
     );
 }
+
+#[test]
+fn cli_publication_preserves_the_callers_manifest_bytes_and_digest() {
+    let tree = Temp::new("cli-verbatim");
+    let source_root = tree.0.join("source");
+    let publication_authority = tree.0.join("publication-authority");
+    let objects = source_root.join("objects").join("sha256");
+    fs::create_dir_all(&objects).unwrap();
+    fs::create_dir(&publication_authority).unwrap();
+    let inventory = b"portable evidence\n";
+    let inventory_digest = capability::sha256_hex(inventory);
+    fs::write(objects.join(&inventory_digest), inventory).unwrap();
+    // Key order mirrors the PowerShell producer; serde re-serialization would
+    // reorder it, so byte preservation is observable through the digest.
+    let manifest_text = format!(
+        concat!(
+            "{{\"schema\":\"code-intel-run-manifest.v1\",\"runIdentity\":\"dag-v1:aabb\",",
+            "\"snapshotIdentity\":\"{snap}\",\"outcome\":\"completed\",\"nodes\":{{\"inventory\":",
+            "{{\"status\":\"succeeded\",\"verdict\":\"pass\",\"artifacts\":[{{",
+            "\"schema\":\"code-intel-artifact-ref.v1\",",
+            "\"artifactSchema\":\"code-intel-file-inventory.v1\",\"type\":\"inventory.files\",",
+            "\"path\":\"objects/sha256/{inv}\",\"sha256\":\"{inv}\",",
+            "\"consumedSnapshotIdentity\":\"{snap}\"}}]}}}}}}"
+        ),
+        snap = SNAPSHOT,
+        inv = inventory_digest
+    );
+    let reparsed: Value = serde_json::from_str(&manifest_text).unwrap();
+    assert_ne!(
+        serde_json::to_vec(&reparsed).unwrap(),
+        manifest_text.as_bytes(),
+        "fixture must be non-canonical for byte preservation to be observable"
+    );
+    let manifest_digest = capability::sha256_hex(manifest_text.as_bytes());
+    fs::write(objects.join(&manifest_digest), manifest_text.as_bytes()).unwrap();
+    let manifest_ref = json!({
+        "schema":"code-intel-artifact-ref.v1",
+        "artifactSchema":"code-intel-run-manifest.v1",
+        "type":"run.manifest",
+        "path":format!("objects/sha256/{manifest_digest}"),
+        "sha256":manifest_digest,
+        "consumedSnapshotIdentity":SNAPSHOT
+    });
+    let manifest_ref_path = tree.0.join("manifest-ref.json");
+    fs::write(
+        &manifest_ref_path,
+        serde_json::to_vec(&manifest_ref).unwrap(),
+    )
+    .unwrap();
+    let raw = vec![
+        "commit".to_string(),
+        "--source-root".to_string(),
+        source_root.display().to_string(),
+        "--authority-root".to_string(),
+        publication_authority.display().to_string(),
+        "--manifest-ref".to_string(),
+        manifest_ref_path.display().to_string(),
+        "--final-name".to_string(),
+        "published".to_string(),
+    ];
+    assert_eq!(run_commit::run_raw(&raw), 0);
+    let published = publication_authority.join("published");
+    let marker: Value =
+        serde_json::from_slice(&fs::read(published.join("run-complete.json")).unwrap()).unwrap();
+    assert_eq!(marker["manifest"]["sha256"], json!(manifest_digest));
+    let committed = fs::read(
+        published
+            .join("objects")
+            .join("sha256")
+            .join(&manifest_digest),
+    )
+    .unwrap();
+    assert_eq!(committed, manifest_text.as_bytes());
+}


### PR DESCRIPTION
## Problem (#61)

`code-intel run commit` (the facade behind `run-code-intel.ps1 -RunCommit*`) re-serialized the run manifest unconditionally after restaging. With canonical content-addressed source refs the staged refs are byte-identical to the source refs, so the only change was serde's alphabetical key reordering — a different digest. The store received the rewritten object (the caller's digest-bound object was absent), and the published `run-complete.json` bound `manifest.sha256` to the rewritten digest instead of the one the caller's manifest Artifact Ref vouches for. `scripts/tests/test-run-commit-contract.ps1:73` caught exactly this once PR #60 wired it into CI.

## Fix

In `publish_existing`, when `published_refs == source_refs` commit the caller's manifest bytes **verbatim** (via a new `read_manifest_stable` that returns the digest-verified bytes). Re-serialization remains only for runs whose refs were genuinely rewritten. Kernel-path `commit()` is untouched.

## Verification

- New Rust regression: `cli_publication_preserves_the_callers_manifest_bytes_and_digest` — publishes a PowerShell-key-ordered (provably non-canonical) manifest, asserts the marker and the committed object keep the caller's digest/bytes. Suite: 169/169.
- `scripts/tests/test-run-commit-contract.ps1`: **pass** (was the #61 failure); CI step's `continue-on-error` shim dropped.
- `internalization_record` + `capability_exec` digest suites: 75/75. `cargo fmt --check` clean.

Closes #61
