### PR TITLE
feat(release): macos/linux release artifacts + cross-platform Skill bootstrap (#59 P2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,13 +5,19 @@ on:
     tags:
       - "v*"
 
+# Build jobs only need to read the repository. The write-capable scopes
+# (contents for release creation, id-token/attestations for provenance)
+# are granted only to the publish job below, so no build or validation
+# step ever holds a token that could publish or mutate a release.
 permissions:
-  contents: write
-  id-token: write
-  attestations: write
+  contents: read
 
 jobs:
-  release:
+  release-windows:
+    # Authoritative full release gate. Tag/version validation, Skill and
+    # Rust test suites, the authoritative self-scan, packaging, and
+    # packaged-payload validation all run here; publishing happens only in
+    # the publish job after every platform's package has passed its gates.
     runs-on: windows-latest
 
     steps:
@@ -222,19 +228,237 @@ jobs:
             if ($LASTEXITCODE -ne 0) { throw "packaged audit report failed --operation validate: $report" }
           }
 
+      - name: Upload release dist artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: release-dist-windows
+          path: |
+            dist/code-intel-pipeline-*-windows.zip
+            dist/code-intel-pipeline-*-windows.zip.sha256
+            dist/code-intel-pipeline-*-windows.zip.release-manifest.json
+          if-no-files-found: error
+
+  package-unix:
+    # Platform build + package lane. The windows job above stays the
+    # authoritative full gate; this lane still refuses to hand a package to
+    # publish unless the candidate passes its own self-scan and the packaged
+    # payload passes the same structural gates as the windows package.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            platform: macos
+          - os: ubuntu-latest
+            platform: linux
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.11"
+
+      - name: Setup Rust
+        shell: pwsh
+        run: |
+          rustup toolchain install
+          rustup show active-toolchain
+
+      - name: Install ripgrep
+        shell: pwsh
+        # Same recipe as ci.yml cross-platform-smoke. Homebrew has no
+        # supported way to pin a formula version, so the macOS install is
+        # unpinned; apt installs the distribution-pinned ripgrep.
+        run: |
+          if ($IsMacOS) {
+            brew install ripgrep
+          }
+          else {
+            sudo apt-get update
+            sudo apt-get install -y ripgrep
+          }
+
+      - name: Build Rust CLI
+        shell: pwsh
+        run: cargo build -p code-intel --release --locked
+
+      - name: Authoritative self-scan (release blocking)
+        shell: pwsh
+        run: |
+          $staging = Join-Path $env:RUNNER_TEMP "code-intel-release-self-scan"
+          $authority = Join-Path $env:RUNNER_TEMP "code-intel-release-self-authority"
+          New-Item -ItemType Directory -Force $authority | Out-Null
+          ./target/release/code-intel run execute --repo . --out $staging --authority-root $authority --final-name release-self-scan --manifest orchestration/integrations.json --doctor-require-repowise false
+          if ($LASTEXITCODE -ne 0) {
+            throw "release candidate failed its own scan (exit ${LASTEXITCODE}: 10 = architecture/domain gate failure, 70 = process failure). A failing self-scan must never publish."
+          }
+
+      - name: Package
+        shell: pwsh
+        run: |
+          $version = "${{ github.ref_name }}"
+          $platform = "${{ matrix.platform }}"
+          # Package from `git archive HEAD`, not the working tree: earlier
+          # steps must never be able to mutate what ships.
+          New-Item -ItemType Directory -Force dist/code-intel-pipeline/bin | Out-Null
+          git archive --format=zip -o dist/payload.zip HEAD
+          if ($LASTEXITCODE -ne 0) { throw "git archive failed" }
+          Expand-Archive -LiteralPath dist/payload.zip -DestinationPath dist/code-intel-pipeline -Force
+          Remove-Item dist/payload.zip
+          Copy-Item -LiteralPath target/release/code-intel -Destination dist/code-intel-pipeline/bin/code-intel -Force
+          chmod 755 dist/code-intel-pipeline/bin/code-intel
+          if ($LASTEXITCODE -ne 0) { throw "chmod failed with exit code ${LASTEXITCODE}" }
+          # Compress-Archive does not store POSIX file modes; the system zip
+          # binary records the executable bit in each entry's external
+          # attributes so the packaged binary stays runnable after unzip.
+          $zipLeaf = "code-intel-pipeline-$version-$platform.zip"
+          Push-Location dist
+          try {
+            zip -r $zipLeaf code-intel-pipeline
+            if ($LASTEXITCODE -ne 0) { throw "zip failed with exit code ${LASTEXITCODE}" }
+          }
+          finally {
+            Pop-Location
+          }
+          $zip = "dist/$zipLeaf"
+          $hash = (Get-FileHash -Algorithm SHA256 $zip).Hash.ToLowerInvariant()
+          "$hash *$(Split-Path -Leaf $zip)" | Set-Content -Encoding ascii "$zip.sha256"
+          $manifest = [ordered]@{
+            schema = "code-intel-release-manifest.v1"
+            tag = $version
+            commit = (git rev-parse HEAD).Trim()
+            zipSha256 = $hash
+            toolchain = (rustc --version).Trim()
+            builtAt = (Get-Date).ToUniversalTime().ToString("o")
+          }
+          $manifest | ConvertTo-Json | Set-Content -Encoding ascii "$zip.release-manifest.json"
+
+      - name: Validate packaged Skill bootstrap
+        shell: pwsh
+        run: |
+          $tag = "${{ github.ref_name }}"
+          $platform = "${{ matrix.platform }}"
+          $asset = "dist/code-intel-pipeline-$tag-$platform.zip"
+          $expanded = Join-Path $env:RUNNER_TEMP "code-intel-release-layout"
+          # Extract with the system unzip so POSIX modes are restored from
+          # the archive; running the packaged binary below then proves the
+          # executable bit survived the zip round trip.
+          unzip -q $asset -d $expanded
+          if ($LASTEXITCODE -ne 0) { throw "unzip failed with exit code ${LASTEXITCODE}" }
+          $payload = Join-Path $expanded "code-intel-pipeline"
+          $required = @(
+            (Join-Path $payload "install-code-intel-pipeline.ps1"),
+            (Join-Path $payload "code-intel.ps1"),
+            (Join-Path $payload "skills/code-intel-pipeline/SKILL.md"),
+            (Join-Path $payload "skills/code-intel-pipeline/agents/openai.yaml"),
+            (Join-Path $payload "skills/code-intel-pipeline/scripts/bootstrap.py"),
+            (Join-Path $payload "bin/code-intel")
+          )
+          foreach ($path in $required) {
+            if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+              throw "Release package is missing required file: $path"
+            }
+          }
+          python (Join-Path $payload "skills/code-intel-pipeline/scripts/bootstrap.py") --help
+          $packagedBinary = Join-Path $payload "bin/code-intel"
+          bash -c "test -x '$packagedBinary'"
+          if ($LASTEXITCODE -ne 0) { throw "packaged binary lost its executable bit in the zip round trip: $packagedBinary" }
+          # The packaged binary must pass its own structural gates against the
+          # packaged payload: release green, self-scan green, and published
+          # artifact green must refer to the same snapshot content.
+          & $packagedBinary sentrux --operation check --repo $payload
+          if ($LASTEXITCODE -ne 0) { throw "packaged binary failed its own structural check" }
+          & $packagedBinary sentrux --operation gate --repo $payload
+          if ($LASTEXITCODE -ne 0) { throw "packaged binary failed its own no-degradation gate" }
+
+          # ai-safety-003 (issue #34): if the packaged snapshot carries an
+          # audit report, it must pass the same fail-closed validate
+          # pipeline against the packaged payload, using the packaged
+          # binary -- same guarantee as the windows package validation.
+          $packagedReports = Get-ChildItem -LiteralPath $payload -Recurse -Filter "audit-report.json" -File -ErrorAction SilentlyContinue |
+            Select-Object -ExpandProperty FullName
+          foreach ($report in $packagedReports) {
+            Write-Host "Validating packaged audit report: $report"
+            & $packagedBinary audit --operation validate --repo $payload --report $report
+            if ($LASTEXITCODE -ne 0) { throw "packaged audit report failed --operation validate: $report" }
+          }
+
+      - name: Upload release dist artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: release-dist-${{ matrix.platform }}
+          path: |
+            dist/code-intel-pipeline-*-${{ matrix.platform }}.zip
+            dist/code-intel-pipeline-*-${{ matrix.platform }}.zip.sha256
+            dist/code-intel-pipeline-*-${{ matrix.platform }}.zip.release-manifest.json
+          if-no-files-found: error
+
+  publish:
+    # Single release creator: every platform package must already have
+    # passed its build, self-scan, and packaged-payload gates before this
+    # job runs, and only this job holds a write-capable token.
+    runs-on: ubuntu-latest
+    needs:
+      - release-windows
+      - package-unix
+
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+
+    steps:
+      - name: Download release dist artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: "release-dist-*"
+          path: dist
+          merge-multiple: true
+
+      - name: Verify release inventory
+        shell: pwsh
+        run: |
+          $tag = "${{ github.ref_name }}"
+          foreach ($platform in @("windows", "macos", "linux")) {
+            $zip = "dist/code-intel-pipeline-$tag-$platform.zip"
+            foreach ($path in @($zip, "$zip.sha256", "$zip.release-manifest.json")) {
+              if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+                throw "Release asset is missing: $path -- a partial release must never publish."
+              }
+            }
+            $hash = (Get-FileHash -Algorithm SHA256 $zip).Hash.ToLowerInvariant()
+            $sidecar = (Get-Content -Raw -LiteralPath "$zip.sha256").Trim()
+            $expected = "$hash *$(Split-Path -Leaf $zip)"
+            if ($sidecar -cne $expected) {
+              throw "Checksum sidecar mismatch for ${zip}: expected '$expected', found '$sidecar'."
+            }
+          }
+
       - name: Attest build provenance
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
-          subject-path: "dist/code-intel-pipeline-*-windows.zip"
+          subject-path: "dist/code-intel-pipeline-*.zip"
 
       - name: Create GitHub Release
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
+          # No checkout in this job; gh must be told the target repository.
+          GH_REPO: ${{ github.repository }}
         run: |
           $tag = "${{ github.ref_name }}"
