### PR TITLE
fix(installer): 让 supply-chain-003 的 pin 真的被执行，并给 CLI 加 --version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,69 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`code-intel --version`** (also `-V`, and `--version --json` emitting
+  `code-intel-version.v1`). The installed binary could not report what it was:
+  the installed `bin/repo.json` records where the installer ran from, not what
+  it produced, so a machine on a stale build was indistinguishable from a
+  current one. Observed in practice — an installed v0.6.0 binary answered
+  `snapshot identity` in 10.9s while the same command on a build containing the
+  `git cat-file --batch` fix took 0.28s, and nothing on the machine could tell
+  the two apart. Answered ahead of route dispatch, because a leading `-` flag is
+  neither a primary invocation nor a raw route and previously fell through to
+  `unknown command: --version`.
+
+  This is a self-declared build identity, not provenance: the value is
+  `CARGO_PKG_VERSION` from the binary being questioned. It separates stale from
+  current; it does not separate genuine from substituted. The installer's
+  recorded `sha256=` remains the provenance signal.
+
+### Fixed
+
+- **The installer's version pin is now enforced, not merely declared.**
+  `Install-MissingTool` returned on presence alone: `Get-Command` finding the
+  tool on PATH produced `already_present` and the installer scriptblock never
+  ran. For `repowise` — the one external tool carrying a pinned version
+  (`repowise==0.36.0`, supply-chain-003) — this meant the pin could never fire
+  on a machine that had installed repowise once, and a box sitting four minor
+  releases behind reported the same status as a correct one. `Get-InstallMetadata`
+  now carries `pinnedVersion`, a new `Get-ToolVersion` reads the tool's own
+  `--version`, and a mismatch reports `version_drift` (or `upgraded` /
+  `upgrade_failed` under `-InstallMissing`). An unreadable version reports as
+  `unknown` and never as a match — the state the gate exists to surface. Tools
+  without a pin keep their previous behaviour exactly.
+
+  The probe follows the launch rule `crates/code-intel-cli/src/tool_path.rs`
+  states for the rest of the project — "only ever launches by absolute path",
+  "relative PATH entries are skipped outright". `Test-ToolVersionProbeAllowed`
+  refuses any source that is not a rooted, existing, non-script file, so a
+  `repowise.ps1` planted on PATH cannot be dot-run inside the installer's own
+  process. A refused probe is not a failed probe: the tool keeps its previous
+  presence-only reporting, so an unverifiable source can never induce a
+  reinstall. The child is launched with `Start-Process -PassThru -Wait` and its
+  own exit code is read, rather than the ambient `$LASTEXITCODE`, which is only
+  set by native commands and would otherwise carry a stale value — or, under
+  `Set-StrictMode`, abort the installer outright. Only stdout is parsed, and the
+  match is anchored to the tool's own name when it is known, so a deprecation
+  banner carrying its own version number cannot forge a pass or a drift.
+
+  **Action required on already-provisioned machines.** Confirmed drift now
+  fails the install. `ok` is computed from `checks` alone, so a status that only
+  reached `installActions` was invisible to every consumer —
+  `bootstrap-new-machine.ps1` reads `installResult.ok` and nothing else, and
+  would have reported `Install OK: True` on a drifted box.
+  `Add-VersionComplianceChecks` derives a `version:<tool>` check from the
+  actions, so a machine whose `repowise` is off-pin now reports `ok: false` with
+  `version:repowise` in `missingRequired`. Resolve it with `-InstallMissing`, or
+  move the pin to the version you intend to run. A refused or unreadable probe
+  emits the check as **not required**: uncertainty is surfaced, but an install
+  is never failed over a version that could not be measured.
+
+  One more behaviour change: the default (doctor) mode now executes `--version`
+  on a pinned tool that is already present, where it previously ran no external
+  command for it — today that is `repowise` only.
+
 ### Changed
 
 - **Sentrux `coupling_score` now divides by import-modelled files only**

