### PR TITLE
chore(toolchain): 给依赖版本建一份带绑定测试的单一真源

### DIFF
--- a/crates/code-intel-cli/tests/toolchain_versions.rs
+++ b/crates/code-intel-cli/tests/toolchain_versions.rs
@@ -1,0 +1,226 @@
+//! Binding tests for `orchestration/toolchain-versions.v1.json`.
+//!
+//! The manifest exists so the consistency self-check reads one format instead
+//! of five (TOML, pip, a shell variable inside a workflow, JSON, PowerShell).
+//! A second source of truth that can drift from the first is worse than no
+//! second source at all, so every entry is asserted against its real
+//! declaration sites here.
+//!
+//! `declaredIn[].pattern` is checked against EVERY match in the file, not the
+//! first: `ci.yml` installs ast-grep in two independent jobs, each with its own
+//! hardcoded version, and a change that updates one and forgets the other is
+//! exactly the drift this file is meant to catch.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .canonicalize()
+        .expect("repo root")
+}
+
+fn manifest() -> Value {
+    let path = repo_root().join("orchestration/toolchain-versions.v1.json");
+    let text =
+        fs::read_to_string(&path).unwrap_or_else(|err| panic!("read {}: {err}", path.display()));
+    serde_json::from_str(&text).expect("toolchain-versions.v1.json is valid JSON")
+}
+
+fn tools(doc: &Value) -> &Vec<Value> {
+    doc["tools"].as_array().expect("tools array")
+}
+
+/// Minimal regex support for the shapes the manifest actually uses: a literal
+/// prefix, one `([^X]+)` capture, and a literal suffix, optionally anchored
+/// with `^`. Inside the negated class, `\s` expands to whitespace and `\\` to a
+/// backslash; everything else is literal. Pulling in a regex crate for six
+/// patterns would add a dependency to a crate that currently has exactly one.
+fn find_all(text: &str, pattern: &str) -> Vec<String> {
+    let anchored = pattern.starts_with('^');
+    let body = pattern.strip_prefix('^').unwrap_or(pattern);
+
+    let open = body.find("([^").expect("pattern has a capture group");
+    let close = body[open..].find("]+)").expect("capture group is closed") + open;
+    let prefix = unescape(&body[..open]);
+    let terminators = expand_class(&body[open + 3..close]);
+    let suffix = unescape(&body[close + 3..]);
+
+    let mut out = Vec::new();
+    for line in text.lines() {
+        let start = match (anchored, line.find(&prefix)) {
+            (true, Some(0)) => 0,
+            (true, _) => continue,
+            (false, Some(index)) => index,
+            (false, None) => continue,
+        };
+        let rest = &line[start + prefix.len()..];
+        let end = rest
+            .find(|c: char| terminators.contains(&c))
+            .unwrap_or(rest.len());
+        let captured = &rest[..end];
+        if captured.is_empty() {
+            continue;
+        }
+        if !suffix.is_empty() && !rest[end..].starts_with(&suffix) {
+            continue;
+        }
+        out.push(captured.to_string());
+    }
+    out
+}
+
+/// Expands the character class inside `[^...]`. Without this, `\s` reads as the
+/// two literal characters `\` and `s`, so `pyyaml==6.0.3 \` captures a trailing
+/// space and every comparison fails on invisible whitespace.
+fn expand_class(class: &str) -> Vec<char> {
+    let mut out = Vec::new();
+    let mut chars = class.chars();
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            Some('s') => out.extend([' ', '\t', '\r', '\n']),
+            Some(other) => out.push(other),
+            None => out.push('\\'),
+        }
+    }
+    out
+}
+
+fn unescape(pattern: &str) -> String {
+    pattern.replace("\\$", "$").replace("\\\\", "\\")
+}
+
+#[test]
+fn the_manifest_matches_its_declared_schema_shape() {
+    let doc = manifest();
+    assert_eq!(doc["schema"], "code-intel-toolchain-versions.v1");
+
+    for tool in tools(&doc) {
+        let name = tool["name"].as_str().expect("name");
+        for field in ["version", "scope", "rationale"] {
+            assert!(
+                tool[field].as_str().is_some_and(|s| !s.is_empty()),
+                "{name}.{field} must be a non-empty string"
+            );
+        }
+        assert!(
+            tool["required"].is_boolean(),
+            "{name}.required must be a boolean"
+        );
+        assert!(
+            matches!(tool["scope"].as_str(), Some("build" | "ci" | "runtime")),
+            "{name}.scope is not one of build/ci/runtime"
+        );
+        assert!(
+            !tool["declaredIn"]
+                .as_array()
+                .expect("declaredIn")
+                .is_empty(),
+            "{name} declares no source location, so nothing binds it"
+        );
+    }
+}
+
+#[test]
+fn every_declared_version_matches_its_real_declaration_sites() {
+    let doc = manifest();
+    let root = repo_root();
+
+    for tool in tools(&doc) {
+        let name = tool["name"].as_str().expect("name");
+        let expected = tool["version"].as_str().expect("version");
+
+        for declaration in tool["declaredIn"].as_array().expect("declaredIn") {
+            let file = declaration["file"].as_str().expect("file");
+            let pattern = declaration["pattern"].as_str().expect("pattern");
+            let path = root.join(file);
+            let text = fs::read_to_string(&path)
+                .unwrap_or_else(|err| panic!("{name}: read {}: {err}", path.display()));
+
+            let found = find_all(&text, pattern);
+            assert!(
+                !found.is_empty(),
+                "{name}: pattern `{pattern}` matched nothing in {file} — the declaration moved and this manifest is now stale"
+            );
+            for (index, actual) in found.iter().enumerate() {
+                assert_eq!(
+                    actual, expected,
+                    "{name}: match #{index} in {file} is {actual}, manifest says {expected}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn a_file_that_declares_a_tool_twice_may_not_disagree_with_itself() {
+    // ci.yml installs ast-grep in both the windows job and the cross-platform
+    // matrix, each with its own `$version = '...'`. Updating one and forgetting
+    // the other is a silent split; this asserts the manifest sees both.
+    let doc = manifest();
+    let root = repo_root();
+    let ast_grep = tools(&doc)
+        .iter()
+        .find(|t| t["name"] == "ast-grep")
+        .expect("ast-grep entry");
+    let declaration = &ast_grep["declaredIn"][0];
+    let text =
+        fs::read_to_string(root.join(declaration["file"].as_str().unwrap())).expect("ci.yml");
+
+    let found = find_all(&text, declaration["pattern"].as_str().unwrap());
+    assert!(
+        found.len() >= 2,
+        "expected ast-grep to be declared in more than one ci.yml job, found {} — if the duplicate was consolidated, simplify this test rather than deleting it",
+        found.len()
+    );
+}
+
+#[test]
+fn every_probe_is_executable_as_described() {
+    // A probe the self-check cannot run is a tool the self-check silently skips
+    // — the failure mode this whole manifest exists to remove.
+    let doc = manifest();
+    for tool in tools(&doc) {
+        let name = tool["name"].as_str().expect("name");
+        let probe = &tool["probe"];
+        match probe["kind"].as_str() {
+            Some("command") => assert!(
+                probe["command"].as_str().is_some_and(|s| !s.is_empty()),
+                "{name}: command probe needs a command"
+            ),
+            Some("python-module") => assert!(
+                probe["module"].as_str().is_some_and(|s| !s.is_empty()),
+                "{name}: python-module probe needs a module"
+            ),
+            Some("npm-package") => assert!(
+                probe["package"].as_str().is_some_and(|s| !s.is_empty()),
+                "{name}: npm-package probe needs a package"
+            ),
+            other => panic!("{name}: unknown probe kind {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn the_pipelines_own_version_is_the_crate_version() {
+    // If this drifts, `code-intel --version` reports a number the manifest
+    // does not know about, and the self-check compares against a stale target.
+    let doc = manifest();
+    let entry = tools(&doc)
+        .iter()
+        .find(|t| t["name"] == "code-intel")
+        .expect("code-intel entry");
+    assert_eq!(
+        entry["version"].as_str().expect("version"),
+        env!("CARGO_PKG_VERSION"),
+        "manifest and Cargo.toml disagree about the pipeline's own version"
+    );
+}

--- a/orchestration/schemas/code-intel-toolchain-versions.v1.schema.json
+++ b/orchestration/schemas/code-intel-toolchain-versions.v1.schema.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://code-intel.local/schemas/code-intel-toolchain-versions.v1.schema.json",
+  "title": "Code Intel declared toolchain versions",
+  "description": "Single source for the machine-versus-declaration consistency check. Upstream freshness is out of scope by construction: this document records what the repository declares, never what an ecosystem currently publishes.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "tools"],
+  "properties": {
+    "schema": { "const": "code-intel-toolchain-versions.v1" },
+    "note": { "type": "string" },
+    "tools": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/tool" }
+    }
+  },
+  "$defs": {
+    "tool": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version", "scope", "required", "rationale", "declaredIn", "probe"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "version": { "type": "string", "minLength": 1 },
+        "scope": {
+          "enum": ["build", "ci", "runtime"],
+          "description": "build = needed to compile; ci = only on the runner; runtime = needed by an installed pipeline."
+        },
+        "required": {
+          "type": "boolean",
+          "description": "Whether a confirmed mismatch fails the self-check. An absent or unreadable version is never a failure regardless."
+        },
+        "rationale": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Why this version is pinned. A pin without a recorded reason rots into cargo cult."
+        },
+        "declaredIn": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/declaration" }
+        },
+        "probe": { "$ref": "#/$defs/probe" }
+      }
+    },
+    "declaration": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["file", "pattern"],
+      "properties": {
+        "file": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Repo-relative path of the real declaration."
+        },
+        "pattern": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Regex with exactly one capture group holding the version. EVERY match in the file must equal `version` — a file that declares the same tool twice must not be allowed to disagree with itself."
+        },
+        "note": { "type": "string" }
+      }
+    },
+    "probe": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind"],
+      "properties": {
+        "kind": { "enum": ["command", "python-module", "npm-package"] },
+        "command": { "type": "string", "minLength": 1 },
+        "expectedName": {
+          "type": "string",
+          "description": "Token the tool prints before its version, used to anchor the match so a banner's own version number cannot win."
+        },
+        "module": { "type": "string", "minLength": 1 },
+        "package": { "type": "string", "minLength": 1 }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "kind": { "const": "command" } } },
+          "then": { "required": ["command"] }
+        },
+        {
+          "if": { "properties": { "kind": { "const": "python-module" } } },
+          "then": { "required": ["module"] }
+        },
+        {
+          "if": { "properties": { "kind": { "const": "npm-package" } } },
+          "then": { "required": ["package"] }
+        }
+      ]
+    }
+  }
+}

