### PR TITLE
feat(run): T2 (3/n) — launcher 阶段开关进 ExecutionPolicy (#47)

### DIFF
--- a/crates/code-intel-cli/src/execution_policy.rs
+++ b/crates/code-intel-cli/src/execution_policy.rs
@@ -2,99 +2,9 @@ use std::path::{Path, PathBuf};
 
 use serde_json::{json, Value};
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum RunProfile {
-    Default,
-    Strict,
-    Offline,
-    Compatibility,
-}
+mod inputs;
 
-impl RunProfile {
-    pub(crate) fn parse(value: &str) -> Result<Self, String> {
-        match value {
-            "default" => Ok(Self::Default),
-            "strict" => Ok(Self::Strict),
-            "offline" => Ok(Self::Offline),
-            _ => Err("--profile must be default, strict, or offline".into()),
-        }
-    }
-}
-
-/// How much work a run does, ported from the launcher's `-Mode`.
-///
-/// Deliberately a separate axis from [`RunProfile`]: the profile says how
-/// strictly providers are *required*, the mode says how much is *attempted*.
-/// A strict lite run is a meaningful combination, so the two must not be
-/// flattened into one enum — see docs/ps1-exit/t2-launcher-classification.md §2.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub(crate) enum RunMode {
-    /// Skip the optional structural stage; the fastest useful run.
-    Lite,
-    #[default]
-    Normal,
-    /// Normal plus the deeper understand sweep.
-    Full,
-}
-
-impl RunMode {
-    pub(crate) fn parse(value: &str) -> Result<Self, String> {
-        match value {
-            "lite" => Ok(Self::Lite),
-            "normal" => Ok(Self::Normal),
-            "full" => Ok(Self::Full),
-            _ => Err("--mode must be lite, normal, or full".into()),
-        }
-    }
-
-    pub(crate) fn as_str(self) -> &'static str {
-        match self {
-            Self::Lite => "lite",
-            Self::Normal => "normal",
-            Self::Full => "full",
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum WorkingTreePolicy {
-    HeadOnly,
-    ExplicitOverlay,
-}
-
-impl WorkingTreePolicy {
-    pub(crate) fn parse(value: &str) -> Result<Self, String> {
-        match value {
-            "head_only" => Ok(Self::HeadOnly),
-            "explicit_overlay" => Ok(Self::ExplicitOverlay),
-            _ => Err("--working-tree-policy must be head_only or explicit_overlay".into()),
-        }
-    }
-
-    pub(crate) fn as_str(self) -> &'static str {
-        match self {
-            Self::HeadOnly => "head_only",
-            Self::ExplicitOverlay => "explicit_overlay",
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum ProviderRequirement {
-    Required,
-    Optional,
-    Disabled,
-}
-
-impl ProviderRequirement {
-    pub(crate) fn is_required(self) -> bool {
-        matches!(self, Self::Required)
-    }
-
-    pub(crate) fn is_enabled(self) -> bool {
-        !matches!(self, Self::Disabled)
-    }
-}
+pub(crate) use inputs::{ProviderRequirement, RunMode, RunProfile, SkipFlags, WorkingTreePolicy};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct ProviderPolicy {
@@ -169,14 +79,39 @@ impl ExecutionPolicy {
     /// disabled regardless — mode never re-enables.
     pub(crate) fn with_mode(mut self, mode: RunMode) -> Self {
         self.mode = mode;
-        if mode == RunMode::Lite && self.providers.sentrux == ProviderRequirement::Optional {
-            self.providers.sentrux = ProviderRequirement::Disabled;
+        if mode == RunMode::Lite {
+            self.providers.sentrux = self.providers.sentrux.narrowed();
         }
         self
     }
 
     pub(crate) fn mode(&self) -> RunMode {
         self.mode
+    }
+
+    /// Compose the launcher's stage switches onto the requirement policy.
+    ///
+    /// Same rule as [`Self::with_mode`], for the same reason: a skip may only
+    /// narrow within what the profile already permits. `Required` survives
+    /// every skip, so no compatibility switch can disarm a strict gate, and
+    /// `Disabled` is never turned back on, so `Offline` stays offline.
+    ///
+    /// `require_understand_graph` moves in the other direction — it
+    /// *strengthens* — which is always safe, but it still may not resurrect a
+    /// capability the profile disabled.
+    pub(crate) fn with_skips(mut self, skips: SkipFlags) -> Self {
+        if skips.repowise {
+            self.providers.repowise = self.providers.repowise.narrowed();
+        }
+        if skips.sentrux {
+            self.providers.sentrux = self.providers.sentrux.narrowed();
+        }
+        if skips.require_understand_graph
+            && self.providers.understand == ProviderRequirement::Optional
+        {
+            self.providers.understand = ProviderRequirement::Required;
+        }
+        self
     }
 
     pub(crate) fn with_working_tree(
@@ -357,13 +292,64 @@ mod tests {
     }
 
     #[test]
-    fn mode_parsing_accepts_the_launchers_vocabulary_and_rejects_the_rest() {
-        assert_eq!(RunMode::parse("lite").unwrap(), RunMode::Lite);
-        assert_eq!(RunMode::parse("normal").unwrap(), RunMode::Normal);
-        assert_eq!(RunMode::parse("full").unwrap(), RunMode::Full);
-        assert_eq!(RunMode::default(), RunMode::Normal);
-        assert!(RunMode::parse("deep").is_err());
-        assert!(RunMode::parse("").is_err());
+    fn skips_drop_optional_stages_and_narrow_the_hospital_scope_with_them() {
+        let policy = ExecutionPolicy::for_profile(RunProfile::Default).with_skips(SkipFlags {
+            repowise: true,
+            sentrux: true,
+            ..SkipFlags::default()
+        });
+        assert_eq!(policy.providers.repowise, ProviderRequirement::Disabled);
+        assert!(!policy.capability_enabled("provider.sentrux-adapt"));
+        // Skipping the structural stage must tell the hospital the stage was
+        // excluded, not that its evidence went missing.
+        let options = policy.capability_options(
+            "diagnosis.hospital",
+            Path::new("repo"),
+            Path::new("integrations.json"),
+        );
+        assert_eq!(options["structuralEvidenceInScope"], json!(false));
+    }
+
+    #[test]
+    fn skips_cannot_disarm_a_strict_run_or_reenable_an_offline_one() {
+        let all = SkipFlags {
+            repowise: true,
+            sentrux: true,
+            require_understand_graph: true,
+        };
+        let strict = ExecutionPolicy::for_profile(RunProfile::Strict).with_skips(all);
+        assert!(strict.providers.repowise.is_required());
+        assert!(strict.providers.sentrux.is_required());
+        assert!(strict.capability_enabled("provider.sentrux-adapt"));
+
+        let offline = ExecutionPolicy::for_profile(RunProfile::Offline).with_skips(all);
+        assert_eq!(offline.providers.repowise, ProviderRequirement::Disabled);
+        assert_eq!(offline.providers.sentrux, ProviderRequirement::Disabled);
+        // require_understand_graph strengthens, but must not resurrect a
+        // capability the profile disabled.
+        assert_eq!(offline.providers.understand, ProviderRequirement::Disabled);
+    }
+
+    #[test]
+    fn require_understand_graph_promotes_an_optional_stage_to_required() {
+        let policy = ExecutionPolicy::for_profile(RunProfile::Default).with_skips(SkipFlags {
+            require_understand_graph: true,
+            ..SkipFlags::default()
+        });
+        assert!(policy.providers.understand.is_required());
+        // ...and it reaches the doctor, which is what makes a missing graph
+        // fatal rather than advisory.
+        let options =
+            policy.capability_options("doctor", Path::new("repo"), Path::new("integrations.json"));
+        assert_eq!(options["requireUnderstand"], json!(true));
+    }
+
+    #[test]
+    fn no_skips_is_the_identity_on_the_provider_policy() {
+        let plain = ExecutionPolicy::for_profile(RunProfile::Default);
+        let skipped =
+            ExecutionPolicy::for_profile(RunProfile::Default).with_skips(SkipFlags::default());
+        assert_eq!(plain.providers, skipped.providers);
     }
 
     #[test]

--- a/crates/code-intel-cli/src/execution_policy/inputs.rs
+++ b/crates/code-intel-cli/src/execution_policy/inputs.rs
@@ -1,0 +1,181 @@
+//! The parsed inputs an execution policy is compiled from.
+//!
+//! These are small value types with one job each: turn a CLI string into a
+//! checked value, or name a requirement level. They are separated from
+//! `ExecutionPolicy` itself because the policy is about *composition rules*
+//! — what may narrow what — while these are about *vocabulary*.
+
+/// How strictly providers are required.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum RunProfile {
+    Default,
+    Strict,
+    Offline,
+    Compatibility,
+}
+
+impl RunProfile {
+    pub(crate) fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "default" => Ok(Self::Default),
+            "strict" => Ok(Self::Strict),
+            "offline" => Ok(Self::Offline),
+            _ => Err("--profile must be default, strict, or offline".into()),
+        }
+    }
+}
+
+/// How much work a run does, ported from the launcher's `-Mode`.
+///
+/// Deliberately a separate axis from [`RunProfile`]: the profile says how
+/// strictly providers are *required*, the mode says how much is *attempted*.
+/// A strict lite run is a meaningful combination, so the two must not be
+/// flattened into one enum — see docs/ps1-exit/t2-launcher-classification.md §2.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) enum RunMode {
+    /// Skip the optional structural stage; the fastest useful run.
+    Lite,
+    #[default]
+    Normal,
+    /// Normal plus the deeper understand sweep.
+    Full,
+}
+
+impl RunMode {
+    pub(crate) fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "lite" => Ok(Self::Lite),
+            "normal" => Ok(Self::Normal),
+            "full" => Ok(Self::Full),
+            _ => Err("--mode must be lite, normal, or full".into()),
+        }
+    }
+
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Lite => "lite",
+            Self::Normal => "normal",
+            Self::Full => "full",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum WorkingTreePolicy {
+    HeadOnly,
+    ExplicitOverlay,
+}
+
+impl WorkingTreePolicy {
+    pub(crate) fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "head_only" => Ok(Self::HeadOnly),
+            "explicit_overlay" => Ok(Self::ExplicitOverlay),
+            _ => Err("--working-tree-policy must be head_only or explicit_overlay".into()),
+        }
+    }
+
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::HeadOnly => "head_only",
+            Self::ExplicitOverlay => "explicit_overlay",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ProviderRequirement {
+    Required,
+    Optional,
+    Disabled,
+}
+
+impl ProviderRequirement {
+    pub(crate) fn is_required(self) -> bool {
+        matches!(self, Self::Required)
+    }
+
+    pub(crate) fn is_enabled(self) -> bool {
+        !matches!(self, Self::Disabled)
+    }
+
+    /// Narrow one requirement: optional stages switch off, required ones
+    /// survive. The asymmetry is the whole point — see `ExecutionPolicy`'s
+    /// composition rules.
+    pub(crate) fn narrowed(self) -> Self {
+        match self {
+            Self::Optional => Self::Disabled,
+            other => other,
+        }
+    }
+}
+
+/// The launcher stage switches that map cleanly onto provider requirements.
+///
+/// Deliberately not every `-Skip*` the PowerShell launcher accepts. The ones
+/// left out need a Rust surface that does not exist yet, and shipping a flag
+/// that silently does nothing would be worse than not shipping it:
+///
+/// - `-SkipSentruxCheck` / `-SkipSentruxGate` are sub-stage granularity; the
+///   DAG has a single `provider.sentrux-adapt` node, so honouring them means
+///   splitting that node or giving it options, not toggling a requirement.
+/// - `-SkipOpenSpec` / `-AutoOpenSpec` and `-SkipRepomix` / `-RepomixStyle` /
+///   `-RepomixCompress` gate stages with no Rust node at all.
+/// - `-WorkspaceAdd` and `-AllowRepowiseShadowMutation` are options of the
+///   repowise stage rather than switches over whether it runs.
+///
+/// See docs/ps1-exit/t2-launcher-classification.md §1.2.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct SkipFlags {
+    pub(crate) repowise: bool,
+    pub(crate) sentrux: bool,
+    pub(crate) require_understand_graph: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mode_parsing_accepts_the_launchers_vocabulary_and_rejects_the_rest() {
+        assert_eq!(RunMode::parse("lite").unwrap(), RunMode::Lite);
+        assert_eq!(RunMode::parse("normal").unwrap(), RunMode::Normal);
+        assert_eq!(RunMode::parse("full").unwrap(), RunMode::Full);
+        assert_eq!(RunMode::default(), RunMode::Normal);
+        assert!(RunMode::parse("deep").is_err());
+        assert!(RunMode::parse("").is_err());
+    }
+
+    #[test]
+    fn profile_parsing_does_not_expose_compatibility_as_a_user_choice() {
+        assert_eq!(RunProfile::parse("strict").unwrap(), RunProfile::Strict);
+        assert_eq!(RunProfile::parse("offline").unwrap(), RunProfile::Offline);
+        // Compatibility is selected by the dag-coordinate entry point, never
+        // by a user-supplied --profile value.
+        assert!(RunProfile::parse("compatibility").is_err());
+    }
+
+    #[test]
+    fn narrowing_switches_off_optional_and_leaves_the_others_alone() {
+        assert_eq!(
+            ProviderRequirement::Optional.narrowed(),
+            ProviderRequirement::Disabled
+        );
+        assert_eq!(
+            ProviderRequirement::Required.narrowed(),
+            ProviderRequirement::Required
+        );
+        assert_eq!(
+            ProviderRequirement::Disabled.narrowed(),
+            ProviderRequirement::Disabled
+        );
+    }
+
+    #[test]
+    fn working_tree_policy_round_trips_its_wire_vocabulary() {
+        for value in ["head_only", "explicit_overlay"] {
+            assert_eq!(WorkingTreePolicy::parse(value).unwrap().as_str(), value);
+        }
+        assert!(WorkingTreePolicy::parse("dirty").is_err());
+    }
+}

--- a/crates/code-intel-cli/src/run_cli.rs
+++ b/crates/code-intel-cli/src/run_cli.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use crate::dag_run::{self, DagExecutionRequest};
 use crate::execution_kernel;
-use crate::execution_policy::{ExecutionPolicy, RunMode, RunProfile, WorkingTreePolicy};
+use crate::execution_policy::{ExecutionPolicy, RunMode, RunProfile, SkipFlags, WorkingTreePolicy};
 use crate::run_error::RunError;
 
 pub(crate) fn run_raw(raw: &[String]) -> i32 {
@@ -78,6 +78,7 @@ impl Cli {
             RunCommand::Execute => RunProfile::Default,
         };
         let mut mode = RunMode::default();
+        let mut skips = SkipFlags::default();
         let mut session_evidence = None;
         let mut index = 1;
         while index < raw.len() {
@@ -91,6 +92,9 @@ impl Cli {
                     | "--manifest"
                     | "--profile"
                     | "--mode"
+                    | "--skip-repowise"
+                    | "--skip-sentrux"
+                    | "--require-understand-graph"
                     | "--max-concurrency"
                     | "--working-tree-policy"
                     | "--scope"
@@ -134,6 +138,11 @@ impl Cli {
                         return Err("--mode is available only for run execute".into());
                     }
                     mode = RunMode::parse(value)?;
+                }
+                "--skip-repowise" => skips.repowise = parse_bool_flag(flag, value)?,
+                "--skip-sentrux" => skips.sentrux = parse_bool_flag(flag, value)?,
+                "--require-understand-graph" => {
+                    skips.require_understand_graph = parse_bool_flag(flag, value)?
                 }
                 "--max-concurrency" => {
                     max_concurrency = value
@@ -251,6 +260,7 @@ impl Cli {
         // last word on provider requirements.
         let policy = ExecutionPolicy::for_profile(profile)
             .with_mode(mode)
+            .with_skips(skips)
             .with_working_tree(WorkingTreePolicy::parse(&working_tree_policy)?, scopes)
             .with_doctor_overrides(
                 doctor_require_repowise,
@@ -274,7 +284,7 @@ impl Cli {
 }
 
 fn usage() -> String {
-    "usage: run <dag-coordinate|execute> --repo <repo-root> --out <run-staging-directory> [--authority-root <publication-root> --final-name <name>] [--profile <default|strict|offline>] [--mode <lite|normal|full>] [--manifest <integrations.json>] [--max-concurrency <n>] [--working-tree-policy <head_only|explicit_overlay>] [--scope <relative-path>]... [--session-evidence <session-evidence.json>] [--diagnosis-inputs <artifact-refs.json> --seed-artifact-root <root>] [--doctor-tool-path-prefix <directory>] [--doctor-require-repowise <true|false>] [--doctor-require-understand <true|false>]".into()
+    "usage: run <dag-coordinate|execute> --repo <repo-root> --out <run-staging-directory> [--authority-root <publication-root> --final-name <name>] [--profile <default|strict|offline>] [--mode <lite|normal|full>] [--skip-repowise <true|false>] [--skip-sentrux <true|false>] [--require-understand-graph <true|false>] [--manifest <integrations.json>] [--max-concurrency <n>] [--working-tree-policy <head_only|explicit_overlay>] [--scope <relative-path>]... [--session-evidence <session-evidence.json>] [--diagnosis-inputs <artifact-refs.json> --seed-artifact-root <root>] [--doctor-tool-path-prefix <directory>] [--doctor-require-repowise <true|false>] [--doctor-require-understand <true|false>]".into()
 }
 
 fn parse_bool_flag(flag: &str, value: &str) -> Result<bool, String> {


### PR DESCRIPTION
## T2 步骤 3：launcher 的阶段开关进 ExecutionPolicy

`--skip-repowise`、`--skip-sentrux`、`--require-understand-graph` 与 `--mode` 一样成为**策略输入**，而不是脚本里的分支。这正是票里「port the contract, not the script」的意思 —— DAG 早就按 `capability_enabled` 决定节点是否入图，所以一个 skip 是要求等级的变化，不是一条代码路径。

### 组合规则（继承自 `--mode`）

skip 只能在 profile 已允许的范围内收窄：

- `Required` 挺过每一个开关 —— 没有兼容 flag 能解除 strict 门禁
- `Disabled` 永不复活 —— `Offline` 保持 offline
- `--require-understand-graph` 反向走，把 `Optional` 提升到 `Required`（强化总是安全的），但仍然不能复活 profile 禁用掉的能力

四个测试钉死，含「所有 skip 打在 strict 上」和「打在 offline 上」两例。

跳过结构化阶段现在也会告诉 hospital 这是**被排除**而非**缺失**，复用 `d029b3f` 落的那个区分，所以被跳过的跑能给出裁决而不是 `domain_unknown`。

### 刻意只做了一半，并在代码里写明原因

`SkipFlags` 的文档注释逐条记录了**没有**移植的开关和理由 —— 它们目前没有诚实的落点：

| 未移植 | 原因 |
|---|---|
| `-SkipSentruxCheck` / `-SkipSentruxGate` | 子阶段粒度，而 DAG 只有一个 `provider.sentrux-adapt` 节点。要诚实支持得拆节点或给节点选项，不是切换一个要求等级 |
| `-SkipOpenSpec` / `-AutoOpenSpec` | 对应阶段在 Rust 侧根本没有节点 |
| `-SkipRepomix` / `-RepomixStyle` / `-RepomixCompress` | 同上 |
| `-WorkspaceAdd` / `-AllowRepowiseShadowMutation` | 是 repowise 阶段的**选项**，不是「跑不跑」的开关 |

发一个悄悄什么都不做的 flag，比不发更糟。

### 顺带：又撞了一次自己的 god-file 规则

新增内容把 `execution_policy.rs` 顶到 455 行 / 32 函数，触发 `functions > 25 && loc > 400`，god files 32 → 33。

按**真实内聚边界**拆，不是为了满足指标硬拆：`execution_policy/inputs.rs` 放解析出来的词汇（`RunProfile`、`RunMode`、`WorkingTreePolicy`、`ProviderRequirement`、`SkipFlags`），父模块保留组合规则。收窄辅助函数变成 `ProviderRequirement::narrowed`，回到它该在的地方。

副作用是**耦合反而降了**（45.79 → 45.72）、质量升了（3603 → 3604），因为新文件 import 少、拉低了 import/file 比值。所以这次**不需要动 baseline**。

### 验证

三种形态各自端到端跑过：

| | exit | scope | verdict |
|---|---|---|---|
| baseline | 0 | `in_scope` | clean snapshot |
| `--skip-sentrux true` | 0 | `out_of_scope` | clean snapshot |
| `--mode lite` | 0 | `out_of_scope` | clean snapshot |

`cargo test` 45 套 0 失败、`cargo fmt --check` 干净、`sentrux gate` No degradation、`orchestrate --action Validate` ok。

Refs #47