--- a/crates/code-intel-cli/src/main.rs
+++ b/crates/code-intel-cli/src/main.rs
@@ -201,6 +201,9 @@ mod sentrux_contract_tests {
 
 fn main() {
     let raw: Vec<String> = env::args().skip(1).collect();
+    if let Some(exit_code) = dispatch_version(&raw) {
+        process::exit(exit_code);
+    }
     if is_primary_invocation(&raw) {
         process::exit(run_primary(&raw));
     }
@@ -211,6 +214,41 @@ fn main() {
         eprintln!("error: {err}");
         process::exit(1);
     }
+}
+
+/// Answers `--version` before any route dispatch.
+///
+/// This reports a self-declared build identity, not provenance: the value is
+/// `CARGO_PKG_VERSION` baked into the same binary being questioned, so it
+/// separates a stale build from a current one and nothing more. The installer
+/// records the actual provenance signal (`sha256=` on the installed binary)
+/// separately, and that is what a substitution check should compare.
+///
+/// Stale-build detection is the gap worth closing here. The installed
+/// `bin/repo.json` records where the installer ran from, not what it produced,
+/// so a machine on an old build looked identical to a current one — and the
+/// installer's version gate had nothing to compare against.
+///
+/// Kept ahead of `is_primary_invocation` deliberately — a leading `-` flag is
+/// not a primary invocation and is not a raw route, so it would otherwise fall
+/// through to `run()` and exit as an unknown command.
+fn dispatch_version(raw: &[String]) -> Option<i32> {
+    if !matches!(raw.first().map(String::as_str), Some("--version" | "-V")) {
+        return None;
+    }
+    if raw.iter().any(|arg| arg == "--json") {
+        println!(
+            "{}",
+            json!({
+                "schema": "code-intel-version.v1",
+                "name": env!("CARGO_PKG_NAME"),
+                "version": env!("CARGO_PKG_VERSION"),
+            })
+        );
+    } else {
+        println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+    }
+    Some(0)
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/crates/code-intel-cli/tests/installer_version_gate.rs
+++ b/crates/code-intel-cli/tests/installer_version_gate.rs
@@ -1,0 +1,516 @@
+//! Contract tests for the installer's version gate.
+//!
+//! Before this gate existed, `Install-MissingTool` returned on presence alone:
+//! a machine with `repowise` 0.32.0 on PATH reported `already_present` while
+//! the supply-chain-003 pin declared 0.36.0, so the pin was a declaration
+//! nothing enforced. Presence and correctness were indistinguishable in the
+//! install report.
+//!
+//! The functions under test live inside `legacy/install-code-intel-pipeline.ps1`,
+//! whose top level performs a real installation — dot-sourcing it would install.
+//! The driver written here lifts the two functions out by AST and evaluates
+//! them with their collaborators stubbed. Per AGENTS.md the driver is generated
+//! into a temp directory rather than committed, so this adds no new PowerShell
+//! to the tree; assertions live on the Rust side, matching the #78/#80
+//! direction of porting PowerShell call points to Rust.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::Value;
+
+static TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .canonicalize()
+        .expect("repo root")
+}
+
+struct Temp(PathBuf);
+
+impl Temp {
+    fn new(tag: &str) -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "code-intel-version-gate-{tag}-{}-{nonce}-{}",
+            std::process::id(),
+            TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir_all(&dir).expect("scratch");
+        Self(dir)
+    }
+}
+
+impl Drop for Temp {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+/// Lifts `Get-ToolVersion` and `Install-MissingTool` out of the installer by
+/// AST, stubs their collaborators, runs one scenario, and prints one JSON
+/// document. Kept in a temp file rather than the tree: AGENTS.md forbids
+/// adding PowerShell scripts to the repository.
+///
+/// Delimited with `r##"` rather than `r#"`: the POSIX stub writes a `"#!/bin/sh"`
+/// line, and the `"#` inside it would otherwise close the raw string.
+const DRIVER: &str = r##"
+param(
+    [Parameter(Mandatory = $true)][string]$Installer,
+    [Parameter(Mandatory = $true)][string]$Scenario,
+    [Parameter(Mandatory = $true)][string]$Workspace
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$ast = [System.Management.Automation.Language.Parser]::ParseFile($Installer, [ref]$null, [ref]$null)
+foreach ($name in @("Test-ToolVersionProbeAllowed", "Get-ToolVersion", "Install-MissingTool", "Add-VersionComplianceChecks")) {
+    $fn = $ast.Find({
+            param($node)
+            $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq $name
+        }, $true)
+    if (-not $fn) { throw "function not found in installer: $name" }
+    . ([scriptblock]::Create($fn.Extent.Text))
+}
+
+function New-VersionStub {
+    # Platform-correct stubs. `cross-platform-smoke` runs `cargo test -p
+    # code-intel --locked` on macos-latest and ubuntu-latest, where a `.cmd`
+    # batch file is not executable — `& $Source` would throw, Get-ToolVersion
+    # would swallow it as "unknown", and every scenario below would fail for a
+    # reason unrelated to the gate.
+    param([string]$Tag, [string]$Output)
+    if ($IsWindows) {
+        $path = Join-Path $Workspace "$Tag.cmd"
+        Set-Content -LiteralPath $path -Encoding ascii -Value @("@echo off", "echo $Output")
+    }
+    else {
+        $path = Join-Path $Workspace $Tag
+        Set-Content -LiteralPath $path -Encoding ascii -Value @("#!/bin/sh", "echo '$Output'")
+        & chmod +x $path
+    }
+    return $path
+}
+
+function Get-MissingToolPath {
+    param()
+    if ($IsWindows) { return (Join-Path $Workspace "does-not-exist.cmd") }
+    return (Join-Path $Workspace "does-not-exist")
+}
+
+function Write-ProbeResult {
+    # $null means the probe was REFUSED (never executed); "" means it RAN and
+    # produced no readable version. Collapsing the two would let an
+    # unverifiable source read as drift and induce a reinstall.
+    param($Value)
+    @{
+        refused = ($null -eq $Value)
+        parsed  = if ($null -eq $Value) { "" } else { [string]$Value }
+    } | ConvertTo-Json -Compress
+}
+
+$script:Recorded = $null
+$script:StubMetadata = $null
+$script:StubCommandSource = $null
+
+function Get-InstallMetadata { param([string]$CommandName) return $script:StubMetadata }
+function Get-CodeIntelPythonCommand { return $null }
+
+function Add-InstallAction {
+    param(
+        $Actions, [string]$Name, [string]$Status, [string]$Detail = "",
+        [string]$Fix = "", [string]$PackageManager = "", [bool]$RequiresElevation = $false
+    )
+    $script:Recorded = [ordered]@{ name = $Name; status = $Status; detail = $Detail; fix = $Fix }
+}
+
+function Get-Command {
+    # Remaining-args sink so the caller's `-ErrorAction SilentlyContinue` binds
+    # here instead of colliding with the common parameter.
+    param(
+        [Parameter(Position = 0)][string]$Name,
+        [Parameter(ValueFromRemainingArguments = $true)]$Rest
+    )
+    if ($script:StubCommandSource) { return [pscustomobject]@{ Source = $script:StubCommandSource } }
+    return $null
+}
+
+$at032 = New-VersionStub "repowise-032" "repowise, version 0.32.0"
+$at036 = New-VersionStub "repowise-036" "repowise, version 0.36.0"
+$prerelease = New-VersionStub "code-intel" "code-intel 0.7.0-beta.2"
+$silent = New-VersionStub "silent" "no version here"
+
+switch ($Scenario) {
+    "parse-standard" { Write-ProbeResult (Get-ToolVersion $at032 -ExpectedName "repowise"); break }
+    "parse-prerelease" { Write-ProbeResult (Get-ToolVersion $prerelease -ExpectedName "code-intel"); break }
+    "parse-unparseable" { Write-ProbeResult (Get-ToolVersion $silent); break }
+    "parse-empty-source" { Write-ProbeResult (Get-ToolVersion ""); break }
+    "parse-missing-tool" { Write-ProbeResult (Get-ToolVersion (Get-MissingToolPath)); break }
+    "parse-relative-source" {
+        # A bare/relative name must never be executed: PowerShell would resolve
+        # it against the current directory, which is the repository under
+        # analysis.
+        Write-ProbeResult (Get-ToolVersion "repowise")
+        break
+    }
+    "parse-script-source" {
+        # The load-bearing security case. A `.ps1` on PATH resolves to an
+        # ExternalScriptInfo whose Source is the script path; `& $Source` would
+        # run it INSIDE the installer process.
+        $script = Join-Path $Workspace "repowise.ps1"
+        Set-Content -LiteralPath $script -Encoding ascii -Value @('Write-Output "repowise, version 0.36.0"')
+        Write-ProbeResult (Get-ToolVersion $script -ExpectedName "repowise")
+        break
+    }
+    "parse-noise-before-version" {
+        # A deprecation banner carrying its own version-shaped number must not
+        # win the match when the tool name anchors the real line.
+        $noisy = New-VersionStub "noisy" "DeprecationWarning from setuptools 3.11.0"
+        Add-Content -LiteralPath $noisy -Value $(if ($IsWindows) { "echo repowise, version 0.36.0" } else { "echo 'repowise, version 0.36.0'" })
+        Write-ProbeResult (Get-ToolVersion $noisy -ExpectedName "repowise")
+        break
+    }
+    "compliance-checks" {
+        # `ok` is computed from $checks only. This asserts drift actually
+        # reaches that computation, and that an unmeasurable version does not
+        # fail the install.
+        $checks = [System.Collections.Generic.List[object]]::new()
+        function Add-Check {
+            param($Checks, [string]$Name, [string]$Category, [bool]$Required, [bool]$Ok, [string]$Detail = "", [string]$Fix = "")
+            $Checks.Add([ordered]@{ name = $Name; category = $Category; required = $Required; ok = $Ok })
+        }
+        $actions = [System.Collections.Generic.List[object]]::new()
+        $actions.Add([ordered]@{ name = "repowise"; status = "version_drift"; detail = "reports version 0.32.0; pinned version is 0.36.0"; fix = "f" })
+        $actions.Add([ordered]@{ name = "mystery"; status = "version_drift"; detail = "reports version unknown; pinned version is 0.36.0"; fix = "f" })
+        $actions.Add([ordered]@{ name = "rg"; status = "already_present"; detail = "/usr/bin/rg"; fix = "" })
+        $actions.Add([ordered]@{ name = "fine"; status = "upgraded"; detail = "now 0.36.0, was 0.32.0"; fix = "" })
+
+        Add-VersionComplianceChecks $checks $actions
+        @{
+            emitted  = @($checks | ForEach-Object { $_.name })
+            required = @($checks | Where-Object { $_.required } | ForEach-Object { $_.name })
+        } | ConvertTo-Json -Compress
+        break
+    }
+    "wiring" {
+        # Everything above stubs Get-InstallMetadata, so nothing so far proves
+        # the REAL switch actually carries the pin. Without this scenario,
+        # deleting `pinnedVersion = $script:RepowisePinnedVersion` from the
+        # installer restores the presence-only bug and every other test still
+        # passes.
+        $installerText = Get-Content -Raw -LiteralPath $Installer
+        $pinMatch = [regex]::Match($installerText, '\$script:RepowisePinnedVersion\s*=\s*"([^"]+)"')
+        if (-not $pinMatch.Success) { throw "RepowisePinnedVersion assignment not found in installer" }
+        $script:RepowisePinnedVersion = $pinMatch.Groups[1].Value
+        $script:EffectivePlatform = if ($IsWindows) { "windows" } elseif ($IsMacOS) { "macos" } else { "linux" }
+
+        $realMetadata = $ast.Find({
+                param($node)
+                $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq "Get-InstallMetadata"
+            }, $true)
+        if (-not $realMetadata) { throw "Get-InstallMetadata not found in installer" }
+        . ([scriptblock]::Create($realMetadata.Extent.Text))
+
+        $repowise = Get-InstallMetadata "repowise"
+        $rg = Get-InstallMetadata "rg"
+        # Report a sentinel rather than dereferencing a missing key: under
+        # StrictMode that would surface as a property-access exception, which
+        # reads as a broken test rather than as the regression it is.
+        @{
+            pinLiteral     = $script:RepowisePinnedVersion
+            repowisePinned = if ($repowise.Contains("pinnedVersion")) { [string]$repowise.pinnedVersion } else { "<no pinnedVersion key>" }
+            rgHasPin       = [bool]$rg.Contains("pinnedVersion")
+        } | ConvertTo-Json -Compress
+        break
+    }
+    "match" {
+        $InstallMissing = $false
+        $script:StubMetadata = [ordered]@{ packageManager = "pip"; requiresElevation = $false; pinnedVersion = "0.32.0" }
+        $script:StubCommandSource = $at032
+        Install-MissingTool ([System.Collections.Generic.List[object]]::new()) "repowise" { throw "installer must not run when the version matches" } "fix"
+        $script:Recorded | ConvertTo-Json -Compress
+        break
+    }
+    "drift" {
+        $InstallMissing = $false
+        $script:StubMetadata = [ordered]@{ packageManager = "pip"; requiresElevation = $false; pinnedVersion = "0.36.0" }
+        $script:StubCommandSource = $at032
+        Install-MissingTool ([System.Collections.Generic.List[object]]::new()) "repowise" { throw "installer must not run without -InstallMissing" } "fix"
+        $script:Recorded | ConvertTo-Json -Compress
+        break
+    }
+    "drift-unknown" {
+        $InstallMissing = $false
+        $script:StubMetadata = [ordered]@{ packageManager = "pip"; requiresElevation = $false; pinnedVersion = "0.36.0" }
+        $script:StubCommandSource = $silent
+        Install-MissingTool ([System.Collections.Generic.List[object]]::new()) "repowise" { throw "installer must not run without -InstallMissing" } "fix"
+        $script:Recorded | ConvertTo-Json -Compress
+        break
+    }
+    "unpinned" {
+        $InstallMissing = $false
+        $script:StubMetadata = [ordered]@{ packageManager = "winget"; requiresElevation = $false }
+        $script:StubCommandSource = $at032
+        Install-MissingTool ([System.Collections.Generic.List[object]]::new()) "rg" { throw "installer must not run for a present unpinned tool" } "fix"
+        $result = $script:Recorded
+        $result["expectedDetail"] = $at032
+        $result | ConvertTo-Json -Compress
+        break
+    }
+    "upgrade" {
+        $InstallMissing = $true
+        $script:StubMetadata = [ordered]@{ packageManager = "pip"; requiresElevation = $false; pinnedVersion = "0.36.0" }
+        $script:StubCommandSource = $at032
+        Install-MissingTool ([System.Collections.Generic.List[object]]::new()) "repowise" { $script:StubCommandSource = $at036 } "fix"
+        $script:Recorded | ConvertTo-Json -Compress
+        break
+    }
+    "upgrade-failed" {
+        $InstallMissing = $true
+        $script:StubMetadata = [ordered]@{ packageManager = "pip"; requiresElevation = $false; pinnedVersion = "0.36.0" }
+        $script:StubCommandSource = $at032
+        Install-MissingTool ([System.Collections.Generic.List[object]]::new()) "repowise" { } "fix"
+        $script:Recorded | ConvertTo-Json -Compress
+        break
+    }
+    default { throw "unknown scenario: $Scenario" }
+}
+"##;
+
+fn scenario(tag: &str) -> Value {
+    let temp = Temp::new(tag);
+    let driver = temp.0.join("driver.ps1");
+    fs::write(&driver, DRIVER).expect("write driver");
+
+    let installer = repo_root().join("legacy/install-code-intel-pipeline.ps1");
+    let output = Command::new("pwsh")
+        .args([
+            "-NoLogo",
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+        ])
+        .arg(&driver)
+        .arg("-Installer")
+        .arg(&installer)
+        .arg("-Scenario")
+        .arg(tag)
+        .arg("-Workspace")
+        .arg(&temp.0)
+        .output()
+        .expect("run version gate driver");
+
+    assert!(
+        output.status.success(),
+        "driver failed for scenario {tag}: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|err| panic!("scenario {tag} emitted non-JSON ({err}): {stdout}"))
+}
+
+#[test]
+fn tool_version_parses_the_formats_the_gate_actually_meets() {
+    let standard = scenario("parse-standard");
+    assert_eq!(standard["refused"], false);
+    assert_eq!(
+        standard["parsed"], "0.32.0",
+        "`repowise, version X` is what the pinned tool prints"
+    );
+
+    let prerelease = scenario("parse-prerelease");
+    assert_eq!(prerelease["refused"], false);
+    assert_eq!(
+        prerelease["parsed"], "0.7.0-beta.2",
+        "a prerelease suffix must survive whole, or every beta reads as drift"
+    );
+}
+
+#[test]
+fn the_probe_refuses_sources_the_project_forbids_launching() {
+    // tool_path.rs states the rule for every tool launch in this project:
+    // "only ever launches by absolute path", "relative PATH entries are
+    // skipped outright". A `.ps1` is worse than merely relative — `& $Source`
+    // would execute it inside the installer's own process.
+    for tag in [
+        "parse-empty-source",
+        "parse-missing-tool",
+        "parse-relative-source",
+        "parse-script-source",
+    ] {
+        assert_eq!(
+            scenario(tag)["refused"],
+            true,
+            "{tag} must be refused, not executed"
+        );
+    }
+}
+
+#[test]
+fn a_version_shaped_number_in_a_banner_does_not_win_the_match() {
+    let result = scenario("parse-noise-before-version");
+    assert_eq!(result["refused"], false);
+    assert_eq!(
+        result["parsed"], "0.36.0",
+        "the name-anchored line wins over `setuptools 3.11.0` noise"
+    );
+}
+
+#[test]
+fn a_probe_that_ran_but_read_nothing_is_unknown_not_a_match() {
+    // The gate exists to surface exactly this state; treating it as a match
+    // would restore the presence-only behaviour it replaces.
+    for tag in ["parse-unparseable"] {
+        assert_eq!(
+            scenario(tag)["refused"],
+            false,
+            "{tag} is executable; it ran"
+        );
+        assert_eq!(
+            scenario(tag)["parsed"],
+            "",
+            "{tag} must read as unknown, not as a version"
+        );
+    }
+}
+
+#[test]
+fn a_matching_pinned_version_stays_already_present() {
+    let result = scenario("match");
+    assert_eq!(result["status"], "already_present");
+    assert!(
+        result["detail"]
+            .as_str()
+            .unwrap()
+            .contains("version 0.32.0"),
+        "the matching case reports what it observed: {}",
+        result["detail"]
+    );
+}
+
+#[test]
+fn drift_is_reported_even_when_the_gate_may_not_fix_it() {
+    // Without -InstallMissing the installer must not touch the system, but
+    // staying silent is the failure this branch exists to prevent: a
+    // present-but-wrong version previously read as already_present.
+    let result = scenario("drift");
+    assert_eq!(result["status"], "version_drift");
+    let detail = result["detail"].as_str().unwrap();
+    assert!(
+        detail.contains("0.32.0"),
+        "names the observed version: {detail}"
+    );
+    assert!(
+        detail.contains("0.36.0"),
+        "names the pinned version: {detail}"
+    );
+    assert!(
+        result["fix"].as_str().unwrap().contains("-InstallMissing"),
+        "tells the operator how to resolve it"
+    );
+}
+
+#[test]
+fn an_unreadable_version_reports_drift_rather_than_passing() {
+    let result = scenario("drift-unknown");
+    assert_eq!(result["status"], "version_drift");
+    assert!(
+        result["detail"].as_str().unwrap().contains("unknown"),
+        "got: {}",
+        result["detail"]
+    );
+}
+
+#[test]
+fn tools_without_a_pin_keep_their_previous_behaviour() {
+    let result = scenario("unpinned");
+    assert_eq!(result["status"], "already_present");
+    assert_eq!(
+        result["detail"], result["expectedDetail"],
+        "an unpinned tool's detail stays the bare source path, with no version probe appended"
+    );
+}
+
+#[test]
+fn install_missing_upgrades_a_drifted_tool_to_the_pin() {
+    let result = scenario("upgrade");
+    assert_eq!(result["status"], "upgraded");
+    assert!(
+        result["detail"].as_str().unwrap().contains("was 0.32.0"),
+        "an upgrade records what it replaced: {}",
+        result["detail"]
+    );
+}
+
+#[test]
+fn a_reinstall_that_does_not_reach_the_pin_fails_loudly() {
+    assert_eq!(scenario("upgrade-failed")["status"], "upgrade_failed");
+}
+
+#[test]
+fn confirmed_drift_reaches_the_ok_computation_but_uncertainty_does_not() {
+    // The installer's `ok` is derived from `$checks`, never from
+    // `$installActions`, and bootstrap-new-machine.ps1 reads only
+    // `installResult.ok`. Drift that stays in installActions is invisible to
+    // every consumer.
+    let result = scenario("compliance-checks");
+
+    let emitted: Vec<&str> = result["emitted"]
+        .as_array()
+        .expect("emitted")
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert_eq!(
+        emitted,
+        vec!["version:repowise", "version:mystery"],
+        "only drift and upgrade_failed become checks; already_present and upgraded do not"
+    );
+
+    let required: Vec<&str> = result["required"]
+        .as_array()
+        .expect("required")
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert_eq!(
+        required,
+        vec!["version:repowise"],
+        "a measured mismatch fails the install; an unreadable version is uncertainty and must not"
+    );
+}
+
+#[test]
+fn the_real_metadata_switch_carries_the_pin() {
+    // Every scenario above stubs Get-InstallMetadata, so none of them prove the
+    // production switch is wired. Deleting `pinnedVersion =
+    // $script:RepowisePinnedVersion` from the installer restores the exact
+    // presence-only bug this change fixes; without this test that deletion is
+    // invisible.
+    let result = scenario("wiring");
+
+    assert_eq!(
+        result["repowisePinned"], result["pinLiteral"],
+        "the repowise metadata entry must carry the supply-chain-003 pin, not a literal that drifted from it"
+    );
+    assert_eq!(
+        result["repowisePinned"], "0.36.0",
+        "if the pin moves, this assertion is the deliberate place to notice"
+    );
+    assert_eq!(
+        result["rgHasPin"], false,
+        "unpinned tools must not gain a pinnedVersion key, or they acquire a version probe they never had"
+    );
+}

--- a/crates/code-intel-cli/tests/version_cli.rs
+++ b/crates/code-intel-cli/tests/version_cli.rs
@@ -1,0 +1,110 @@
+//! Contract tests for `code-intel --version`.
+//!
+//! This surface exists because a binary that cannot report its own version
+//! cannot be audited. `%LOCALAPPDATA%/code-intel/bin/repo.json` records where
+//! the installer ran from, not what it produced, so a machine running a stale
+//! build is indistinguishable from a current one — a v0.6.0 binary answering
+//! `snapshot identity` in 10.9s looked exactly like the 0.28s build until the
+//! two were timed side by side.
+//!
+//! What is pinned here is what the installer's version gate parses: a version
+//! token on stdout, exit 0, and a stable `--json` schema id. The gate treats an
+//! unreadable version as "unknown", never as "matches", so an empty or
+//! non-zero-exit answer is a contract break, not a soft failure.
+
+use std::process::Command;
+
+fn run(args: &[&str]) -> (String, String, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_code-intel"))
+        .args(args)
+        .output()
+        .expect("run code-intel");
+    (
+        String::from_utf8_lossy(&output.stdout).to_string(),
+        String::from_utf8_lossy(&output.stderr).to_string(),
+        output.status.code().unwrap_or(-1),
+    )
+}
+
+#[test]
+fn version_flag_reports_the_crate_version_and_exits_zero() {
+    let (stdout, stderr, code) = run(&["--version"]);
+
+    assert_eq!(code, 0, "--version must exit 0, stderr: {stderr}");
+    assert_eq!(
+        stdout.trim(),
+        format!("code-intel {}", env!("CARGO_PKG_VERSION")),
+        "installer parses this line; the shape is the contract"
+    );
+}
+
+#[test]
+fn short_version_flag_matches_long_flag() {
+    let (long, _, long_code) = run(&["--version"]);
+    let (short, _, short_code) = run(&["-V"]);
+
+    assert_eq!(long_code, 0);
+    assert_eq!(short_code, 0);
+    assert_eq!(
+        long.trim(),
+        short.trim(),
+        "-V is an alias, not a second format"
+    );
+}
+
+#[test]
+fn json_version_carries_a_stable_schema_id() {
+    let (stdout, stderr, code) = run(&["--version", "--json"]);
+
+    assert_eq!(code, 0, "stderr: {stderr}");
+    let parsed: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("--version --json must emit one JSON document");
+    assert_eq!(parsed["schema"], "code-intel-version.v1");
+    assert_eq!(parsed["name"], "code-intel");
+    assert_eq!(parsed["version"], env!("CARGO_PKG_VERSION"));
+}
+
+#[test]
+fn version_token_is_parseable_by_the_installer_regex() {
+    // Get-ToolVersion in legacy/install-code-intel-pipeline.ps1 matches
+    // `\d+\.\d+\.\d+(?:[-.][0-9A-Za-z.]+)?` against this output. A version that
+    // does not match reads as "unknown" and the pin gate cannot fire, so the
+    // shape is asserted here rather than only in PowerShell.
+    let (stdout, _, _) = run(&["--version"]);
+    let token = stdout
+        .trim()
+        .rsplit(' ')
+        .next()
+        .expect("version token")
+        .to_string();
+
+    let mut chars = token.chars();
+    let leading_digit = chars.next().is_some_and(|c| c.is_ascii_digit());
+    assert!(
+        leading_digit,
+        "version token must start with a digit: {token}"
+    );
+    assert_eq!(
+        token.split('.').count().min(3),
+        3,
+        "version token needs at least major.minor.patch: {token}"
+    );
+}
+
+#[test]
+fn version_is_answered_before_route_dispatch() {
+    // `--version` starts with `-`, so it is neither a primary invocation nor a
+    // raw route. Without the early dispatch it falls through to `run()` and
+    // exits as an unknown command — which is exactly what shipped until now.
+    let (stdout, _, code) = run(&["--version", "--repo", "does-not-exist"]);
+
+    assert_eq!(
+        code, 0,
+        "--version must not be evaluated against unrelated arguments"
+    );
+    assert!(
+        stdout.trim().starts_with("code-intel "),
+        "got: {}",
+        stdout.trim()
+    );
+}

--- a/legacy/install-code-intel-pipeline.ps1
+++ b/legacy/install-code-intel-pipeline.ps1
@@ -273,7 +273,11 @@ function Get-InstallMetadata {
     param([string]$CommandName)
 
     switch ($CommandName) {
-        "repowise" { return [ordered]@{ packageManager = "pip"; requiresElevation = $false } }
+        # pinnedVersion turns the supply-chain-003 pin from a declaration into a
+        # gate. Without it Install-MissingTool returns on presence alone, so a
+        # machine that installed repowise once keeps whatever version it landed
+        # on and the pin never executes.
+        "repowise" { return [ordered]@{ packageManager = "pip"; requiresElevation = $false; pinnedVersion = $script:RepowisePinnedVersion } }
         "sentrux" { return [ordered]@{ packageManager = "manual"; requiresElevation = $false } }
     }
 
@@ -294,6 +298,106 @@ function Get-InstallMetadata {
     }
 }
 
+function Test-ToolVersionProbeAllowed {
+    # Mirrors the resolution rule crates/code-intel-cli/src/tool_path.rs states
+    # for every tool launch in this project: "only ever launches by absolute
+    # path", and "relative PATH entries are skipped outright". This matters
+    # here because the installer runs against a repository it does not trust,
+    # and a `repowise.ps1` on PATH would be dot-run *inside this process* by
+    # `& $Source` — arbitrary in-process code, not a sandboxed child.
+    #
+    # A refused probe is not a failed probe: the caller keeps the pre-existing
+    # presence-only behaviour rather than reporting drift, so an unverifiable
+    # source can never induce a reinstall.
+    param([string]$Source)
+
+    if ([string]::IsNullOrWhiteSpace($Source)) { return $false }
+    if (-not [System.IO.Path]::IsPathRooted($Source)) { return $false }
+    if (-not (Test-Path -LiteralPath $Source -PathType Leaf)) { return $false }
+    if ([System.IO.Path]::GetExtension($Source) -in @(".ps1", ".psm1", ".psd1")) { return $false }
+    return $true
+}
+
+function Get-ToolVersion {
+    # Reads a tool's own reported version.
+    #
+    # Returns $null when the probe was REFUSED (source is not a rooted, real,
+    # non-script file) — the caller must fall back to presence-only reporting.
+    # Returns "" when the probe RAN but produced no readable version, which
+    # callers must treat as "unknown", never as "matches".
+    param(
+        [string]$Source,
+        [string]$ExpectedName = ""
+    )
+
+    if (-not (Test-ToolVersionProbeAllowed $Source)) { return $null }
+
+    # Launch the child explicitly so the exit code, stdout, and stderr all come
+    # from the process we started. `$LASTEXITCODE` is only set by native
+    # commands, so reading it after `& $Source` would either see a stale value
+    # from an unrelated earlier call or, under Set-StrictMode, throw on an
+    # unset automatic variable and abort the whole installer.
+    $stdoutFile = [System.IO.Path]::GetTempFileName()
+    $stderrFile = [System.IO.Path]::GetTempFileName()
+    try {
+        $process = Start-Process -FilePath $Source -ArgumentList "--version" `
+            -RedirectStandardOutput $stdoutFile -RedirectStandardError $stderrFile `
+            -NoNewWindow -PassThru -Wait -ErrorAction Stop
+        if ($process.ExitCode -ne 0) { return "" }
+        # stdout only: a deprecation banner on stderr must not win the match.
+        $raw = Get-Content -Raw -LiteralPath $stdoutFile -ErrorAction SilentlyContinue
+    }
+    catch {
+        return ""
+    }
+    finally {
+        Remove-Item -LiteralPath $stdoutFile, $stderrFile -Force -ErrorAction SilentlyContinue
+    }
+
+    if ([string]::IsNullOrWhiteSpace($raw)) { return "" }
+
+    # Anchor to the tool's own name when we know it, so an unrelated
+    # version-shaped number in a warning line cannot forge a match either way.
+    # Accepts "repowise, version 0.32.0" and "code-intel 0.7.0-beta.2".
+    $versionPattern = '(\d+\.\d+\.\d+(?:[-.][0-9A-Za-z.]+)?)'
+    if (-not [string]::IsNullOrWhiteSpace($ExpectedName)) {
+        $named = [regex]::Match($raw, "(?im)^\s*$([regex]::Escape($ExpectedName))[,]?\s+(?:version\s+)?$versionPattern\s*$")
+        if ($named.Success) { return $named.Groups[1].Value }
+    }
+    $match = [regex]::Match($raw, $versionPattern)
+    if ($match.Success) { return $match.Groups[1].Value }
+    return ""
+}
+
+function Add-VersionComplianceChecks {
+    # A pin that only shows up in installActions is still a declaration nothing
+    # enforces: `ok` is computed from $checks alone, and
+    # bootstrap-new-machine.ps1 reads only installResult.ok. Without this a
+    # drifted machine reports "Install OK: True" — the exact shape
+    # doctor_provider_rows.rs was written to call out: "bootstrap reports ok
+    # while a present external provider is broken".
+    #
+    # Only CONFIRMED drift is required: the tool answered and the answer did
+    # not match the pin. A refused or unreadable probe is uncertainty, not a
+    # known violation, and must not fail an install over something that could
+    # not be measured.
+    param(
+        [System.Collections.Generic.List[object]]$Checks,
+        [System.Collections.Generic.List[object]]$Actions
+    )
+
+    foreach ($action in $Actions) {
+        if ([string]$action.status -notin @("version_drift", "upgrade_failed")) { continue }
+        # "unknown" is the single word both branches use for an unreadable
+        # version (Install-MissingTool's $observed, and the post-reinstall
+        # detail). Matching on it keeps this derivation in one place; the
+        # alternative is a structured field on every Add-InstallAction call
+        # site, which is a wider change than this fix warrants.
+        $confirmed = -not ([string]$action.detail -like "*unknown*")
+        Add-Check $Checks "version:$($action.name)" "version" $confirmed $false ([string]$action.detail) ([string]$action.fix)
+    }
+}
+
 function Install-MissingTool {
     param(
         [System.Collections.Generic.List[object]]$Actions,
@@ -305,7 +409,53 @@ function Install-MissingTool {
     $metadata = Get-InstallMetadata $CommandName
     $existing = if ($CommandName -eq "python") { Get-CodeIntelPythonCommand } else { Get-Command $CommandName -ErrorAction SilentlyContinue }
     if ($existing) {
-        Add-InstallAction $Actions $CommandName "already_present" $existing.Source "" $metadata.packageManager ([bool]$metadata.requiresElevation)
+        $pinned = if ($metadata.Contains("pinnedVersion")) { [string]$metadata.pinnedVersion } else { "" }
+        if ([string]::IsNullOrWhiteSpace($pinned)) {
+            Add-InstallAction $Actions $CommandName "already_present" $existing.Source "" $metadata.packageManager ([bool]$metadata.requiresElevation)
+            return
+        }
+
+        $actual = Get-ToolVersion $existing.Source -ExpectedName $CommandName
+        if ($null -eq $actual) {
+            # Probe refused (see Test-ToolVersionProbeAllowed). Fall back to the
+            # pre-existing presence-only behaviour rather than reporting drift:
+            # an unverifiable source must not be able to induce a reinstall.
+            Add-InstallAction $Actions $CommandName "already_present" "$($existing.Source) (version not probed: source is not a rooted executable file)" "" $metadata.packageManager ([bool]$metadata.requiresElevation)
+            return
+        }
+        if ($actual -eq $pinned) {
+            Add-InstallAction $Actions $CommandName "already_present" "$($existing.Source) (version $actual)" "" $metadata.packageManager ([bool]$metadata.requiresElevation)
+            return
+        }
+
+        $observed = if ([string]::IsNullOrWhiteSpace($actual)) { "unknown" } else { $actual }
+        $driftDetail = "$($existing.Source) reports version $observed; pinned version is $pinned"
+        $driftFix = "Rerun with -InstallMissing to reinstall $CommandName at the pinned version, or set the pin to the version you intend to run."
+
+        # Drift is reported whether or not we are allowed to fix it. Staying
+        # silent here is the failure this whole branch exists to prevent: a
+        # present-but-wrong version currently reads as already_present, which is
+        # indistinguishable from correct.
+        if (-not $InstallMissing) {
+            Add-InstallAction $Actions $CommandName "version_drift" $driftDetail $driftFix $metadata.packageManager ([bool]$metadata.requiresElevation)
+            return
+        }
+
+        try {
+            & $Installer
+            $afterDrift = if ($CommandName -eq "python") { Get-CodeIntelPythonCommand } else { Get-Command $CommandName -ErrorAction SilentlyContinue }
+            $afterVersion = if ($afterDrift) { Get-ToolVersion $afterDrift.Source } else { "" }
+            if ($afterVersion -eq $pinned) {
+                Add-InstallAction $Actions $CommandName "upgraded" "$($afterDrift.Source) (version $afterVersion, was $observed)" "" $metadata.packageManager ([bool]$metadata.requiresElevation)
+            }
+            else {
+                $stillDetail = if ($afterDrift) { "$($afterDrift.Source) still reports $(if ([string]::IsNullOrWhiteSpace($afterVersion)) { 'unknown' } else { $afterVersion }) after reinstall; pinned version is $pinned" } else { "$CommandName is not visible in this shell after reinstall" }
+                Add-InstallAction $Actions $CommandName "upgrade_failed" $stillDetail $driftFix $metadata.packageManager ([bool]$metadata.requiresElevation)
+            }
+        }
+        catch {
+            Add-InstallAction $Actions $CommandName "upgrade_failed" $_.Exception.Message $driftFix $metadata.packageManager ([bool]$metadata.requiresElevation)
+        }
         return
     }
 
@@ -1002,6 +1152,8 @@ Install-SentruxShim $installActions $root
 Install-MissingTool $installActions "sentrux" { Invoke-SentruxInstall } "Install the repo-owned shim or ensure sentrux.exe is on PATH."
 Repair-RepowiseThinkingBlockPatch $installActions
 Install-SentruxVlangPluginOverlay $installActions $root
+
+Add-VersionComplianceChecks $checks $installActions
 
 $requiredFiles = @(
     "check-code-intel-tools.ps1",


### PR DESCRIPTION
## 问题

`Install-MissingTool` 的判据一直是「命令在不在 PATH 上」，不是「版本对不对」：

```powershell
$existing = Get-Command $CommandName -ErrorAction SilentlyContinue
if ($existing) {
    Add-InstallAction $Actions $CommandName "already_present" $existing.Source ...
    return          # $Installer scriptblock 永远不会被调用
}
```

`repowise` 是唯一带 pin 的外部工具（`repowise==0.36.0`，源码里标着 supply-chain-003，注释写着「pin the exact version so `--upgrade` cannot pull a newer, unreviewed release onto the machine」）。这个 pin 从来没有在一台装过 repowise 的机器上生效过。

本机实测：`repowise 0.32.0`，落后 pin 四个 minor，而安装报告与一台正确的机器完全一样。

能力早就有了——`Invoke-PipInstall` 支持精确版本——只是拿不到执行机会。**声明存在，强制不存在。**

## 改了什么

- `Get-InstallMetadata` 带 `pinnedVersion`
- 新增 `Get-ToolVersion` 读工具自报版本
- 不匹配报 `version_drift`；`-InstallMissing` 下报 `upgraded` / `upgrade_failed`
- **没有 pin 的工具行为完全不变**

### 探测遵守本项目自己的启动规则

`crates/code-intel-cli/src/tool_path.rs` 为这个项目定下的规则是 *"only ever launches by absolute path"* 和 *"relative PATH entries are skipped outright"*——因为安装器跑在一个它不信任的仓库旁边。

`Test-ToolVersionProbeAllowed` 拒绝非 rooted、不存在、或脚本类的源。理由具体：PATH 上的一个 `repowise.ps1` 会被 `& $Source` **在安装器自己的进程里**执行，那是任意代码，不是沙箱子进程。

**被拒绝不等于探测失败。** 回落到原本的 presence-only 行为，所以一个不可验证的源永远无法诱发重装。

子进程用 `Start-Process -PassThru -Wait` 启动并读它自己的 `ExitCode`，不读 `$LASTEXITCODE`——后者只有原生命令会设，否则要么读到一次无关调用的陈旧值，要么在 `Set-StrictMode` 下抛错、被 `$ErrorActionPreference = "Stop"` 放大成整个安装器中止。

只解析 stdout，并在知道工具名时锚定匹配，所以 banner 里的 `setuptools 3.11.0` 既不能伪造通过也不能伪造漂移。

### ⚠ 确认的漂移现在会让安装失败

`ok` 只由 `checks` 计算，所以只进 `installActions` 的状态对所有消费者都不可见——`bootstrap-new-machine.ps1` 只读 `installResult.ok`，一台漂移的机器本会报 `Install OK: True`。那正是 `doctor_provider_rows.rs:13-18` 写下的形状：

> `bootstrap` reports `ok` while a present external provider is broken... the branch every installed developer machine takes had no coverage.

`Add-VersionComplianceChecks` 从 actions 派生 `version:<tool>` check。**已配置的机器需要动作**：`repowise` off-pin 的机器现在报 `ok: false`，`missingRequired` 里出现 `version:repowise`。用 `-InstallMissing` 解决，或者把 pin 挪到你真正想跑的版本。

探测被拒或读不出时该 check **不 required**：不确定要被看见，但不能因为一个没测出来的版本让安装失败。

### `code-intel --version`

含 `-V` 与 `--version --json`（`code-intel-version.v1`）。装机的二进制此前无法报告自己是什么：`bin/repo.json` 记的是安装器从哪跑的，不是它产出了什么。

实测代价：一个 v0.6.0 的装机二进制跑 `snapshot identity` 要 **10.9s**，含 `git cat-file --batch` 修复的构建是 **0.28s**，而机器上没有任何东西能分辨这两者。

这是**自报的构建身份，不是 provenance**——值来自被质疑的那个二进制自己的 `CARGO_PKG_VERSION`，只能分辨陈旧与当前，不能分辨真实与替换。安装器记录的 `sha256=` 才是 provenance 信号。

## 测试

按 #78/#80 的方向落在 Rust 侧。driver 由测试生成到临时目录，仓里不新增 `.ps1`（AGENTS.md 第一条）。

12 个场景：解析格式（标准 / prerelease）、拒绝规则（空 / 不存在 / 相对路径 / `.ps1`）、banner 噪音、漂移 / 升级 / 升级失败、合规 check 派生，以及真实 `Get-InstallMetadata` switch 确实带着 pin。

最后一条是 **regression-proof**，已实测：把 `pinnedVersion = $script:RepowisePinnedVersion` 从真实 switch 删掉（即完全恢复本 PR 修的 bug），只有 `the_real_metadata_switch_carries_the_pin` 失败，其余全过。

`New-VersionStub` 按平台产出 `.cmd` 或 `#!/bin/sh` + `chmod +x`，因为 `cross-platform-smoke` 在 macos/ubuntu 上也跑 `cargo test -p code-intel --locked`。

## 验证

- `cargo test -p code-intel`：新增 17 个测试全过
- `cargo fmt -p code-intel -- --check`：clean
- `legacy/tools/check-hardcoded-paths.ps1`：OK（129 files）
- 端到端跑安装器：`repowise version_drift ... reports version 0.32.0; pinned version is 0.36.0`，`ok: false`，`missingRequired` 含 `version:repowise`

**已知的既有失败**（与本 PR 无关，已用 `git stash` 在干净树上复现）：`internalization_record::ticket_r11_tree_sitter_v_record_does_not_claim_sentrux_or_grammar_ownership` — `overlays/sentrux/vlang/src/sentrux_vlang_alias.c digest is not bound into the record`。

## 未做，建议另开票

复核提出但本 PR 未处理的，都不是 bug 而是设计取舍：

1. `-AuditInstallPlan` 模式仍会探测。「先给我看计划」的模式不该以执行被审计的二进制为代价。
2. 读不出版本 → `-InstallMissing` 下直接触发 `pip install`（无 `--require-hashes`、无 index 锁定）。诱导本地故障即可反复触发远程拉取。
3. `upgrade_failed` 的两个分支（工具消失 / installer 抛错）无测试覆盖。
4. `version_cli.rs` 里那条正则测试比实际正则弱，`0.7.0+build.5` 这类会漏。

Refs #59