--- a/orchestration/toolchain-versions.v1.json
+++ b/orchestration/toolchain-versions.v1.json
@@ -1,0 +1,113 @@
+{
+  "schema": "code-intel-toolchain-versions.v1",
+  "note": "Single source for the consistency self-check: does this machine run the versions this repository declares? Every entry's `version` is asserted against its real declaration sites by tests/toolchain_versions.rs, so this file cannot silently drift from them. Upstream freshness (is the declared version behind what the ecosystem publishes?) is deliberately NOT modelled here — pinning is a supply-chain control (supply-chain-001/003) and reproducibility control (rust-toolchain.toml), and conflating the two would turn a pin into an auto-upgrade.",
+  "tools": [
+    {
+      "name": "rust-toolchain",
+      "version": "1.95.0",
+      "scope": "build",
+      "required": true,
+      "rationale": "Pinned so CI, release, and local builds share one compiler; an unpinned channel makes released binaries unreproducible.",
+      "declaredIn": [
+        {
+          "file": "rust-toolchain.toml",
+          "pattern": "channel = \"([^\"]+)\""
+        }
+      ],
+      "probe": {
+        "kind": "command",
+        "command": "rustc",
+        "expectedName": "rustc"
+      }
+    },
+    {
+      "name": "ast-grep",
+      "version": "0.42.3",
+      "scope": "ci",
+      "required": false,
+      "rationale": "Structural-edit engine. CI pins the version, verifies the download's sha256, and re-checks --version after install.",
+      "declaredIn": [
+        {
+          "file": ".github/workflows/ci.yml",
+          "pattern": "\\$version = '([^']+)'",
+          "note": "Two jobs install ast-grep independently; every match must agree."
+        }
+      ],
+      "probe": {
+        "kind": "command",
+        "command": "ast-grep",
+        "expectedName": "ast-grep"
+      }
+    },
+    {
+      "name": "pyyaml",
+      "version": "6.0.3",
+      "scope": "ci",
+      "required": false,
+      "rationale": "Hash-pinned for skill-check.yml (supply-chain-001); installed with --require-hashes.",
+      "declaredIn": [
+        {
+          "file": "requirements-ci.txt",
+          "pattern": "^pyyaml==([^\\s\\\\]+)"
+        }
+      ],
+      "probe": {
+        "kind": "python-module",
+        "module": "yaml"
+      }
+    },
+    {
+      "name": "claude-code-merge-queue",
+      "version": "0.5.1",
+      "scope": "ci",
+      "required": false,
+      "rationale": "Merge-queue tooling, pinned exactly rather than by range.",
+      "declaredIn": [
+        {
+          "file": "package.json",
+          "pattern": "\"claude-code-merge-queue\": \"([^\"]+)\""
+        }
+      ],
+      "probe": {
+        "kind": "npm-package",
+        "package": "claude-code-merge-queue"
+      }
+    },
+    {
+      "name": "repowise",
+      "version": "0.36.0",
+      "scope": "runtime",
+      "required": true,
+      "rationale": "Semantic index provider. Pinned so --upgrade cannot pull an unreviewed release onto the machine (supply-chain-003).",
+      "declaredIn": [
+        {
+          "file": "legacy/install-code-intel-pipeline.ps1",
+          "pattern": "\\$script:RepowisePinnedVersion = \"([^\"]+)\""
+        }
+      ],
+      "probe": {
+        "kind": "command",
+        "command": "repowise",
+        "expectedName": "repowise"
+      }
+    },
+    {
+      "name": "code-intel",
+      "version": "0.7.0-beta.2",
+      "scope": "runtime",
+      "required": true,
+      "rationale": "The pipeline's own binary. An installed copy that lags the tree is invisible without a version surface: a v0.6.0 build answered `snapshot identity` in 10.9s where the current tree answers in 0.28s.",
+      "declaredIn": [
+        {
+          "file": "crates/code-intel-cli/Cargo.toml",
+          "pattern": "^version = \"([^\"]+)\""
+        }
+      ],
+      "probe": {
+        "kind": "command",
+        "command": "code-intel",
+        "expectedName": "code-intel"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## 为什么

一致性自检——**这台机器跑的是不是仓里声明的版本**——现在得读五个文件、五种格式：

| 依赖 | 声明处 | 格式 |
|---|---|---|
| Rust toolchain | `rust-toolchain.toml` | TOML 字段 |
| PyYAML | `requirements-ci.txt` | pip + hash |
| ast-grep | `.github/workflows/ci.yml` | **硬编码在 shell 变量里** |
| claude-code-merge-queue | `package.json` | JSON |
| repowise | `legacy/install-code-intel-pipeline.ps1` | PowerShell 变量 |
| code-intel | `crates/code-intel-cli/Cargo.toml` | TOML |

让自检器去解析这五种，等于让它在别人改了 `ci.yml` 的引号写法时**静默少检一项**——正是这个仓反复出现的那个形状（`doctor_provider_rows.rs:13-18`：*"bootstrap reports ok while a present external provider is broken"*）。

## 改了什么

`orchestration/toolchain-versions.v1.json` 收敛成一种格式，附 `code-intel-toolchain-versions.v1` schema（draft 2020-12，`additionalProperties: false`，与仓内其他 schema 同构）。

每条带 `rationale`。**一个没有记录理由的 pin 会腐烂成 cargo cult**，而这里每个理由都是现成的：

- `rust-toolchain` → 不 pin 会让发布产物不可复现
- `pyyaml` → supply-chain-001 的 hash 锁定
- `repowise` → supply-chain-003，不让 `--upgrade` 拉进未审核的版本
- `code-intel` → 装机版落后会带来实测 39 倍的性能差（10.9s vs 0.28s）

### 绑定测试是这个 PR 的重点

**第二真源如果会跟第一真源分叉，比没有第二真源更糟。** `tests/toolchain_versions.rs` 把清单逐条绑回真实声明处，5 个测试：

1. 清单形状符合 schema
2. 每条 `version` 等于真实声明处抓到的值
3. **一个文件声明同一工具两次时不许自相矛盾**
4. 每个 probe 描述可执行
5. 清单里的 `code-intel` 版本等于 `CARGO_PKG_VERSION`

绑定按「**每一处匹配都必须一致**」而不是「第一处匹配」。这不是理论问题：`ci.yml` 在 `windows-build-test-package` 和 `cross-platform-smoke` 两个 job 里**各装了一次 ast-grep**，各有一份硬编码的 `$version = '0.42.3'`。改一处漏一处就是无声分叉，第 3 条测试专门盯它。

## 刻意排除的范围

**「上游最新版本」不在这份清单里。** pin 是供应链控制和可复现性控制；把它跟「追最新」混在一起，等于把 pin 变成自动升级，supply-chain-001 的 hash 锁定和 `rust-toolchain.toml` 的可复现性都会失效。

上游新鲜度（声明是否落后于生态发布）是**独立的一层**，只报告不强制，另开。schema 的 description 里写明了这个边界。

## 本次只落声明侧

探测侧（真的去读机器版本并比对，接进 `code-intel doctor`）接着做，它会复用 #88 落地的 `Get-ToolVersion` / `Test-ToolVersionProbeAllowed`。

清单在探测侧落地前是没有消费者的——但绑定测试本身已经有独立价值：它现在就在盯着 `ci.yml` 那两处 ast-grep 版本。

## 验证

- `cargo test -p code-intel --test toolchain_versions`：5 passed
- schema 校验：`Test-Json -SchemaFile` 通过（仓内既有做法）
- `cargo fmt -p code-intel -- --check`：clean
- 无新增依赖（mini-regex 手写，crate 目前只有 `serde_json` 一个依赖，不为六个 pattern 再加一个）

Refs #59
