### PR TITLE
T2 launcher (1/n): 分类审计 + --mode 独立轴 (#47)

### DIFF
--- a/crates/code-intel-cli/src/execution_policy.rs
+++ b/crates/code-intel-cli/src/execution_policy.rs
@@ -21,6 +21,41 @@ impl RunProfile {
     }
 }
 
+/// How much work a run does, ported from the launcher's `-Mode`.
+///
+/// Deliberately a separate axis from [`RunProfile`]: the profile says how
+/// strictly providers are *required*, the mode says how much is *attempted*.
+/// A strict lite run is a meaningful combination, so the two must not be
+/// flattened into one enum — see docs/ps1-exit/t2-launcher-classification.md §2.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) enum RunMode {
+    /// Skip the optional structural stage; the fastest useful run.
+    Lite,
+    #[default]
+    Normal,
+    /// Normal plus the deeper understand sweep.
+    Full,
+}
+
+impl RunMode {
+    pub(crate) fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "lite" => Ok(Self::Lite),
+            "normal" => Ok(Self::Normal),
+            "full" => Ok(Self::Full),
+            _ => Err("--mode must be lite, normal, or full".into()),
+        }
+    }
+
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Lite => "lite",
+            Self::Normal => "normal",
+            Self::Full => "full",
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum WorkingTreePolicy {
     HeadOnly,
@@ -77,6 +112,7 @@ pub(crate) enum EffectPolicy {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct ExecutionPolicy {
     profile: RunProfile,
+    mode: RunMode,
     working_tree: WorkingTreePolicy,
     scopes: Vec<String>,
     providers: ProviderPolicy,
@@ -114,12 +150,33 @@ impl ExecutionPolicy {
         };
         Self {
             profile,
+            mode: RunMode::Normal,
             working_tree: WorkingTreePolicy::ExplicitOverlay,
             scopes: vec![".".into()],
             providers,
             effects: EffectPolicy::RegistryDeclared,
             tool_path_prefix: None,
         }
+    }
+
+    /// Compose the run mode onto the profile's requirement policy.
+    ///
+    /// Mode may only *narrow within what the profile already permits*. `lite`
+    /// drops the structural stage when the profile left it optional, but a
+    /// profile that marks it `Required` keeps it: otherwise `--mode lite`
+    /// would be a way to silently disarm a strict run, which is the same
+    /// hazard `with_doctor_overrides` already refuses. `Offline` stays
+    /// disabled regardless — mode never re-enables.
+    pub(crate) fn with_mode(mut self, mode: RunMode) -> Self {
+        self.mode = mode;
+        if mode == RunMode::Lite && self.providers.sentrux == ProviderRequirement::Optional {
+            self.providers.sentrux = ProviderRequirement::Disabled;
+        }
+        self
+    }
+
+    pub(crate) fn mode(&self) -> RunMode {
+        self.mode
     }
 
     pub(crate) fn with_working_tree(
@@ -243,6 +300,63 @@ mod tests {
         assert!(!offline.capability_enabled("provider.graph-adapt"));
         assert!(!offline.capability_enabled("provider.sentrux-adapt"));
         assert!(!offline.provider_diagnosis_enabled());
+    }
+
+    #[test]
+    fn mode_is_a_separate_axis_and_leaves_the_profile_intact() {
+        // Mode and profile are orthogonal: every combination has to stay
+        // expressible, so composing a mode must not change which profile the
+        // policy reports or what `normal`/`full` require.
+        for mode in [RunMode::Lite, RunMode::Normal, RunMode::Full] {
+            let policy = ExecutionPolicy::for_profile(RunProfile::Default).with_mode(mode);
+            assert_eq!(policy.profile, RunProfile::Default);
+            assert_eq!(policy.mode(), mode);
+        }
+        let normal = ExecutionPolicy::for_profile(RunProfile::Default).with_mode(RunMode::Normal);
+        let full = ExecutionPolicy::for_profile(RunProfile::Default).with_mode(RunMode::Full);
+        assert_eq!(normal.providers, full.providers);
+        assert!(normal.capability_enabled("provider.sentrux-adapt"));
+    }
+
+    #[test]
+    fn lite_drops_the_structural_stage_only_where_the_profile_left_it_optional() {
+        let lite = ExecutionPolicy::for_profile(RunProfile::Default).with_mode(RunMode::Lite);
+        assert!(!lite.capability_enabled("provider.sentrux-adapt"));
+        // The graph stage is Required under Default and must survive lite.
+        assert!(lite.capability_enabled("provider.graph-adapt"));
+        assert!(lite.provider_diagnosis_enabled());
+    }
+
+    #[test]
+    fn lite_cannot_disarm_a_strict_run_or_reenable_an_offline_one() {
+        // The hazard this pins: if `--mode lite` could drop a Required
+        // capability, it would be a compatibility flag that silently weakens
+        // a strict gate — exactly what with_doctor_overrides already refuses.
+        let strict = ExecutionPolicy::for_profile(RunProfile::Strict).with_mode(RunMode::Lite);
+        assert!(strict.providers.sentrux.is_required());
+        assert!(strict.capability_enabled("provider.sentrux-adapt"));
+
+        let compatibility =
+            ExecutionPolicy::for_profile(RunProfile::Compatibility).with_mode(RunMode::Lite);
+        assert!(compatibility.providers.sentrux.is_required());
+
+        // ...and mode never turns anything back on.
+        for mode in [RunMode::Lite, RunMode::Normal, RunMode::Full] {
+            let offline = ExecutionPolicy::for_profile(RunProfile::Offline).with_mode(mode);
+            assert_eq!(offline.providers.sentrux, ProviderRequirement::Disabled);
+            assert_eq!(offline.providers.graph, ProviderRequirement::Disabled);
+            assert!(!offline.provider_diagnosis_enabled());
+        }
+    }
+
+    #[test]
+    fn mode_parsing_accepts_the_launchers_vocabulary_and_rejects_the_rest() {
+        assert_eq!(RunMode::parse("lite").unwrap(), RunMode::Lite);
+        assert_eq!(RunMode::parse("normal").unwrap(), RunMode::Normal);
+        assert_eq!(RunMode::parse("full").unwrap(), RunMode::Full);
+        assert_eq!(RunMode::default(), RunMode::Normal);
+        assert!(RunMode::parse("deep").is_err());
+        assert!(RunMode::parse("").is_err());
     }
 
     #[test]

--- a/crates/code-intel-cli/src/run_cli.rs
+++ b/crates/code-intel-cli/src/run_cli.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use crate::dag_run::{self, DagExecutionRequest};
 use crate::execution_kernel;
-use crate::execution_policy::{ExecutionPolicy, RunProfile, WorkingTreePolicy};
+use crate::execution_policy::{ExecutionPolicy, RunMode, RunProfile, WorkingTreePolicy};
 use crate::run_error::RunError;
 
 pub(crate) fn run_raw(raw: &[String]) -> i32 {
@@ -77,6 +77,7 @@ impl Cli {
             RunCommand::DagCoordinate => RunProfile::Compatibility,
             RunCommand::Execute => RunProfile::Default,
         };
+        let mut mode = RunMode::default();
         let mut session_evidence = None;
         let mut index = 1;
         while index < raw.len() {
@@ -89,6 +90,7 @@ impl Cli {
                     | "--final-name"
                     | "--manifest"
                     | "--profile"
+                    | "--mode"
                     | "--max-concurrency"
                     | "--working-tree-policy"
                     | "--scope"
@@ -126,6 +128,12 @@ impl Cli {
                         return Err("--profile is available only for run execute".into());
                     }
                     profile = RunProfile::parse(value)?;
+                }
+                "--mode" => {
+                    if command != RunCommand::Execute {
+                        return Err("--mode is available only for run execute".into());
+                    }
+                    mode = RunMode::parse(value)?;
                 }
                 "--max-concurrency" => {
                     max_concurrency = value
@@ -238,7 +246,11 @@ impl Cli {
                 }
             }
         }
+        // Mode composes after the profile so it can only narrow what the
+        // profile permits, and before the doctor overrides so those keep the
+        // last word on provider requirements.
         let policy = ExecutionPolicy::for_profile(profile)
+            .with_mode(mode)
             .with_working_tree(WorkingTreePolicy::parse(&working_tree_policy)?, scopes)
             .with_doctor_overrides(
                 doctor_require_repowise,
@@ -262,7 +274,7 @@ impl Cli {
 }
 
 fn usage() -> String {
-    "usage: run <dag-coordinate|execute> --repo <repo-root> --out <run-staging-directory> [--authority-root <publication-root> --final-name <name>] [--profile <default|strict|offline>] [--manifest <integrations.json>] [--max-concurrency <n>] [--working-tree-policy <head_only|explicit_overlay>] [--scope <relative-path>]... [--session-evidence <session-evidence.json>] [--diagnosis-inputs <artifact-refs.json> --seed-artifact-root <root>] [--doctor-tool-path-prefix <directory>] [--doctor-require-repowise <true|false>] [--doctor-require-understand <true|false>]".into()
+    "usage: run <dag-coordinate|execute> --repo <repo-root> --out <run-staging-directory> [--authority-root <publication-root> --final-name <name>] [--profile <default|strict|offline>] [--mode <lite|normal|full>] [--manifest <integrations.json>] [--max-concurrency <n>] [--working-tree-policy <head_only|explicit_overlay>] [--scope <relative-path>]... [--session-evidence <session-evidence.json>] [--diagnosis-inputs <artifact-refs.json> --seed-artifact-root <root>] [--doctor-tool-path-prefix <directory>] [--doctor-require-repowise <true|false>] [--doctor-require-understand <true|false>]".into()
 }
 
 fn parse_bool_flag(flag: &str, value: &str) -> Result<bool, String> {

--- a/docs/ps1-exit/t2-launcher-classification.md
+++ b/docs/ps1-exit/t2-launcher-classification.md
@@ -1,0 +1,174 @@
+# T2 launcher classification (issue #47)
+
+Working document for retiring `archive/run-code-intel.ps1` (4742 lines, 90
+function definitions, 72 parameters) into `code-intel run` plus a ≤50-line
+thin forwarder.
+
+Every claim below is a measurement taken against `origin/main` at
+`02f0444`, not an estimate. Uncertain rows are marked `?` with the reason,
+following the T1 discipline in [contract-inventory.md](contract-inventory.md).
+
+## 0. The blocker T1 did not name
+
+`run-code-intel.ps1` is not only an entry point. It is also a **function
+library that two PowerShell test suites dot-source out of**, via
+`Get-ScriptFunctionsSource -Path .../run-code-intel.ps1 -Only @(...)`:
+
+| test file | functions pulled | subject |
+|---|---|---|
+| `archive/scripts/tests/test-hospital-trust-contract.ps1` | 18 | hospital state machine, diagnosis, scoring |
+| `archive/scripts/tests/test-regression-fixes.ps1` | 9 | code-evidence symbol extraction (6 languages) |
+| `archive/scripts/tests/test-regression-fixes.ps1` | 3 | sentrux gate metric deltas / no-degradation |
+| `archive/scripts/tests/test-regression-fixes.ps1` | 4 | hospital state machine + surgery target |
+
+34 function references in total. **Shrinking the launcher to a forwarder
+deletes the subject of those tests.** No amount of parameter forwarding
+avoids this: the tests reach past the parameter surface into the file body.
+
+This is why the ticket's exit criterion (`≤50 lines`) cannot be met by
+routing alone, and why T2 necessarily touches test assets that the campaign
+map assigns to T7.
+
+### Why retiring them is safe rather than a coverage loss
+
+Both subjects already have native implementations with their own integration
+suites on the Rust side:
+
+| PowerShell subject | Rust owner | Rust test suite |
+|---|---|---|
+| hospital state machine / diagnosis / scoring | `crates/code-intel-cli/src/hospital_diagnosis.rs` (558 lines) | `tests/hospital_diagnosis.rs` — 978 lines, 10 tests |
+| code-evidence symbol extraction | `crates/code-intel-cli/src/native_code_evidence.rs` (718 lines) | `tests/native_code_evidence.rs` — 511 lines, 6 tests |
+| sentrux gate metric deltas | `crates/code-intel-cli/src/sentrux_gate.rs` (1080 lines) | exercised by the repo's own `sentrux gate` self-scan in CI |
+
+The PowerShell copies are duplicate implementations of logic the Rust DAG
+already runs in production — `diagnosis.hospital` and `evidence.native-code`
+are live DAG nodes in every `code-intel run execute`. Retiring the
+PowerShell copies removes duplication, not coverage.
+
+**Not yet verified, and required before deletion (`?`):** that each of the 16
+Rust tests asserts the *same* behaviour as the PowerShell test it would
+replace, case for case. A per-function mapping table has to land in the
+retirement PR; "a Rust suite exists" is not by itself evidence that a
+specific assertion survives. Treat any PowerShell case with no Rust
+counterpart as a gap to close before the file is deleted, not after.
+
+## 1. Parameter classification
+
+72 parameters. The three buckets the ticket asks for.
+
+### 1.1 Already covered by `code-intel run execute`
+
+The Rust runner already accepts these concepts; T2 only needs flag aliases
+and the config-alias resolution the PowerShell side did.
+
+| PowerShell | Rust today | note |
+|---|---|---|
+| `-RepoPath` | `--repo` | direct |
+| `-Repo` (alias via `pipeline.config.json`) | — | alias resolution itself must port; `code-intel doctor bootstrap` already ports the same `repos`/`sentruxPath` lookup in `doctor_bootstrap/config.rs` and can be reused |
+| `-ArtifactRoot` | `--authority-root` / `--out` | staging vs authority split differs; see §3 |
+| `-Platform` | implicit from target | no flag needed |
+| `-DagCoordinate` | `run dag-coordinate` | already a subcommand |
+
+### 1.2 To port
+
+Mode and the Skip/Allow switches are the substance. The architectural home
+is already there: `ExecutionPolicy` in `crates/code-intel-cli/src/execution_policy.rs`
+compiles a profile into an immutable `ProviderPolicy`, and `dag_run.rs`
+already gates node inclusion on `policy.capability_enabled(...)` and
+`policy.provider_diagnosis_enabled()`. Skip flags become policy inputs, not
+branches in a script.
+
+Load-bearing property to preserve: `with_doctor_overrides` refuses to weaken
+`Strict` or re-enable `Offline`. Any new Skip flag must inherit that
+guarantee, or a compatibility flag becomes a way to silently disarm a strict
+run.
+
+| behaviour | current PS1 anchor | target |
+|---|---|---|
+| `-Mode lite\|normal\|full` | mode gates the sentrux stage and repowise docs | a `RunProfile`-adjacent input, not a fourth profile — see §2 |
+| `-SkipRepowise` / `-SkipSentrux` / `-SkipSentruxCheck` / `-SkipSentruxGate` | per-stage gates | `ProviderRequirement::Disabled` on the matching capability |
+| `-SkipOpenSpec` / `-AutoOpenSpec` | OpenSpec stage | `?` — no Rust DAG node exists for OpenSpec today |
+| `-SkipRepomix` / `-RepomixStyle` / `-RepomixCompress` | external `repomix` invocation | `?` — no Rust node; may belong in the dead bucket if unconsumed |
+| `-RequireUnderstandGraph` | missing graph is fatal vs advisory | maps onto `providers.understand` requirement |
+| `-SaveSentruxBaseline` / `-AutoSaveMissingSentruxBaseline` | writes `.sentrux/baseline.json` inside the scanned repo | needs an explicit effect declaration; writing into the scanned tree is a declared effect, not a side effect |
+| `-InventoryExclude` | feeds the `rg` inventory | `inventory.rg` node options |
+| `-ProactiveSkillSuggestions` / `-AutomaticPullRequests` / `-BugSkill` | follow-up automation block in the hospital report | `?` — consumer is the hospital report renderer |
+| multi-artifact publishing (`report.json`, `summary.md`, `understanding.md`, `hospital.md`) | `:4179-4182` area | Rust publishes a run manifest; the markdown views are PS1-only today |
+
+### 1.3 Declare dead
+
+| item | evidence | why dead |
+|---|---|---|
+| `-SkipGitHubResearch` | T1 §1.1 and §7.1: zero other references to `$SkipGitHubResearch`; `$githubResearch` is unconditionally the `New-GitHubSolutionResearchNotApplicable` stub regardless of the flag | the switch has no effect at all — five test files pass it and none assert on it, because there is nothing to assert |
+| `Test-GitHubSolutionResearchRequired` | T1 §1.1: defined, zero call sites | dead function reachable only by dot-sourcing |
+
+Both were recorded by T1 as findings and deliberately left unfixed there
+("record, don't fix"). T2 is the ticket that removes them.
+
+### 1.4 Route away rather than port
+
+The eight early-exit facades (T1 §1.8) are already thin forwarders into the
+Rust CLI. Their retirement work is *stop routing through the launcher*, not
+*port logic*, because the logic already lives in Rust:
+
+`-ModelInventoryResult`, `-ModelAdapterRequest`, `-RepowiseAdapterRequest`,
+`-GraphAdapterRequest`, `-SentruxAdapterRequest`, `-CodeNexusAdapterRequest`,
+`-SurvivalScanRequest`, `-RunCommitManifestRef` (plus their companion
+`*ArtifactRoot`/`*EvaluatedAt`/`*MaxAgeSeconds` parameters).
+
+Each already resolves `target/debug/<exe>`, invokes a subcommand, and
+`exit $LASTEXITCODE`. Callers should invoke `code-intel` directly; the
+forwarder does not need to reproduce them.
+
+`-SentruxAdapterArtifactRoot`, `-SentruxAdapterEvaluatedAt` and
+`-SentruxAdapterMaxAgeSeconds` are additionally never passed by any live
+caller — measured across every non-frozen `.ps1`/`.yml` in the tree.
+
+## 2. Open design question: what `-Mode` becomes
+
+`RunProfile` already has four values (`Default`, `Strict`, `Offline`,
+`Compatibility`) that describe *provider requirement policy*. `-Mode`
+(`lite`/`normal`/`full`) describes *how much work to do*. These are
+orthogonal — a strict lite run is meaningful — so `-Mode` must not be
+flattened into `RunProfile`.
+
+Recommended: a separate `--mode` input that adjusts which optional nodes
+enter the DAG, composed with, never overriding, the profile's requirement
+policy. Deciding this before writing code matters, because collapsing the
+two axes is the kind of mistake that is expensive to reverse once the flag
+is public.
+
+## 3. Known contract divergences to resolve during the port
+
+Carried from T1 §5 and §7, all still true at `02f0444`:
+
+1. **Exit codes.** `run execute` distinguishes `10` (architecture/domain
+   gate) from `70` (process failure). The launcher only ever exits `0` or
+   `1`. The forwarder must decide whether to propagate the richer code or
+   collapse it; propagating is preferable but is a behaviour change for
+   anything parsing the old binary outcome.
+2. **`run-complete.json` name collision.** Both sides write a file with that
+   name under different schemas. They never coexist in one directory today,
+   but tooling that globs for it across both pipelines will mis-parse.
+3. **Hospital shape drift.** Both producers claim schema
+   `code-intel-hospital.v1`; PS1 nests its verdict under `triage`, Rust under
+   `diagnosis` + `domainVerdict`. The schema string is not currently a
+   guarantee of shape compatibility.
+4. **Two paths to "sentrux skipped".** `-Mode lite` and `-SkipSentrux`
+   produce the same user-visible outcome with different `error` text. The
+   port has to pick one.
+
+## 4. Sequencing
+
+1. Land this classification. *(this commit)*
+2. Resolve §2 (`--mode` axis) and §3.1 (exit-code contract) — both are
+   public-surface decisions that are cheap now and expensive later.
+3. Port §1.2 into `ExecutionPolicy` + `dag_run`, with the strict/offline
+   non-weakening guarantee extended to every new switch.
+4. Build the per-function mapping table for §0 and close any assertion gaps
+   on the Rust side.
+5. Delete the dead items in §1.3, retire the duplicated PowerShell functions
+   and their tests, shrink the launcher to a forwarder.
+6. Repoint `ci.yml`, `release.yml`, `README.md` and the skill docs to the
+   binary; keep the forwarder as a documented compatibility entry point.
+7. T1 parity harness green across the forwarder and the direct path.


### PR DESCRIPTION
## T2 launcher 收编：分类审计 + `--mode` 轴

issue #47 的前两步。**这不是完整的 T2** —— `run-code-intel.ps1` 仍是 4742 行，没有降到 ≤50 行。本 PR 落的是审计结论和第一个公开面决定，进度对照见文末。

### 1. 分类审计（`010ba83`）

新增 [docs/ps1-exit/t2-launcher-classification.md](docs/ps1-exit/t2-launcher-classification.md)。所有数字是对 `02f0444` 的实测，不是估算。

**改变 T2 形状的发现**：`run-code-intel.ps1` 不只是入口，还是个函数库。两个 PowerShell 测试套件用 `Get-ScriptFunctionsSource` 从它的**文件体内部**掏函数 —— 绕过参数面：

| 测试文件 | 函数数 | 主体 |
|---|---|---|
| `test-hospital-trust-contract.ps1` | 18 | hospital 状态机、诊断、评分 |
| `test-regression-fixes.ps1` | 9 | code-evidence 符号提取（6 种语言） |
| `test-regression-fixes.ps1` | 3 | sentrux 门禁 metric delta |
| `test-regression-fixes.ps1` | 4 | hospital 状态机 + surgery target |

共 34 处函数引用。**把 launcher 缩成 forwarder 会删掉这些测试的主体**，所以票里的 `≤50 行` 出口条件靠单纯路由达不到 —— 这也是 T2 必然会碰到战役划给 T7 的测试资产的原因。

退役看起来是去重不是丢覆盖：hospital 诊断和 code-evidence 提取在 Rust 侧都有属主，且都是每次 `run execute` 都跑的活 DAG 节点：

| PowerShell 主体 | Rust 属主 | Rust 测试 |
|---|---|---|
| hospital 状态机 / 诊断 / 评分 | `hospital_diagnosis.rs`（558 行） | `tests/hospital_diagnosis.rs` — 978 行、10 个测试 |
| code-evidence 符号提取 | `native_code_evidence.rs`（718 行） | `tests/native_code_evidence.rs` — 511 行、6 个测试 |
| sentrux 门禁 metric delta | `sentrux_gate.rs`（1080 行） | CI 自扫在跑 |

**文档明确写了这还不足以作为删除依据**：「存在一个 Rust 套件」不等于「某条具体断言还在」。删除前必须产出逐函数映射表，PS1 侧没有 Rust 对应的用例按缺口处理、先补再删。这被列为必做工作，不是假定已满足。

**死亡清单**（逐条给理由）：

- `-SkipGitHubResearch` — T1 §1.1/§7.1 证实：文件内零其它引用，`$githubResearch` 无论该 flag 如何都被无条件赋成 `New-GitHubSolutionResearchNotApplicable` 存根。五个测试传它、没有一个断言它的效果，因为它没有效果。
- `Test-GitHubSolutionResearchRequired` — 已定义，零调用点。

**路由掉而非 port**：八个 early-exit facade 本来就是转发进 Rust CLI 的（解析 `target/debug/<exe>`、调子命令、`exit $LASTEXITCODE`）。退役工作是让调用方直接调 `code-intel`，forwarder 不需要复现它们。另外实测 `-SentruxAdapter{ArtifactRoot,EvaluatedAt,MaxAgeSeconds}` 在全树非冻结的 `.ps1`/`.yml` 里没有任何活调用者传过。

### 2. `--mode` 独立轴（`bcccdd7`）

把 launcher 的 `-Mode lite|normal|full` 作为**独立输入**移植，而不是第四个 `RunProfile`。profile 说 provider 有多严格地被要求，mode 说尝试做多少活 —— 「strict 的 lite 跑」是有意义的组合，合并成一个轴会让它无法表达，而公开 flag 定型后再拆很贵。

承重部分是组合规则。`with_mode` 只能在 profile 已允许的范围内收窄：

```
profile  →  mode（只收窄）  →  doctor overrides（provider 要求的最终话语权）
```

`lite` 在 profile 标 `Optional` 时丢掉结构化阶段；标 `Required` 时保留；`Offline` 在任何 mode 下都不被重新启用。没有这条规则，`--mode lite` 就是悄悄解除 strict 门禁的后门 —— 正是 `with_doctor_overrides` 已经在拒绝的同一类危险。四个测试钉死它，含 strict 不可削弱与 offline 不可复活两例。

端到端验过，不只单测：`run execute --mode lite` 确实把 `evidence.sentrux` 移出执行的 DAG，`evidence.graph` / `inventory.rg` / `evidence.native-code` / `doctor` / `repo.snapshot` 保留。

### 审阅者需要知道的：一个跑出来才暴露的行为变更

结构化阶段缺席后，`diagnosis.hospital` 判定 `authoritative structural evidence unavailable`，于是 **lite 跑退出 20（`domain_unknown`）而不是 0**。

这是 fail-closed 设计在正常工作，但 hospital 目前**不区分**两种缺席：

- 「按策略禁用」—— 你要的就是更窄的范围
- 「本该产出却没有」—— 真正的证据缺口

只有后者是缺口。PS1 的 `-Mode lite` 是照常出 amber 报告的，所以这对任何拿 lite 当快速绿灯检查的用法是行为变更。

本 PR **没有**顺手改 hospital：那要动诊断层和 admissibility 契约，够分量单独做一轮。已记入 commit message 与分类文档的待办。后续每引入一个 Skip 开关都会撞上同一个问题，所以建议在第 3 步之前先修，避免改三遍。

### 验证

- `cargo test -p code-intel`：45 套、0 失败
- `cargo fmt -p code-intel -- --check`：干净
- `run execute --mode lite` 的 DAG 节点集合按上述实测确认

### T2 进度

| 步骤 | 状态 |
|---|---|
| 1. 分类审计 | 本 PR |
| 2. `--mode` 轴 + 退出码契约 | mode 完成；退出码透传待 forwarder |
| 3. Skip*/Allow* 进 ExecutionPolicy | 未开始 |
| 4. 34 个函数逐条映射表 | 未开始 |
| 5. 删死代码 + PS1 降到 ≤50 行 | 未开始 |
| 6. 文档 / CI 改直调 | 未开始 |
| 7. parity harness 绿 | 未开始 |

出口条件（`run-code-intel.ps1 ≤50 行`、`ci.yml`/`release.yml`/文档主路径零 PS1 依赖、parity harness green）本 PR **均未满足**，#47 保持 open。

Refs #47
