### PR TITLE
chore(gitignore): ignore transient .repowise.backup-* index caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ __pycache__/
 .ruff_cache/
 .repowise-workspace/
 .repowise/
+.repowise.backup*/
 .understand-anything/
 .sentrux/cache/
 artifacts/


### PR DESCRIPTION
## 为什么

`.repowise.backup-YYYYMMDD/` 是 repowise 重建索引时留下的临时缓存（~2MB 的 .pkl/.db），不该进版本控制（S1216 已确认口径）。现有 `.gitignore` 只盖 `.repowise/` 与 `.repowise-workspace/`，backup 目录每次重索引都会重新变成未跟踪噪音。

## 改动

- `.gitignore` +1 行：`.repowise.backup*/`

## 不做

- 根目录 `test-scoped-repowise-validator.py` / `Run-ScopedRepowiseDocs.py` 曾被 dead-code 扫描标记，但核实为 ci.yml L247/L554 运行时调用 + installer 校验对象 — 属误报，不动。
