### PR TITLE
fix(hospital): 区分「按策略排除」与「本该有却缺失」 (#47)

### DIFF
--- a/crates/code-intel-cli/src/execution_policy.rs
+++ b/crates/code-intel-cli/src/execution_policy.rs
@@ -246,7 +246,14 @@ impl ExecutionPolicy {
         manifest: &Path,
     ) -> Value {
         let mut options = match capability {
-            "diagnosis.hospital" => json!({}),
+            // The hospital must be able to tell "the structural stage was
+            // never requested" from "it was requested and produced nothing".
+            // Only the policy can say this, and the policy refuses to disable
+            // a capability its profile marks Required — so a narrow scope can
+            // never be claimed for a run that demanded the gate.
+            "diagnosis.hospital" => json!({
+                "structuralEvidenceInScope": self.capability_enabled("provider.sentrux-adapt")
+            }),
             "doctor" => json!({
                 "repoPath":repo,
                 "manifestPath":manifest,

--- a/crates/code-intel-cli/src/hospital_diagnosis.rs
+++ b/crates/code-intel-cli/src/hospital_diagnosis.rs
@@ -8,12 +8,24 @@ use crate::adapter_contract::{AdapterArtifact, AdapterDomainVerdict, AdapterErro
 use crate::artifact_ref::VerifiedArtifact;
 use crate::audit_report::AuditReport;
 
-#[derive(Default)]
 struct Signals {
     local_tool_failure: bool,
     provider_quota: bool,
     graph_seen: bool,
     graph_current: bool,
+    /// Whether the run was configured to produce structural evidence at all.
+    ///
+    /// Absence and exclusion are different facts. A run that was asked for the
+    /// structural stage and got nothing has an evidence gap and must not be
+    /// certified; a run that was never asked for it (`--mode lite`) simply has
+    /// a narrower scope, and reporting that as "unavailable" would make every
+    /// deliberately-narrow run indistinguishable from a broken one.
+    ///
+    /// Only the execution policy may set this false, and the policy already
+    /// refuses to disable a capability its profile marks `Required` — so this
+    /// cannot become a way to talk the hospital out of a gate that a strict
+    /// run demanded. The resulting narrowing is recorded in the report.
+    structural_in_scope: bool,
     structural_seen: bool,
     structural_trusted: bool,
     structural_rules: bool,
@@ -25,6 +37,29 @@ struct Signals {
     admissions: BTreeMap<String, String>,
 }
 
+impl Default for Signals {
+    fn default() -> Self {
+        Self {
+            local_tool_failure: false,
+            provider_quota: false,
+            graph_seen: false,
+            graph_current: false,
+            // Fail closed: unless a run explicitly declares the structural
+            // stage out of scope, its absence stays an evidence gap.
+            structural_in_scope: true,
+            structural_seen: false,
+            structural_trusted: false,
+            structural_rules: false,
+            structural_failure: false,
+            native_seen: false,
+            modernization_debt: false,
+            top_target: None,
+            failing_rules: Vec::new(),
+            admissions: BTreeMap::new(),
+        }
+    }
+}
+
 pub(crate) fn execute(
     request: &Value,
     verified_inputs: &[VerifiedArtifact],
@@ -34,17 +69,35 @@ pub(crate) fn execute(
         .get("options")
         .and_then(Value::as_object)
         .ok_or_else(|| AdapterError::InvalidOptions("options must be an object".into()))?;
-    if !options.is_empty() {
-        return Err(AdapterError::InvalidOptions(
-            "diagnosis.hospital accepts no options".into(),
-        ));
+    // `structuralEvidenceInScope` is the only option, and it may only ever
+    // narrow: the caller declares that the run never asked for the structural
+    // stage. Anything else is rejected so the option surface cannot grow into
+    // a way to hand-tune a diagnosis.
+    let mut structural_in_scope = true;
+    for (key, value) in options {
+        match (key.as_str(), value.as_bool()) {
+            ("structuralEvidenceInScope", Some(in_scope)) => structural_in_scope = in_scope,
+            ("structuralEvidenceInScope", None) => {
+                return Err(AdapterError::InvalidOptions(
+                    "diagnosis.hospital structuralEvidenceInScope must be boolean".into(),
+                ))
+            }
+            _ => {
+                return Err(AdapterError::InvalidOptions(
+                    "diagnosis.hospital accepts only structuralEvidenceInScope".into(),
+                ))
+            }
+        }
     }
     if verified_inputs.is_empty() {
         return Err(AdapterError::Contract(
             "diagnosis.hospital requires A04 admission Artifact Refs".into(),
         ));
     }
-    let mut signals = Signals::default();
+    let mut signals = Signals {
+        structural_in_scope,
+        ..Signals::default()
+    };
     for input in verified_inputs {
         if input.artifact_schema() != "code-intel-evidence-admissibility-result.v1"
             || input.artifact_type() != "evidence.admission"
@@ -274,7 +327,7 @@ fn diagnose(request: &Value, s: &Signals, audit: Option<&AuditReport>) -> Value 
             "admit",
             "unknown",
         )
-    } else if !s.structural_seen || !s.structural_trusted {
+    } else if s.structural_in_scope && (!s.structural_seen || !s.structural_trusted) {
         (
             "unknown",
             "authoritative structural evidence unavailable",
@@ -282,7 +335,7 @@ fn diagnose(request: &Value, s: &Signals, audit: Option<&AuditReport>) -> Value 
             "admit",
             "unknown",
         )
-    } else if !s.structural_rules {
+    } else if s.structural_in_scope && !s.structural_rules {
         (
             "amber",
             "ungoverned structural scope",
@@ -368,7 +421,7 @@ fn diagnose(request: &Value, s: &Signals, audit: Option<&AuditReport>) -> Value 
         },
         "state_machine":{"schema":"code-intel-hospital-state-machine.v1","current_state":next_protocol,"disposition":disposition,"next_protocol":next_protocol,"states":["triage","diagnose","govern","surgery_plan","post_op","discharge_ready"],"transitions":[]},
         "modalities":evidence,
-        "policies":{"precedence":["local tool failure","provider quota exhausted","architecture gate failure","architecture graph missing","authoritative structural evidence unavailable","ungoverned structural scope","known modernization debt","clean snapshot"]},
+        "policies":{"precedence":["local tool failure","provider quota exhausted","architecture gate failure","architecture graph missing","authoritative structural evidence unavailable","ungoverned structural scope","known modernization debt","clean snapshot"],"scope":{"structuralEvidence":if s.structural_in_scope {"in_scope"} else {"out_of_scope"}}},
         "report_quality":{"overall_score":null,"diagnostic_score":null,"governance_score":null,"dimensions":[]},
         "diagnosis":{"findings":[diagnosis],"impression":diagnosis,"risk":status,"evidence":evidence},
         "treatment":{"plan":treatment,"follow_up":["Rerun diagnosis.hospital with current admitted evidence."]},
@@ -558,6 +611,115 @@ mod audit_wiring_tests {
         assert!(machine.get("audit").is_none());
         let markdown = render_hospital(&machine, None);
         assert!(!markdown.contains("## Audit"));
+    }
+
+    /// A run that never asked for the structural stage has a narrower scope,
+    /// not an evidence gap. Before this distinction existed, `--mode lite`
+    /// exited 20 on a clean repository because absence was read as a gap.
+    #[test]
+    fn structural_evidence_out_of_scope_reaches_a_verdict_instead_of_unknown() {
+        let signals = Signals {
+            graph_seen: true,
+            graph_current: true,
+            structural_in_scope: false,
+            ..Signals::default()
+        };
+        let machine = diagnose(&sample_request(), &signals, None);
+        assert_eq!(machine["domainVerdict"], "pass");
+        assert_eq!(machine["diagnosis"]["impression"], "clean snapshot");
+        // The narrowing has to be visible in the artifact, never silent.
+        assert_eq!(
+            machine["policies"]["scope"]["structuralEvidence"],
+            "out_of_scope"
+        );
+    }
+
+    /// The fail-closed half: in scope and absent is still a gap.
+    #[test]
+    fn structural_evidence_in_scope_but_absent_stays_unknown() {
+        let signals = Signals {
+            graph_seen: true,
+            graph_current: true,
+            ..Signals::default()
+        };
+        let machine = diagnose(&sample_request(), &signals, None);
+        assert_eq!(machine["domainVerdict"], "unknown");
+        assert_eq!(
+            machine["diagnosis"]["impression"],
+            "authoritative structural evidence unavailable"
+        );
+        assert_eq!(
+            machine["policies"]["scope"]["structuralEvidence"],
+            "in_scope"
+        );
+    }
+
+    /// Defence in depth: admitted evidence beats a scope claim. If structural
+    /// evidence was actually produced and it fails, declaring it out of scope
+    /// must not launder the failure into a pass — otherwise the option would
+    /// be a way to talk the hospital out of a gate it already has evidence for.
+    #[test]
+    fn an_out_of_scope_claim_cannot_launder_an_admitted_structural_failure() {
+        let signals = Signals {
+            graph_seen: true,
+            graph_current: true,
+            structural_in_scope: false,
+            structural_seen: true,
+            structural_trusted: true,
+            structural_rules: true,
+            structural_failure: true,
+            ..Signals::default()
+        };
+        let machine = diagnose(&sample_request(), &signals, None);
+        assert_eq!(machine["domainVerdict"], "fail");
+        assert_eq!(
+            machine["diagnosis"]["impression"],
+            "architecture gate failure"
+        );
+    }
+
+    /// Scope narrowing never outranks a real failure signal that precedes it
+    /// in the ladder.
+    #[test]
+    fn out_of_scope_does_not_mask_local_tool_failure_or_quota_exhaustion() {
+        for (label, signals) in [
+            (
+                "local tool failure",
+                Signals {
+                    local_tool_failure: true,
+                    structural_in_scope: false,
+                    ..Signals::default()
+                },
+            ),
+            (
+                "provider quota exhausted",
+                Signals {
+                    provider_quota: true,
+                    structural_in_scope: false,
+                    ..Signals::default()
+                },
+            ),
+        ] {
+            let machine = diagnose(&sample_request(), &signals, None);
+            assert_eq!(machine["domainVerdict"], "unknown", "{label}");
+            assert_eq!(machine["diagnosis"]["impression"], label);
+        }
+    }
+
+    /// A missing architecture graph outranks the structural scope question,
+    /// so lite runs still cannot certify without one.
+    #[test]
+    fn out_of_scope_does_not_excuse_a_missing_architecture_graph() {
+        let signals = Signals {
+            structural_in_scope: false,
+            ..Signals::default()
+        };
+        let machine = diagnose(&sample_request(), &signals, None);
+        assert_eq!(machine["domainVerdict"], "unknown");
+        assert_eq!(
+            machine["diagnosis"]["impression"],
+            "architecture graph missing"
+        );
     }
 
     #[test]

--- a/orchestration/integrations.json
+++ b/orchestration/integrations.json
@@ -1456,7 +1456,7 @@
           "id": "diagnosis.hospital.compat",
           "version": "1.0.0",
           "toolchainDigests": [
-            "5bc06caa29f786b3f6e4d732dc26005d313a01071940221c1b03b65911283efd"
+            "15fe44854b79b0b860ad2b63fbd461f358f2b19ec4ac8921eca08978239a9703"
           ]
         },
         "determinism": "deterministic",


### PR DESCRIPTION
## hospital：区分「按策略排除」与「本该有却缺失」

承接 `--mode` 落地时记录的已知后果（#47，T2 步骤 2 的收尾）。

### 问题

`diagnosis.hospital` 把结构化证据的缺席**无条件**当作证据缺口，于是 `--mode lite`（刻意不跑结构化阶段）在干净仓库上退出 20（`domain_unknown`）。

缺席和排除是两个不同的事实：

- **本该产出却没有** → 真证据缺口，不能认证
- **从没被要求产出** → 只是范围更窄

压成一个的后果是：任何**刻意收窄**的跑和**坏掉**的跑长得一模一样，`lite` 因此失去了作为快速检查的用途。PS1 的 `-Mode lite` 是照常出报告的，所以这也是个未被承认的行为回退。

### 改动

`diagnosis.hospital` 原本显式拒绝任何 option。现在只接受一个 `structuralEvidenceInScope`，判定阶梯里那两级结构化判定只在「在范围内」时才触发。

收窄记录进产物 `policies.scope.structuralEvidence`（`in_scope` / `out_of_scope`）—— 收窄必须在产物里可见，不能让窄范围的跑与完整的跑在事后无法区分。

### 审阅重点：这个 option 本身是个危险面

它长得就像「一个能让 hospital 闭嘴的开关」。三道护栏，每道都有测试钉死：

1. **只有 `ExecutionPolicy` 能发出它**，由 `capability_enabled("provider.sentrux-adapt")` 推导。而 policy 已经拒绝禁用 profile 标 `Required` 的能力（`with_mode` / `with_doctor_overrides` 的既有保证）—— 所以 strict 跑声明不了窄范围。

2. **已录入的证据压过声明**。同时出现「声明出范围」与「已录入且失败的结构化规则」时仍判 `architecture gate failure` —— 失败那一级在阶梯上排在范围判定之前。这条防的是拿 scope 洗白已知失败。

3. **范围压不过它上面的信号**。`local tool failure`、`provider quota exhausted`、`architecture graph missing` 在出范围声明下仍然给 `unknown`。

默认 fail-closed：`Signals` 现在有显式 `Default` impl，`structural_in_scope` 为 `true`，任何没有刻意收窄的路径保持原行为。

option 解析也收紧了：未知 key 和非布尔值都拒绝，避免这个 option 面日后长成「手调诊断结果」的入口。

### 验证

端到端，不只单测：

| | 结果 |
|---|---|
| `run execute --mode lite` | exit **0**，`clean snapshot` / green，`scope: out_of_scope` |
| 正常自扫（CI 那条命令） | exit 0，`in_scope`，`clean snapshot` —— **未变** |
| `cargo test -p code-intel` | 45 套、0 失败 |
| `cargo fmt -p code-intel -- --check` | 干净 |
| `code-intel sentrux gate .` | No degradation detected |
| `orchestrate --action Validate` | ok、0 errors、registryAudit ok |

`hospital_diagnosis.rs` 的 toolchain digest 已在所有源码编辑完成后一次性重算。

### 为什么单独开一个 PR

这个改动碰的是诊断裁决逻辑和一个新的可收窄面，值得被单独审一眼。混进 T2 后续那批 Skip*/Allow* 开关里容易被淹没 —— 而那批开关每一个都会依赖这里定下的「排除 ≠ 缺失」语义。

Refs #47
