### PR TITLE
fix(mac-linux): shell env persistence, self-contained install, doctor paths, README quickstart (#59 P1+P3+P4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Follow-up automation can proactively propose `/investigate` for actionable scan 
 
 ## 30 秒开始
 
+> **macOS / Linux 用户**：当前只支持源码构建安装——没有非 Windows 的 Release ZIP，`bootstrap.py` 也不支持非 Windows。请直接看 [macOS / Linux 快速开始](#macos--linux-快速开始)；本节以下命令默认 Windows。
+
 在要分析的仓库目录中运行稳定入口；不传参数时默认分析当前目录：
 
 ```powershell
@@ -37,6 +39,58 @@ code-intel C:\path\to\your\repo
 ```
 
 首次安装、Skill 安装和依赖说明见[完整上手](#安装与完整上手)。
+
+## macOS / Linux 快速开始
+
+**支持等级**：macOS / Linux 目前只支持源码构建安装。Release ZIP 和 `bootstrap.py` 引导只覆盖 Windows（同 [Public beta guide](docs/public-beta.md)）。所有入口脚本都要求 PowerShell 7.2+（`pwsh`），README 里其余 `.ps1` 命令在 macOS / Linux 上同样用 `pwsh` 运行。
+
+前置依赖（macOS，Homebrew）：
+
+```bash
+brew install --cask powershell
+brew install ripgrep git rustup
+rustup-init -y
+```
+
+前置依赖（Debian / Ubuntu）：
+
+```bash
+# PowerShell：Microsoft 官方仓库（或 sudo snap install powershell --classic）
+wget -q "https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb"
+sudo dpkg -i packages-microsoft-prod.deb
+sudo apt-get update && sudo apt-get install -y powershell ripgrep git
+# Rust toolchain（安装器不会代装 rustup/cargo）
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+注意：`-InstallMissing` 只会通过 brew/apt/dnf/pacman 补装 `rg`、`git`、`python`；`rustup`/`cargo` 必须自己先装好——macOS / Linux 没有预编译二进制，安装器要现场 `cargo build`。
+
+安装：
+
+```bash
+git clone https://github.com/2233admin/code-intel-pipeline.git
+cd code-intel-pipeline
+pwsh ./install-code-intel-pipeline.ps1 -RepoPath ~/src/your-repo -InstallMissing
+```
+
+安装器把编译好的 `code-intel` 复制到平台 bin 目录：
+
+```text
+macOS: ~/Library/Application Support/code-intel/bin
+Linux: ~/.local/share/code-intel/bin   （设置了 XDG_DATA_HOME 时优先用它）
+```
+
+并写出 POSIX 环境文件 `~/.config/code-intel/env.sh`。按安装摘要末尾打印的那一行，把 `source` 追加进 shell 配置（zsh 用 `~/.zshrc`，bash 用 `~/.bashrc`），或手动把上面的 bin 目录加进 `PATH`：
+
+```bash
+echo 'source "$HOME/.config/code-intel/env.sh"' >> ~/.zshrc
+```
+
+重开 shell 后第一次运行：
+
+```bash
+code-intel ~/src/your-repo
+```
 
 ## 仓库入口
 
@@ -145,7 +199,7 @@ https://github.com/2233admin/code-intel-pipeline/tree/main/skills/code-intel-pip
 
 Skill 默认只解析稳定版，校验 GitHub Release 提供的 SHA-256 后才解压。预发布版本和第三方依赖安装都需要显式选择。
 
-人工用户从 GitHub Release 下载并解压安装包；Agent 用户通过 Skill 安装。源码安装仍可使用：
+人工用户从 GitHub Release 下载并解压安装包；Agent 用户通过 Skill 安装。macOS / Linux 没有 Release ZIP，走[macOS / Linux 快速开始](#macos--linux-快速开始)的源码构建路径。Windows 源码安装仍可使用：
 
 ```powershell
 git clone https://github.com/2233admin/code-intel-pipeline.git

--- a/check-code-intel-tools.ps1
+++ b/check-code-intel-tools.ps1
@@ -181,9 +181,16 @@ if (Test-Path -LiteralPath $Config -PathType Leaf) {
 
 $pipelineRoot = Split-Path -Parent $PSCommandPath
 $pipelineScript = Join-Path $pipelineRoot "run-code-intel.ps1"
-$codeIntelCargo = Join-Path $pipelineRoot "crates\code-intel-cli\Cargo.toml"
-$codeIntelGraphSource = Join-Path $pipelineRoot "crates\code-intel-cli\src\graph.rs"
-$codeIntelGraphBinary = Join-Path $pipelineRoot "target\debug\code-intel.exe"
+$codeIntelCliRoot = Join-Path (Join-Path $pipelineRoot "crates") "code-intel-cli"
+$codeIntelCargo = Join-Path $codeIntelCliRoot "Cargo.toml"
+$codeIntelGraphSource = Join-Path (Join-Path $codeIntelCliRoot "src") "graph.rs"
+$codeIntelGraphBinaryName = if ($effectivePlatform -eq "windows") { "code-intel.exe" } else { "code-intel" }
+$codeIntelGraphBinaryCandidates = @(
+    (Join-Path (Join-Path (Join-Path $pipelineRoot "target") "release") $codeIntelGraphBinaryName),
+    (Join-Path (Join-Path (Join-Path $pipelineRoot "target") "debug") $codeIntelGraphBinaryName)
+)
+$codeIntelGraphBinary = @($codeIntelGraphBinaryCandidates | Where-Object { Test-Path -LiteralPath $_ -PathType Leaf }) | Select-Object -First 1
+$codeIntelGraphCommandBinary = if ($null -ne $codeIntelGraphBinary) { $codeIntelGraphBinary } else { $codeIntelGraphBinaryCandidates[0] }
 $repoConfig = Resolve-RepoConfig $Repo $configData
 $repoInput = if (-not [string]::IsNullOrWhiteSpace($RepoPath)) { $RepoPath } else { $Repo }
 $repoPath = if (-not [string]::IsNullOrWhiteSpace($RepoPath)) {
@@ -300,8 +307,9 @@ $checks = [ordered]@{
     graphProvider = [ordered]@{
         sourceFound = (Test-Path -LiteralPath $codeIntelGraphSource -PathType Leaf)
         cargoFound = (Test-Path -LiteralPath $codeIntelCargo -PathType Leaf)
-        binaryFound = (Test-Path -LiteralPath $codeIntelGraphBinary -PathType Leaf)
-        command = "$codeIntelGraphBinary graph --repo <repo-path> --language zh --write --json"
+        binaryFound = ($null -ne $codeIntelGraphBinary)
+        binaryPath = if ($null -ne $codeIntelGraphBinary) { $codeIntelGraphBinary } else { "" }
+        command = "$codeIntelGraphCommandBinary graph --repo <repo-path> --language zh --write --json"
     }
     repo = $repoState
     env = [ordered]@{

--- a/install-code-intel-pipeline.ps1
+++ b/install-code-intel-pipeline.ps1
@@ -402,6 +402,17 @@ function Add-UserPathPrefix {
     return (code-intel-platform\Add-UserPathPrefix -PathToAdd $PathToAdd -Platform $script:EffectivePlatform)
 }
 
+function Get-PathRefreshFix {
+    param([string]$CommandName)
+
+    if ($script:EffectivePlatform -eq "windows") {
+        return "Open a new terminal if this shell cannot find $CommandName from PATH."
+    }
+    # A new terminal does NOT pick up process-only PATH changes on macOS/Linux;
+    # the one-time profile line is what makes fresh shells source env.sh.
+    return "If a new shell cannot find $CommandName, run once: $(Get-CodeIntelPosixProfileInstruction -Platform $script:EffectivePlatform)"
+}
+
 function New-ThinForwarderPs1 {
     param(
         [string]$RepoRoot,
@@ -504,7 +515,7 @@ function Install-SentruxShim {
             return
         }
 
-        Add-InstallAction $Actions "sentrux-shim" "installed" "$shimDir (thin forwarder -> $Root) path=$($pathResult.detail)" "Open a new terminal if this shell cannot find sentrux from PATH." "repo-local" $false
+        Add-InstallAction $Actions "sentrux-shim" "installed" "$shimDir (thin forwarder -> $Root) path=$($pathResult.detail)" (Get-PathRefreshFix "sentrux") "repo-local" $false
     }
     catch {
         Add-InstallAction $Actions "sentrux-shim" "install_failed" $_.Exception.Message "Check write permission for the code-intel bin directory." "repo-local" $false
@@ -565,10 +576,43 @@ function Install-CodeIntelBinary {
             throw "installed binary failed --help: $($help -join [Environment]::NewLine)"
         }
         $digest = (Get-FileHash -LiteralPath $destination -Algorithm SHA256).Hash.ToLowerInvariant()
-        Add-InstallAction $Actions "code-intel" "installed" "$destination sha256=$digest path=$($pathResult.detail)" "Open a new terminal if this shell cannot resolve code-intel from PATH." "repo-local" $false
+        Add-InstallAction $Actions "code-intel" "installed" "$destination sha256=$digest path=$($pathResult.detail)" (Get-PathRefreshFix "code-intel") "repo-local" $false
+        Install-IntegrationsManifest $Actions $Root $binDir
     }
     catch {
         Add-InstallAction $Actions "code-intel" "install_failed" $_.Exception.Message "Check write permission for the code-intel bin directory and close any process locking the old binary." "repo-local" $false
+    }
+}
+
+function Install-IntegrationsManifest {
+    param(
+        [System.Collections.Generic.List[object]]$Actions,
+        [string]$Root,
+        [string]$BinDir
+    )
+
+    # The installed binary resolves orchestration/integrations.json by walking
+    # up from its own directory (discover_manifest in
+    # crates/code-intel-cli/src/capability.rs probes each ancestor of the exe
+    # dir for orchestration/integrations.json). Copy the repo manifest to the
+    # first candidate of that walk, <bin>/orchestration/integrations.json, so
+    # the installed binary works without a repo checkout. Overwrites on
+    # reinstall to keep the copy current.
+    $manifestSource = Join-Path (Join-Path $Root "orchestration") "integrations.json"
+    if (-not (Test-Path -LiteralPath $manifestSource -PathType Leaf)) {
+        Add-InstallAction $Actions "integrations-manifest" "install_failed" "missing $manifestSource" "Restore orchestration/integrations.json from the repository." "repo-local" $false
+        return
+    }
+
+    try {
+        $manifestDir = Join-Path $BinDir "orchestration"
+        New-Item -ItemType Directory -Force -Path $manifestDir | Out-Null
+        $destination = Join-Path $manifestDir "integrations.json"
+        Copy-Item -LiteralPath $manifestSource -Destination $destination -Force
+        Add-InstallAction $Actions "integrations-manifest" "installed" $destination "" "repo-local" $false
+    }
+    catch {
+        Add-InstallAction $Actions "integrations-manifest" "install_failed" $_.Exception.Message "Check write permission for the code-intel bin directory." "repo-local" $false
     }
 }
 
@@ -855,6 +899,7 @@ switch ($script:EffectivePlatform) {
 }
 Add-InstallPlan $installPlan "repowise" "pip" "python/python3 -m pip install --user repowise==$script:RepowisePinnedVersion" "Semantic index and wiki/docs memory." "MEDIUM: Python package supply chain; installed version is pinned to repowise==$script:RepowisePinnedVersion." "Skip repowise with -SkipRepowise for exact-search-only runs." "pip" $false
 Add-InstallPlan $installPlan "code-intel" "repo-local release binary" "copy bin/code-intel or target/release/code-intel into CODE_INTEL_BIN; build with cargo when no binary is present" "Manifest-bound DAG, evidence query, impact analysis, and atomic publication." "LOW: Pipeline-owned binary; installed digest is reported and --help is executed before success." "Use code-intel.ps1 only when the compiled command needs recovery." "repo-local" $false
+Add-InstallPlan $installPlan "integrations-manifest" "repo-local" "copy orchestration/integrations.json into CODE_INTEL_BIN/orchestration so the installed binary resolves capabilities outside a repo checkout" "Capability registry for the installed code-intel binary; overwritten on every reinstall." "LOW: repo-owned JSON manifest copied verbatim." "Set CODE_INTEL_INTEGRATIONS_MANIFEST to point at a custom manifest instead." "repo-local" $false
 $sentruxBinaryName = if ($script:EffectivePlatform -eq "windows") { "sentrux.exe" } else { "sentrux" }
 Add-InstallPlan $installPlan "sentrux" "repo-local shim or preinstalled binary" "install tools/sentrux-shim first; optionally place a real $sentruxBinaryName on PATH" "Structural quality and regression gate." "LOW for repo-owned shim; MEDIUM for any separately supplied $sentruxBinaryName." "The repo-owned sentrux-lite core keeps scan/check/gate/plugin usable until the real binary is installed." "repo-local" $false
 Add-InstallPlan $installPlan "sentrux-shim" "repo-local" "copy tools/sentrux-shim launcher to CODE_INTEL_BIN and prepend PATH" "Opt-in local Pro activation, stable forwarding to real sentrux, and deterministic lite-core fallback." "LOW: repo-owned PowerShell/CMD/sh shim; review tools/sentrux-shim before install." "Pro auto-activation is off by default; set SENTRUX_AUTO_PRO=1 to opt in." "repo-local" $false

--- a/scripts/tests/test-regression-fixes.ps1
+++ b/scripts/tests/test-regression-fixes.ps1
@@ -906,6 +906,246 @@ Test-Case "check-code-intel-tools.ps1 fails CODE_INTEL_HOME pointing at a missin
 }
 
 # ---------------------------------------------------------------------------
+# Issue #59 proposal 3a: on macOS/Linux the platform module additionally
+# maintains a POSIX env file (~/.config/code-intel/env.sh) so fresh bash/zsh
+# sessions keep PATH and CODE_INTEL_HOME. The POSIX logic lives in small pure
+# helpers plus -Platform-parameterized branches, so everything below runs on
+# Windows. The *Windows* persistence branches of Set-CodeIntelUserEnv /
+# Add-UserPathPrefix write the real user registry and are intentionally NOT
+# invoked here.
+# ---------------------------------------------------------------------------
+. (Get-ScriptFunctionsSource -Path (Join-Path $root "tools\code-intel-platform.psm1") -Only @(
+    "Get-CodeIntelPlatform",
+    "Get-CodeIntelPosixProfileInstruction",
+    "ConvertTo-CodeIntelPosixEnvLine",
+    "Update-CodeIntelPosixEnvContent",
+    "Update-CodeIntelPosixEnvFile",
+    "Set-CodeIntelUserEnv",
+    "Add-UserPathPrefix"
+))
+
+Test-Case "posix env: profile instruction is the single copy-paste source line per platform" {
+    Assert-Equal "echo 'source ~/.config/code-intel/env.sh' >> ~/.zshrc" (Get-CodeIntelPosixProfileInstruction -Platform macos) "macos instruction must target ~/.zshrc"
+    Assert-Equal "echo 'source ~/.config/code-intel/env.sh' >> ~/.bashrc" (Get-CodeIntelPosixProfileInstruction -Platform linux) "linux instruction must target ~/.bashrc"
+}
+
+Test-Case "posix env: export lines render the PATH prefix form and escape sh metacharacters" {
+    Assert-Equal 'export PATH="/opt/code-intel/bin:$PATH"' (ConvertTo-CodeIntelPosixEnvLine -Name "PATH" -Value "/opt/code-intel/bin" -AsPathPrefix) "PATH prefix line must keep the trailing `$PATH expandable"
+    Assert-Equal 'export CODE_INTEL_HOME="/home/user/code-intel"' (ConvertTo-CodeIntelPosixEnvLine -Name "CODE_INTEL_HOME" -Value "/home/user/code-intel") "plain export line"
+    Assert-Equal 'export X="a\$b\"c\\d"' (ConvertTo-CodeIntelPosixEnvLine -Name "X" -Value 'a$b"c\d') "dollar, quote, and backslash must be escaped inside the double quotes"
+}
+
+Test-Case "posix env: content updates are idempotent and replace same-variable exports" {
+    $pathLine = ConvertTo-CodeIntelPosixEnvLine -Name "PATH" -Value "/opt/code-intel/bin" -AsPathPrefix
+    $once = Update-CodeIntelPosixEnvContent -Lines @() -Line $pathLine
+    $twice = Update-CodeIntelPosixEnvContent -Lines $once -Line $pathLine
+    Assert-Equal ($once -join "`n") ($twice -join "`n") "re-adding the same PATH line must not duplicate it"
+    Assert-Equal 1 @($twice).Count "exactly one PATH line after two identical updates"
+
+    $otherPathLine = ConvertTo-CodeIntelPosixEnvLine -Name "PATH" -Value "/opt/other/bin" -AsPathPrefix
+    $withOther = Update-CodeIntelPosixEnvContent -Lines $twice -Line $otherPathLine
+    Assert-Equal 2 @($withOther).Count "a different directory must keep its own PATH line"
+
+    $homePattern = '^\s*export\s+CODE_INTEL_HOME='
+    $v1 = Update-CodeIntelPosixEnvContent -Lines $withOther -MatchPattern $homePattern -Line (ConvertTo-CodeIntelPosixEnvLine -Name "CODE_INTEL_HOME" -Value "/old/home")
+    $v2 = Update-CodeIntelPosixEnvContent -Lines $v1 -MatchPattern $homePattern -Line (ConvertTo-CodeIntelPosixEnvLine -Name "CODE_INTEL_HOME" -Value "/new/home")
+    Assert-Equal 3 @($v2).Count "a same-variable export must be replaced, not appended"
+    Assert-True (($v2 -join "`n").Contains('/new/home')) "replacement must keep the newest value"
+    Assert-False (($v2 -join "`n").Contains('/old/home')) "the stale value must be dropped"
+}
+
+Test-Case "posix env: Add-UserPathPrefix (linux branch) maintains env.sh and returns the copy-paste instruction" {
+    $dir = New-ScratchDir "posix-pathprefix"
+    $savedPath = $env:PATH
+    try {
+        $script:PosixTestHome = Join-Path $dir "home"
+        New-Item -ItemType Directory -Force -Path $script:PosixTestHome | Out-Null
+        function Get-CodeIntelHomeDirectory { return $script:PosixTestHome }
+
+        $binDir = Join-Path $dir "bin"
+        $result = Add-UserPathPrefix -PathToAdd $binDir -Platform linux
+        Assert-False $result.persisted "non-Windows PATH persistence stays opt-in (persisted=false)"
+        Assert-True ($result.detail.Contains("echo 'source ~/.config/code-intel/env.sh' >> ~/.bashrc")) "detail must carry the single copy-paste line (issue #59 proposal 3a)"
+
+        $envSh = Join-Path (Join-Path (Join-Path $script:PosixTestHome ".config") "code-intel") "env.sh"
+        Assert-True (Test-Path -LiteralPath $envSh -PathType Leaf) "env.sh must be written under ~/.config/code-intel"
+        $expectedLine = ConvertTo-CodeIntelPosixEnvLine -Name "PATH" -Value $result.path -AsPathPrefix
+        $lines = @(Get-Content -LiteralPath $envSh)
+        Assert-Equal 1 @($lines | Where-Object { $_ -ceq $expectedLine }).Count "env.sh must contain exactly one PATH export for the directory"
+
+        Add-UserPathPrefix -PathToAdd $binDir -Platform linux | Out-Null
+        $lines = @(Get-Content -LiteralPath $envSh)
+        Assert-Equal 1 @($lines | Where-Object { $_ -ceq $expectedLine }).Count "a reinstall must not duplicate the PATH export"
+
+        $firstEntry = @($env:PATH -split [regex]::Escape([string][System.IO.Path]::PathSeparator))[0]
+        Assert-Equal $result.path $firstEntry "the process PATH must still be prefixed"
+    }
+    finally {
+        $env:PATH = $savedPath
+        Remove-Item -Recurse -Force $dir -ErrorAction SilentlyContinue
+    }
+}
+
+Test-Case "posix env: Set-CodeIntelUserEnv (linux branch) rewrites env.ps1 + env.sh idempotently" {
+    $dir = New-ScratchDir "posix-setenv"
+    $savedValue = $env:CIP_TEST_POSIX_ENV
+    try {
+        $script:PosixTestHome = $dir
+        function Get-CodeIntelHomeDirectory { return $script:PosixTestHome }
+
+        Set-CodeIntelUserEnv -Name "CIP_TEST_POSIX_ENV" -Value "/repo/v1" -Platform linux | Out-Null
+        $result = Set-CodeIntelUserEnv -Name "CIP_TEST_POSIX_ENV" -Value "/repo/v2" -Platform linux
+        Assert-Equal "/repo/v2" $env:CIP_TEST_POSIX_ENV "the process environment must carry the newest value"
+        Assert-False $result.persisted "non-Windows env persistence stays opt-in (persisted=false)"
+        Assert-True ($result.detail.Contains("echo 'source ~/.config/code-intel/env.sh' >> ~/.bashrc")) "detail must carry the single copy-paste line"
+
+        $configDir = Join-Path (Join-Path $dir ".config") "code-intel"
+        $shLines = @(Get-Content -LiteralPath (Join-Path $configDir "env.sh"))
+        Assert-Equal 1 @($shLines).Count "env.sh must hold a single export for the variable after two writes"
+        Assert-Equal 'export CIP_TEST_POSIX_ENV="/repo/v2"' $shLines[0] "the env.sh export must be replaced with the newest value"
+
+        $psLines = @(Get-Content -LiteralPath (Join-Path $configDir "env.ps1"))
+        Assert-Equal 1 @($psLines).Count "env.ps1 must be rewritten idempotently, not appended (old behavior accumulated duplicates)"
+        Assert-Equal "`$env:CIP_TEST_POSIX_ENV = '/repo/v2'" $psLines[0] "the env.ps1 line must carry the newest value"
+    }
+    finally {
+        if ($null -ne $savedValue) { $env:CIP_TEST_POSIX_ENV = $savedValue } else { Remove-Item Env:CIP_TEST_POSIX_ENV -ErrorAction SilentlyContinue }
+        Remove-Item -Recurse -Force $dir -ErrorAction SilentlyContinue
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Issue #59 proposal 3b: the installer copies orchestration/integrations.json
+# next to the installed binary (<bin>/orchestration/) — the first candidate of
+# discover_manifest's exe-ancestor walk in crates/code-intel-cli/src/capability.rs
+# — so the installed code-intel works outside a repo checkout.
+# ---------------------------------------------------------------------------
+. (Get-ScriptFunctionsSource -Path (Join-Path $root "install-code-intel-pipeline.ps1") -Only @(
+    "Add-InstallAction",
+    "Install-IntegrationsManifest"
+))
+
+Test-Case "installer: Install-IntegrationsManifest copies the manifest beside the binary and overwrites on reinstall" {
+    $dir = New-ScratchDir "manifest-copy"
+    try {
+        $repoRoot = Join-Path $dir "repo"
+        $binDir = Join-Path $dir "bin"
+        New-Item -ItemType Directory -Force -Path (Join-Path $repoRoot "orchestration"), $binDir | Out-Null
+        $sourceManifest = Join-Path (Join-Path $repoRoot "orchestration") "integrations.json"
+        Set-Content -LiteralPath $sourceManifest -Value '{"integrations":[]}' -Encoding UTF8
+
+        $actions = New-Object System.Collections.Generic.List[object]
+        Install-IntegrationsManifest $actions $repoRoot $binDir
+        $destination = Join-Path (Join-Path $binDir "orchestration") "integrations.json"
+        Assert-True (Test-Path -LiteralPath $destination -PathType Leaf) "manifest must land at <bin>/orchestration/integrations.json (first candidate of the discover_manifest ancestor walk)"
+        Assert-Equal "installed" $actions[0].status "the copy must be reported as installed in the install actions"
+        Assert-Equal $destination $actions[0].detail "the reported detail must be the installed manifest path"
+
+        Set-Content -LiteralPath $sourceManifest -Value '{"integrations":[{"id":"x"}]}' -Encoding UTF8
+        Install-IntegrationsManifest $actions $repoRoot $binDir
+        Assert-True ((Get-Content -LiteralPath $destination -Raw).Contains('"id"')) "a reinstall must overwrite the previously copied manifest"
+    }
+    finally {
+        Remove-Item -Recurse -Force $dir -ErrorAction SilentlyContinue
+    }
+}
+
+Test-Case "installer: Install-IntegrationsManifest reports install_failed when the repo manifest is missing" {
+    $dir = New-ScratchDir "manifest-missing"
+    try {
+        $repoRoot = Join-Path $dir "repo"
+        $binDir = Join-Path $dir "bin"
+        New-Item -ItemType Directory -Force -Path $repoRoot, $binDir | Out-Null
+
+        $actions = New-Object System.Collections.Generic.List[object]
+        Install-IntegrationsManifest $actions $repoRoot $binDir
+        Assert-Equal "install_failed" $actions[0].status "a missing repo manifest must be reported, not silently skipped"
+        Assert-False (Test-Path -LiteralPath (Join-Path (Join-Path $binDir "orchestration") "integrations.json")) "no manifest file may be fabricated"
+    }
+    finally {
+        Remove-Item -Recurse -Force $dir -ErrorAction SilentlyContinue
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Issue #59 proposal 4: the doctor's graph-provider check must build its paths
+# with chained Join-Path (single literal 'a\b\c' segments never exist on
+# mac/linux), use the platform binary name, and accept target/release builds in
+# addition to target/debug. Exercised black-box against a scratch pipeline root
+# so binary/source presence is controlled exactly.
+# ---------------------------------------------------------------------------
+function New-DoctorScratchRoot {
+    param([string]$Dir)
+
+    Copy-Item -LiteralPath (Join-Path $root "check-code-intel-tools.ps1") -Destination (Join-Path $Dir "check-code-intel-tools.ps1")
+    New-Item -ItemType Directory -Force -Path (Join-Path $Dir "tools") | Out-Null
+    Copy-Item -LiteralPath (Join-Path $root "tools\code-intel-platform.psm1") -Destination (Join-Path $Dir "tools\code-intel-platform.psm1")
+
+    $crateDir = Join-Path (Join-Path $Dir "crates") "code-intel-cli"
+    New-Item -ItemType Directory -Force -Path (Join-Path $crateDir "src") | Out-Null
+    Set-Content -LiteralPath (Join-Path $crateDir "Cargo.toml") -Value "[package]" -Encoding UTF8
+    Set-Content -LiteralPath (Join-Path (Join-Path $crateDir "src") "graph.rs") -Value "// graph provider" -Encoding UTF8
+}
+
+function Invoke-DoctorScratch {
+    param(
+        [string]$Dir,
+        [string[]]$ExtraArgs = @()
+    )
+
+    $raw = @(& pwsh -NoLogo -NoProfile -File (Join-Path $Dir "check-code-intel-tools.ps1") -Json @ExtraArgs 2>&1)
+    return ($raw -join "`n") | ConvertFrom-Json
+}
+
+Test-Case "doctor graph provider: a target/release platform binary satisfies the binary check" {
+    $dir = New-ScratchDir "doctor-graph-release"
+    try {
+        New-DoctorScratchRoot $dir
+        $binaryName = if ($IsWindows) { "code-intel.exe" } else { "code-intel" }
+        $releaseBinary = Join-Path (Join-Path (Join-Path $dir "target") "release") $binaryName
+        New-Item -ItemType Directory -Force -Path (Split-Path -Parent $releaseBinary) | Out-Null
+        Set-Content -LiteralPath $releaseBinary -Value "fake binary" -Encoding UTF8
+
+        $json = Invoke-DoctorScratch $dir @("-RequireUnderstand")
+        Assert-True $json.checks.graphProvider.sourceFound "chained Join-Path must find crates/code-intel-cli/src/graph.rs"
+        Assert-True $json.checks.graphProvider.cargoFound "chained Join-Path must find crates/code-intel-cli/Cargo.toml"
+        Assert-True $json.checks.graphProvider.binaryFound "a target/release build must satisfy the binary check (regression: only target\debug\code-intel.exe was probed)"
+        Assert-Equal $releaseBinary $json.checks.graphProvider.binaryPath "binaryPath must report the discovered release binary"
+        Assert-True ($json.checks.graphProvider.command.Contains($releaseBinary)) "the command hint must reference the discovered release binary"
+        Assert-False ([bool](@($json.missing) -contains "internal graph provider source")) "-RequireUnderstand must not report a false MISSING graph provider source"
+        Assert-False ([bool](@($json.missing) -contains "code-intel Rust runtime")) "-RequireUnderstand must not report a false MISSING Rust runtime"
+    }
+    finally {
+        Remove-Item -Recurse -Force $dir -ErrorAction SilentlyContinue
+    }
+}
+
+Test-Case "doctor graph provider: debug fallback still detected; absent binary reports a platform-correct hint" {
+    $dir = New-ScratchDir "doctor-graph-debug"
+    try {
+        New-DoctorScratchRoot $dir
+        $binaryName = if ($IsWindows) { "code-intel.exe" } else { "code-intel" }
+        $debugBinary = Join-Path (Join-Path (Join-Path $dir "target") "debug") $binaryName
+        New-Item -ItemType Directory -Force -Path (Split-Path -Parent $debugBinary) | Out-Null
+        Set-Content -LiteralPath $debugBinary -Value "fake binary" -Encoding UTF8
+
+        $json = Invoke-DoctorScratch $dir
+        Assert-True $json.checks.graphProvider.binaryFound "a target/debug build must still satisfy the binary check"
+        Assert-Equal $debugBinary $json.checks.graphProvider.binaryPath "binaryPath must report the debug binary when no release build exists"
+
+        Remove-Item -LiteralPath $debugBinary -Force
+        $json = Invoke-DoctorScratch $dir
+        Assert-False $json.checks.graphProvider.binaryFound "no built binary must report binaryFound=false"
+        Assert-Equal "" ([string]$json.checks.graphProvider.binaryPath) "binaryPath must be empty when nothing is built"
+        $expectedHint = Join-Path (Join-Path (Join-Path $dir "target") "release") $binaryName
+        Assert-True ($json.checks.graphProvider.command.Contains($expectedHint)) "the command hint must fall back to the platform-correct release candidate path"
+    }
+    finally {
+        Remove-Item -Recurse -Force $dir -ErrorAction SilentlyContinue
+    }
+}
+
+# ---------------------------------------------------------------------------
 # Fail-open lint: scan all tracked .ps1 files in the repo for catch blocks
 # that return/emit a permissive boolean ($true) directly, which is the exact
 # anti-pattern all 7 fixes above were closing. A whitelist mechanism exists

--- a/tools/code-intel-platform.psm1
+++ b/tools/code-intel-platform.psm1
@@ -142,6 +142,75 @@ function Get-CodeIntelPaths {
     }
 }
 
+function Get-CodeIntelPosixProfileInstruction {
+    # Pure: the single copy-paste line that makes new POSIX shells pick up
+    # ~/.config/code-intel/env.sh. macOS defaults to zsh, Linux to bash.
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet("macos", "linux")]
+        [string]$Platform
+    )
+
+    $shellProfile = if ($Platform -eq "macos") { "~/.zshrc" } else { "~/.bashrc" }
+    return "echo 'source ~/.config/code-intel/env.sh' >> $shellProfile"
+}
+
+function ConvertTo-CodeIntelPosixEnvLine {
+    # Pure: renders one POSIX sh export line with the value double-quoted and
+    # sh metacharacters escaped. -AsPathPrefix renders the PATH prefix form
+    # (export PATH="<dir>:$PATH") with the trailing $PATH left expandable.
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$Value,
+        [switch]$AsPathPrefix
+    )
+
+    $escaped = $Value.Replace('\', '\\').Replace('"', '\"').Replace('$', '\$').Replace('`', '\`')
+    if ($AsPathPrefix) {
+        return ('export {0}="{1}:$PATH"' -f $Name, $escaped)
+    }
+    return ('export {0}="{1}"' -f $Name, $escaped)
+}
+
+function Update-CodeIntelPosixEnvContent {
+    # Pure: idempotent line-set update. Drops any exact duplicate of $Line and
+    # any line matching $MatchPattern (a previous export of the same variable),
+    # then appends the canonical $Line once.
+    param(
+        [string[]]$Lines = @(),
+        [string]$MatchPattern = "",
+        [Parameter(Mandatory = $true)][string]$Line
+    )
+
+    $kept = @($Lines | Where-Object {
+        if ($_ -ceq $Line) { return $false }
+        if (-not [string]::IsNullOrEmpty($MatchPattern) -and $_ -match $MatchPattern) { return $false }
+        return $true
+    })
+    return @($kept + $Line)
+}
+
+function Update-CodeIntelPosixEnvFile {
+    # Rewrites ~/.config/code-intel/env.sh idempotently with the given line and
+    # returns the file path. Sourced from the user's shell profile so fresh
+    # bash/zsh sessions keep PATH and CODE_INTEL_* across installs.
+    param(
+        [string]$MatchPattern = "",
+        [Parameter(Mandatory = $true)][string]$Line
+    )
+
+    $configDir = Join-Path (Join-Path (Get-CodeIntelHomeDirectory) ".config") "code-intel"
+    New-Item -ItemType Directory -Force -Path $configDir | Out-Null
+    $envFile = Join-Path $configDir "env.sh"
+    $existing = @()
+    if (Test-Path -LiteralPath $envFile -PathType Leaf) {
+        $existing = @(Get-Content -LiteralPath $envFile)
+    }
+    $updated = Update-CodeIntelPosixEnvContent -Lines $existing -MatchPattern $MatchPattern -Line $Line
+    Set-Content -LiteralPath $envFile -Value $updated -Encoding UTF8
+    return $envFile
+}
+
 function Set-CodeIntelUserEnv {
     param(
         [Parameter(Mandatory = $true)][string]$Name,
@@ -161,11 +230,19 @@ function Set-CodeIntelUserEnv {
     New-Item -ItemType Directory -Force -Path $configDir | Out-Null
     $envFile = Join-Path $configDir "env.ps1"
     $escaped = $Value.Replace("'", "''")
-    "`$env:$Name = '$escaped'" | Add-Content -LiteralPath $envFile -Encoding UTF8
+    $pwshLines = @()
+    if (Test-Path -LiteralPath $envFile -PathType Leaf) {
+        $pwshLines = @(Get-Content -LiteralPath $envFile)
+    }
+    $pwshPattern = '^\s*\$env:' + [regex]::Escape($Name) + '\s*='
+    $pwshUpdated = Update-CodeIntelPosixEnvContent -Lines $pwshLines -MatchPattern $pwshPattern -Line "`$env:$Name = '$escaped'"
+    Set-Content -LiteralPath $envFile -Value $pwshUpdated -Encoding UTF8
+    $shPattern = '^\s*export\s+' + [regex]::Escape($Name) + '='
+    $shFile = Update-CodeIntelPosixEnvFile -MatchPattern $shPattern -Line (ConvertTo-CodeIntelPosixEnvLine -Name $Name -Value $Value)
     return [pscustomobject][ordered]@{
         name = $Name
         persisted = $false
-        detail = "process environment set; dot-source $envFile from your pwsh profile to persist"
+        detail = "process environment set; $shFile updated; run once: $(Get-CodeIntelPosixProfileInstruction -Platform $os)"
     }
 }
 
@@ -198,10 +275,11 @@ function Add-UserPathPrefix {
         return [pscustomobject][ordered]@{ path = $resolved; persisted = $true; detail = "user PATH" }
     }
 
+    $shFile = Update-CodeIntelPosixEnvFile -Line (ConvertTo-CodeIntelPosixEnvLine -Name "PATH" -Value $resolved -AsPathPrefix)
     return [pscustomobject][ordered]@{
         path = $resolved
         persisted = $false
-        detail = "process PATH only; add this directory to your shell profile"
+        detail = "process PATH updated; $shFile updated; run once: $(Get-CodeIntelPosixProfileInstruction -Platform $os)"
     }
 }
 
@@ -278,6 +356,10 @@ Export-ModuleMember -Function @(
     "Get-CodeIntelArtifactRoot",
     "Get-CodeIntelShadowRoot",
     "Get-CodeIntelPaths",
+    "Get-CodeIntelPosixProfileInstruction",
+    "ConvertTo-CodeIntelPosixEnvLine",
+    "Update-CodeIntelPosixEnvContent",
+    "Update-CodeIntelPosixEnvFile",
     "Set-CodeIntelUserEnv",
     "Add-UserPathPrefix",
     "New-CodeIntelLink",


### PR DESCRIPTION
Implements proposals **1, 3, 4** of #59 — the three `small` items behind the reported "install on mac/linux is painful" feedback.

## Proposal 3: env that survives a real shell + self-contained install

- `tools/code-intel-platform.psm1`: on macOS/Linux, `Add-UserPathPrefix` / `Set-CodeIntelUserEnv` now maintain an idempotent POSIX `~/.config/code-intel/env.sh` (duplicate-guarded `export PATH="<bin>:$PATH"` + `CODE_INTEL_HOME`) and return the one copy-paste line: `echo 'source ~/.config/code-intel/env.sh' >> ~/.zshrc` (`~/.bashrc` on Linux). Previously a fresh bash/zsh session lost everything (`env.ps1` was pwsh-only). Windows branches byte-identical.
- Installer fix text: "Open a new terminal" was wrong on non-Windows (new terminals don't inherit process-only PATH) — now platform-correct.
- New `Install-IntegrationsManifest`: copies `orchestration/integrations.json` next to the installed binary on **all** platforms. Verified against `capability.rs::discover_manifest` — the exe's own directory is the first ancestor probed, so an installed `code-intel` now works outside a repo checkout (previously errored "cannot locate orchestration/integrations.json").

## Proposal 4: doctor stops lying on mac/linux

`check-code-intel-tools.ps1` built graph-provider paths as literal backslash segments (`target\debug\code-intel.exe`) — never present on mac/linux, so doctor always printed a false "MISSING internal graph provider" (hard failure with `-RequireUnderstand`). Now: chained `Join-Path`, platform-aware binary name, `target/release` probed before `target/debug`, platform-correct fix hint.

## Proposal 1: README macOS/Linux quickstart

- Early router line in the 30-second quickstart sends non-Windows readers to a new `macOS / Linux 快速开始` section: honest support-tier statement (source-build-only — no release ZIP, no bootstrap.py), exact prerequisites (brew / apt + Microsoft repo, rustup — with the honest note that `-InstallMissing` does not install rustup), install command, per-platform bin dirs, the `env.sh` source line, first run.

## Verification

- Parser check 4/4 clean; `scripts/tests/test-regression-fixes.ps1` **42/42** including 9 new cases (POSIX helpers, linux-branch `env.sh` idempotency via the module's platform injection, manifest copy + overwrite-on-reinstall, doctor black-box: release found / debug fallback / absent → platform-correct hint).
- `internalization_record` + `capability_exec`: 75/75 (no digest pin fallout).
- Honest limits: real macOS/Linux shells can't be executed on this Windows host — the POSIX branches are covered by injected-platform unit tests; #59 proposal 6 (CI fresh-login-shell assertion) is the cross-platform ratchet that will exercise them for real.

Refs #59 — proposals 2, 5, 6 remain open there.