-          $asset = "dist\code-intel-pipeline-$tag-windows.zip"
-          $assets = @($asset, "$asset.sha256", "$asset.release-manifest.json")
+          $assets = @()
+          foreach ($platform in @("windows", "macos", "linux")) {
+            $asset = "dist/code-intel-pipeline-$tag-$platform.zip"
+            $assets += @($asset, "$asset.sha256", "$asset.release-manifest.json")
+          }
           gh release view $tag *> $null
           if ($LASTEXITCODE -eq 0) {
             # No --clobber: a leaked contents:write token must not be able to

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ code-intel C:\path\to\your\repo
 
 ## macOS / Linux 快速开始
 
-**支持等级**：macOS / Linux 目前只支持源码构建安装。Release ZIP 和 `bootstrap.py` 引导只覆盖 Windows（同 [Public beta guide](docs/public-beta.md)）。所有入口脚本都要求 PowerShell 7.2+（`pwsh`），README 里其余 `.ps1` 命令在 macOS / Linux 上同样用 `pwsh` 运行。
+**支持等级**：对已发布的版本（v0.6.0 及更早），macOS / Linux 只支持源码构建安装——这些版本的 Release ZIP 和 `bootstrap.py` 引导只覆盖 Windows。从下一个 release 起，每个版本会同时发布 windows / macos / linux 三个 Release ZIP，`bootstrap.py` 引导在 macOS / Linux 上同样可用（详见 [Public beta guide](docs/public-beta.md)）。所有入口脚本都要求 PowerShell 7.2+（`pwsh`），README 里其余 `.ps1` 命令在 macOS / Linux 上同样用 `pwsh` 运行。
 
 前置依赖（macOS，Homebrew）：
 

--- a/docs/public-beta.md
+++ b/docs/public-beta.md
@@ -2,10 +2,17 @@
 
 ## Supported surface
 
-The public beta ships as a Windows ZIP. The stable entrypoint is the packaged
-`bin/code-intel.exe`; `code-intel.ps1` is the PowerShell 7.2+ recovery launcher
-and `invoke-code-intel.ps1` is a v0.x compatibility forwarder. A release package must not require Cargo, a source-tree
-`target/` directory, or a local Rust installation.
+Existing public beta releases (v0.6.0 and earlier) ship a Windows ZIP only.
+From the next tag onward, every release ships three ZIPs:
+`code-intel-pipeline-<tag>-windows.zip`, `code-intel-pipeline-<tag>-macos.zip`,
+and `code-intel-pipeline-<tag>-linux.zip`. The stable entrypoint is the
+packaged `bin/code-intel.exe` on Windows and `bin/code-intel` on macOS/Linux;
+`code-intel.ps1` is the PowerShell recovery launcher and
+`invoke-code-intel.ps1` is a v0.x compatibility forwarder. PowerShell 7.2+
+(`pwsh`) is required on every platform, including macOS and Linux, because the
+installer and launchers are implemented in PowerShell. A release package must
+not require Cargo, a source-tree `target/` directory, or a local Rust
+installation.
 
 The beta core covers repository inventory, Sentrux structural evidence,
 transactional artifact publication, failure classification, and the
@@ -32,22 +39,32 @@ surface is the optional compatibility adapter and its artifact contract.
 
 ## Install and verify
 
-1. Download the release ZIP and its `.sha256` file.
+1. Download the release ZIP for your platform (`windows`, `macos`, or `linux`)
+   and its `.sha256` file.
 2. Verify the checksum with `Get-FileHash -Algorithm SHA256`.
-3. Verify the build provenance attestation (requires `gh` 2.49+):
+3. Verify the build provenance attestation (requires `gh` 2.49+). The same
+   check applies to all three platform ZIPs:
 
 ```powershell
-gh attestation verify .\code-intel-pipeline-<tag>-windows.zip --repo 2233admin/code-intel-pipeline
+gh attestation verify .\code-intel-pipeline-<tag>-<platform>.zip --repo 2233admin/code-intel-pipeline
 ```
 
    The release workflow signs every ZIP with GitHub Artifact Attestations
    (`actions/attest-build-provenance`); a failed verification means the asset
    was not produced by this repository's release workflow and must not be run.
 4. Extract the ZIP to a writable directory.
-5. Run:
+5. Run (Windows):
 
 ```powershell
 .\bin\code-intel.exe C:\path\to\repo
+```
+
+   On macOS/Linux (`chmod` is only needed if your unzip tool did not preserve
+   the execute bit; `bootstrap.py` restores it automatically):
+
+```bash
+chmod +x ./bin/code-intel
+./bin/code-intel ~/path/to/repo
 ```
 
 Use `--mode lite` or `--mode full` only when the default `normal` profile is
@@ -56,7 +73,10 @@ used when available.
 
 ## Known limits
 
-- The beta release package is Windows-only.
+- Release packages published up to and including v0.6.0 are Windows-only;
+  installing them on macOS/Linux is not supported. Releases from the next tag
+  onward ship windows/macos/linux ZIPs, and macOS/Linux still require
+  PowerShell 7.2+ (`pwsh`) for the installer and launchers.
 - External providers can be unavailable, rate-limited, or unconfigured. Their
   outcomes are reported rather than rewritten as local success.
 - Understand Anything graph generation still depends on its host integration.

--- a/skills/code-intel-pipeline/scripts/bootstrap.py
+++ b/skills/code-intel-pipeline/scripts/bootstrap.py
@@ -39,6 +39,11 @@ WINDOWS_RESERVED_NAMES = {
     *(f"com{index}" for index in ("¹", "²", "³")),
     *(f"lpt{index}" for index in ("¹", "²", "³")),
 }
+PLATFORM_NAMES = {
+    "win32": "windows",
+    "darwin": "macos",
+    "linux": "linux",
+}
 MAX_ARCHIVE_MEMBERS = 10_000
 MAX_ARCHIVE_BYTES = 512 * 1024 * 1024
 MAX_MEMBER_BYTES = 256 * 1024 * 1024
@@ -49,6 +54,25 @@ RELEASE_MARKER = ".code-intel-release.json"
 
 class BootstrapError(RuntimeError):
     """Raised when the release cannot be installed safely."""
+
+
+def resolve_platform_name(platform: str) -> str:
+    """Map a ``sys.platform`` value onto a release asset platform name."""
+    platform_name = PLATFORM_NAMES.get(platform)
+    if platform_name is None:
+        supported = ", ".join(
+            f"{key} ({value})" for key, value in sorted(PLATFORM_NAMES.items())
+        )
+        raise BootstrapError(
+            f"Unsupported platform for the published Skill bootstrap: {platform!r}. "
+            f"Supported platforms: {supported}."
+        )
+    return platform_name
+
+
+def release_binary_name(platform_name: str) -> str:
+    """Packaged CLI binary file name for a release platform."""
+    return "code-intel.exe" if platform_name == "windows" else "code-intel"
 
 
 def request_json(url: str) -> Any:
@@ -282,6 +306,27 @@ def validated_archive_members(
     return validated
 
 
+def member_unix_mode(member: zipfile.ZipInfo) -> int | None:
+    """POSIX permission bits stored in a zip member, or None when absent.
+
+    ``zipfile`` does not restore modes on extraction, so archives built on a
+    POSIX host record them in the high 16 bits of ``external_attr`` and we
+    re-apply them ourselves. Archives built on Windows leave those bits zero.
+    """
+    permissions = stat.S_IMODE(member.external_attr >> 16)
+    if permissions == 0:
+        return None
+    return permissions
+
+
+def restore_member_mode(member: zipfile.ZipInfo, target: Path) -> None:
+    if os.name == "nt":
+        return
+    mode = member_unix_mode(member)
+    if mode is not None:
+        target.chmod(mode)
+
+
 def safe_extract_zip(archive: Path, destination: Path) -> None:
     destination.mkdir(parents=True, exist_ok=True)
     destination_root = destination.resolve()
@@ -312,6 +357,7 @@ def safe_extract_zip(archive: Path, destination: Path) -> None:
                 raise BootstrapError(
                     f"Release archive member size mismatch: {member.filename!r}"
                 )
+            restore_member_mode(member, target)
 
 
 def find_payload_root(extracted_root: Path) -> Path:
@@ -370,11 +416,27 @@ def manifest_digest(manifest: dict[str, dict[str, Any]]) -> str:
     return hashlib.sha256(canonical).hexdigest()
 
 
-def default_install_root() -> Path:
+def default_data_root() -> Path:
+    override = os.environ.get("CODE_INTEL_DATA_ROOT")
+    if override:
+        return Path(override).expanduser()
+    platform_name = PLATFORM_NAMES.get(sys.platform)
+    if platform_name == "macos":
+        return Path.home() / "Library" / "Application Support" / "code-intel"
+    if platform_name == "linux":
+        xdg_data_home = os.environ.get("XDG_DATA_HOME")
+        base = Path(xdg_data_home).expanduser() if xdg_data_home else (
+            Path.home() / ".local" / "share"
+        )
+        return base / "code-intel"
     local_app_data = os.environ.get("LOCALAPPDATA")
     if not local_app_data:
         local_app_data = str(Path.home() / "AppData" / "Local")
-    return Path(local_app_data) / "code-intel" / "releases"
+    return Path(local_app_data) / "code-intel"
+
+
+def default_install_root() -> Path:
+    return default_data_root() / "releases"
 
 
 def find_pwsh() -> str:
@@ -382,8 +444,30 @@ def find_pwsh() -> str:
     if executable:
         return executable
     raise BootstrapError(
-        "PowerShell 7.2+ (pwsh) is required by the published Windows installer."
+        "PowerShell 7.2+ (pwsh) is required on every platform because the "
+        "published installer is implemented in PowerShell."
     )
+
+
+def ensure_release_binary_executable(release_root: Path, platform_name: str) -> None:
+    """Fail closed unless the packaged CLI binary is runnable on this platform.
+
+    Windows does not use POSIX execute bits, so the check only applies to the
+    macos/linux payloads, which always ship ``bin/code-intel``.
+    """
+    if platform_name == "windows":
+        return
+    binary = release_root / "bin" / release_binary_name(platform_name)
+    if not binary.is_file():
+        raise BootstrapError(
+            f"Release payload is missing the packaged binary: {binary}"
+        )
+    if not os.access(binary, os.X_OK):
+        binary.chmod(0o755)
+    if not os.access(binary, os.X_OK):
+        raise BootstrapError(
+            f"Packaged binary is not executable after restoring permissions: {binary}"
+        )
 
 
 def command_result(
@@ -530,22 +614,20 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def run(args: argparse.Namespace) -> dict[str, Any]:
-    if sys.platform != "win32":
-        raise BootstrapError(
-            "The published Skill bootstrap currently supports Windows releases only."
-        )
+    platform_name = resolve_platform_name(sys.platform)
     repo_path = args.repo_path.expanduser().resolve()
     if not repo_path.is_dir():
         raise BootstrapError(f"Repository path does not exist: {repo_path}")
     install_root = args.install_root.expanduser().resolve()
     requested_version = resolve_version(args.version, args.channel)
     release = fetch_release(requested_version, args.channel)
-    asset = select_release_asset(release, "windows")
+    asset = select_release_asset(release, platform_name)
     actual_channel = "prerelease" if release.get("prerelease") else "stable"
     plan: dict[str, Any] = {
         "schema": "code-intel-skill-bootstrap.v1",
         "status": "planned" if args.dry_run else "installing",
         "channel": actual_channel,
+        "platform": platform_name,
         "tag": asset["tag"],
         "version_source": (
             "explicit"
@@ -564,6 +646,7 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
         return plan
 
     release_root, install_status = install_release(asset, install_root)
+    ensure_release_binary_executable(release_root, platform_name)
     pwsh = find_pwsh()
     installer = release_root / "install-code-intel-pipeline.ps1"
     install_command = [
@@ -586,7 +669,7 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
 
     environment = os.environ.copy()
     environment["CODE_INTEL_HOME"] = str(release_root)
-    data_root = Path(os.environ.get("LOCALAPPDATA", str(Path.home()))) / "code-intel"
+    data_root = default_data_root()
     environment["PATH"] = (
         str(data_root / "bin") + os.pathsep + environment.get("PATH", "")
     )

--- a/tests/test_skill_package.py
+++ b/tests/test_skill_package.py
@@ -4,6 +4,7 @@ import hashlib
 import importlib.util
 import json
 import shutil
+import stat
 import tempfile
 import unittest
 import zipfile
@@ -97,6 +98,103 @@ class SkillPackageTests(unittest.TestCase):
 
         with self.assertRaises(bootstrap.BootstrapError):
             bootstrap.select_release_asset(release, "windows")
+
+    def test_maps_sys_platform_to_release_platform_names(self) -> None:
+        bootstrap = load_bootstrap_module()
+        self.assertEqual(bootstrap.resolve_platform_name("win32"), "windows")
+        self.assertEqual(bootstrap.resolve_platform_name("darwin"), "macos")
+        self.assertEqual(bootstrap.resolve_platform_name("linux"), "linux")
+        with self.assertRaises(bootstrap.BootstrapError):
+            bootstrap.resolve_platform_name("freebsd14")
+
+    def test_release_binary_name_is_platform_specific(self) -> None:
+        bootstrap = load_bootstrap_module()
+        self.assertEqual(bootstrap.release_binary_name("windows"), "code-intel.exe")
+        self.assertEqual(bootstrap.release_binary_name("macos"), "code-intel")
+        self.assertEqual(bootstrap.release_binary_name("linux"), "code-intel")
+
+    def test_selects_release_asset_for_each_platform(self) -> None:
+        bootstrap = load_bootstrap_module()
+        release = {
+            "tag_name": "v1.2.3",
+            "assets": [
+                {
+                    "name": f"code-intel-pipeline-v1.2.3-{platform_name}.zip",
+                    "browser_download_url": (
+                        "https://github.com/2233admin/code-intel-pipeline/"
+                        f"releases/download/v1.2.3/{platform_name}.zip"
+                    ),
+                    "digest": "sha256:" + ("a" * 64),
+                }
+                for platform_name in ("windows", "macos", "linux")
+            ],
+        }
+        for platform_name in ("windows", "macos", "linux"):
+            with self.subTest(platform=platform_name):
+                selected = bootstrap.select_release_asset(release, platform_name)
+                self.assertEqual(
+                    selected["name"],
+                    f"code-intel-pipeline-v1.2.3-{platform_name}.zip",
+                )
+
+    def test_member_unix_mode_honors_external_attributes(self) -> None:
+        bootstrap = load_bootstrap_module()
+        posix_member = zipfile.ZipInfo("code-intel-pipeline/bin/code-intel")
+        posix_member.external_attr = (stat.S_IFREG | 0o755) << 16
+        self.assertEqual(bootstrap.member_unix_mode(posix_member), 0o755)
+
+        windows_member = zipfile.ZipInfo("code-intel-pipeline/bin/code-intel.exe")
+        self.assertIsNone(bootstrap.member_unix_mode(windows_member))
+
+        with tempfile.TemporaryDirectory() as temp:
+            archive = Path(temp) / "release.zip"
+            with zipfile.ZipFile(archive, "w") as handle:
+                handle.writestr(posix_member, "binary")
+            with zipfile.ZipFile(archive) as handle:
+                reloaded = handle.infolist()[0]
+                self.assertEqual(bootstrap.member_unix_mode(reloaded), 0o755)
+
+    def test_restore_member_mode_applies_posix_modes(self) -> None:
+        bootstrap = load_bootstrap_module()
+        member = zipfile.ZipInfo("code-intel-pipeline/bin/code-intel")
+        member.external_attr = (stat.S_IFREG | 0o755) << 16
+        target = mock.Mock()
+        with mock.patch.object(bootstrap.os, "name", "posix"):
+            bootstrap.restore_member_mode(member, target)
+        target.chmod.assert_called_once_with(0o755)
+
+        modeless_member = zipfile.ZipInfo("code-intel-pipeline/readme.txt")
+        untouched = mock.Mock()
+        with mock.patch.object(bootstrap.os, "name", "posix"):
+            bootstrap.restore_member_mode(modeless_member, untouched)
+        untouched.chmod.assert_not_called()
+
+    def test_ensure_release_binary_executable_fails_closed(self) -> None:
+        bootstrap = load_bootstrap_module()
+        with tempfile.TemporaryDirectory() as temp:
+            release_root = Path(temp) / "v1.2.3"
+            (release_root / "bin").mkdir(parents=True)
+
+            bootstrap.ensure_release_binary_executable(release_root, "windows")
+
+            with self.assertRaises(bootstrap.BootstrapError):
+                bootstrap.ensure_release_binary_executable(release_root, "linux")
+
+            binary = release_root / "bin" / "code-intel"
+            binary.write_bytes(b"binary")
+            with mock.patch.object(
+                bootstrap.os, "access", return_value=False
+            ), mock.patch.object(
+                bootstrap.Path, "chmod", autospec=True
+            ) as chmod:
+                with self.assertRaises(bootstrap.BootstrapError):
+                    bootstrap.ensure_release_binary_executable(
+                        release_root, "linux"
+                    )
+            chmod.assert_called_once_with(binary, 0o755)
+
+            with mock.patch.object(bootstrap.os, "access", return_value=True):
+                bootstrap.ensure_release_binary_executable(release_root, "linux")
 
     def test_fetch_release_enforces_requested_channel_and_publication(self) -> None:
         bootstrap = load_bootstrap_module()

--- a/tools/New-BetaPackage.ps1
+++ b/tools/New-BetaPackage.ps1
@@ -7,6 +7,7 @@ param(
     [string]$OutputDirectory,
     [string]$PackageName = "code-intel-pipeline-windows-beta",
     [string]$ExpectedVersion,
+    [string]$BinaryName = "code-intel.exe",
     [switch]$AllowDirty,
     [switch]$DevelopmentOnlyAllowUnresolvedLicense
 )
@@ -31,9 +32,13 @@ function Get-RelativeSlashPath {
     return [System.IO.Path]::GetRelativePath($BasePath, $Path).Replace([System.IO.Path]::DirectorySeparatorChar, '/')
 }
 
+if ($BinaryName -notmatch '^[A-Za-z0-9._-]+$') {
+    throw "BinaryName must be a bare file name, got '$BinaryName'."
+}
+
 $script:RepoRoot = (Resolve-Path -LiteralPath $RepoPath).Path
 if (-not $ExecutablePath) {
-    $ExecutablePath = Join-Path $script:RepoRoot "target/release/code-intel.exe"
+    $ExecutablePath = Join-Path $script:RepoRoot "target/release/$BinaryName"
 }
 if (-not $OutputDirectory) {
     $OutputDirectory = Join-Path $script:RepoRoot "dist"
@@ -133,7 +138,7 @@ foreach ($relativePath in $sourceFiles) {
     }
     Copy-Item -LiteralPath $sourcePath -Destination $targetPath -Force
 }
-Copy-Item -LiteralPath $resolvedExecutable -Destination (Join-Path $packageRoot "bin/code-intel.exe") -Force
+Copy-Item -LiteralPath $resolvedExecutable -Destination (Join-Path $packageRoot "bin/$BinaryName") -Force
 
 $inventory = @(Get-ChildItem -LiteralPath $packageRoot -File -Recurse | Sort-Object FullName | ForEach-Object {
     [ordered]@{
@@ -143,7 +148,7 @@ $inventory = @(Get-ChildItem -LiteralPath $packageRoot -File -Recurse | Sort-Obj
     }
 })
 $lockPath = Join-Path $script:RepoRoot "Cargo.lock"
-$binaryHash = (Get-FileHash -LiteralPath (Join-Path $packageRoot "bin/code-intel.exe") -Algorithm SHA256).Hash.ToLowerInvariant()
+$binaryHash = (Get-FileHash -LiteralPath (Join-Path $packageRoot "bin/$BinaryName") -Algorithm SHA256).Hash.ToLowerInvariant()
 $generatedAt = [DateTimeOffset]::UtcNow.ToString('o')
 $releaseManifest = [ordered]@{
     schema = "code-intel-beta-release-manifest.v1"

--- a/tools/Test-BetaPackage.ps1
+++ b/tools/Test-BetaPackage.ps1
@@ -6,6 +6,7 @@ param(
     [string]$ZipPath,
     [string]$ChecksumPath = "$ZipPath.sha256",
     [string]$ManifestPath,
+    [string]$BinaryName = "code-intel.exe",
     [switch]$AllowDirty,
     [switch]$DevelopmentOnlyAllowUnresolvedLicense,
     [switch]$Json
@@ -18,6 +19,10 @@ $PSNativeCommandUseErrorActionPreference = $false
 function Assert-Condition {
     param([bool]$Condition, [string]$Message)
     if (-not $Condition) { throw $Message }
+}
+
+if ($BinaryName -notmatch '^[A-Za-z0-9._-]+$') {
+    throw "BinaryName must be a bare file name, got '$BinaryName'."
 }
 
 $resolvedZip = (Resolve-Path -LiteralPath $ZipPath).Path
@@ -121,10 +126,10 @@ try {
     }
     Assert-Condition ($parserErrors.Count -eq 0) "Packaged PowerShell scripts contain parser errors."
 
-    $executable = Join-Path $packageRoot "bin/code-intel.exe"
-    Assert-Condition (Test-Path -LiteralPath $executable -PathType Leaf) "Package is missing bin/code-intel.exe."
+    $executable = Join-Path $packageRoot "bin/$BinaryName"
+    Assert-Condition (Test-Path -LiteralPath $executable -PathType Leaf) "Package is missing bin/$BinaryName."
     $helpText = (& $executable --help 2>&1) -join "`n"
-    Assert-Condition ($LASTEXITCODE -eq 0) "Packaged code-intel.exe --help failed."
+    Assert-Condition ($LASTEXITCODE -eq 0) "Packaged $BinaryName --help failed."
     Assert-Condition ($helpText -match 'code-intel') "Packaged CLI help output is unexpected."
 
     $invokeWrapper = Join-Path $packageRoot "code-intel.ps1"


### PR DESCRIPTION
Implements proposal **2** of #59: every release from the next tag ships `code-intel-pipeline-<tag>-{windows,macos,linux}.zip`, and the Skill bootstrap installs them on all three platforms.

## release.yml: one gate chain, three packages, one publisher

- **release-windows** — the existing authoritative chain (tag/version validation, skill tests, fmt/check/test, self-scan, package, packaged-payload validation) unchanged; now uploads its dist as a workflow artifact instead of publishing directly.
- **package-unix** (macos-latest / ubuntu-latest matrix) — `cargo build --release --locked`, the same release-blocking self-scan, packaging via `chmod 755` + system `zip` (PowerShell `Compress-Archive` cannot carry POSIX modes), identical `.sha256` sidecar and `code-intel-release-manifest.v1` fields, and a packaged validation that **executes the binary straight from the extracted zip** — proving the exec bit survived the round trip.
- **publish** (`needs` both) — downloads all dists, fail-closed 9-asset inventory with sidecar re-hash, attests all three ZIPs, then the original no-clobber `gh release` logic extended to 9 assets. **Privilege split**: workflow-level permissions dropped to `contents: read`; only `publish` holds `contents:write + id-token + attestations` — no build step ever sees a write-capable token.

## bootstrap.py: platform map + executable-bit restore

- `win32`-only raise → platform map (`windows`/`macos`/`linux`; clear error otherwise), threaded into asset selection and recorded in the plan JSON.
- POSIX modes restored from `ZipInfo.external_attr` during extraction; after install, a fail-closed check ensures `bin/code-intel` is executable (fallback `chmod 0o755`).
- pwsh 7.2+ requirement kept, message made platform-neutral.

## Also

- `New-BetaPackage.ps1` / `Test-BetaPackage.ps1`: `-BinaryName` parameter (default `code-intel.exe`, bare-name guard) — existing callers unaffected.
- `docs/public-beta.md` + README: honest versioned statement — releases ≤ v0.6.0 stay Windows-only; next tag onward ships all three; attestation verify applies to every ZIP.

## Verification

- `python tests/test_skill_package.py` / `test_repository_layout.py`: OK (new cases: platform map incl. unsupported-platform error, mode-restore from crafted ZipInfo).
- `yaml.safe_load` on release.yml passes; all embedded pwsh blocks parser-checked; action pins verified (`download-artifact` pin confirmed = v4.3.0 via `git ls-remote`, chosen to match the repo's upload-artifact v4 generation).
- Honest limit: the workflow fires only on tag push, so the new jobs cannot run on this PR — first real exercise is the next release tag. The unix self-scan invocation is identical to what cross-platform-smoke already gates on both OSes per PR. macOS ripgrep via brew is unpinned (no supported pinning; mirrors the existing ci.yml precedent, noted in a workflow comment).

Refs #59 — proposals 5 (cargo install / brew) and 6 (CI real-user assertions) remain open there.
