### PR TITLE
fix(repin): boundary-safe excludes, mode-preserving writes, symlink safety

### DIFF
--- a/crates/code-intel-cli/src/repin.rs
+++ b/crates/code-intel-cli/src/repin.rs
@@ -175,9 +175,9 @@ struct AmbiguousSource {
 }
 
 /// A scan target repin could not read at all. `gates_clean` is false only
-/// for binary files, which structurally cannot hold a pin in this repo's
-/// convention; anything else (too large, unreadable) means real text went
-/// uninspected and must not be reported as "clean".
+/// for binary files and symlinks, which structurally cannot hold a pin in
+/// this repo's convention; anything else (too large, unreadable) means real
+/// text went uninspected and must not be reported as "clean".
 struct SkippedFile {
     path: String,
     reason: String,
@@ -304,11 +304,13 @@ fn print_human(report: &RepinReport, write: bool) {
     }
     let action = if write { "rewrote" } else { "found" };
     println!(
-        "repin: {action} {} substitution(s) across {} file(s) in {} pass(es); {} orphaned pin(s)",
+        "repin: {action} {} substitution(s) across {} file(s) in {} pass(es); {} orphaned pin(s), {} ambiguous digest(s), {} skipped file(s)",
         report.total_substitutions(),
         report.findings.len(),
         report.passes,
-        report.orphaned.len()
+        report.orphaned.len(),
+        report.ambiguous.len(),
+        report.skipped.len()
     );
 }
 
@@ -330,6 +332,13 @@ fn flush(repo: &Path, report: &RepinReport) -> Result<(), String> {
             let _ = fs::remove_file(&temporary);
             return Err(format!("write {path}: {error}"));
         }
+        // Best-effort: `fs::write` creates `temporary` with default
+        // permissions, which would silently drop the original file's mode
+        // (e.g. an executable bit) across the rename below. A failure to
+        // read or set permissions is not fatal to the rewrite itself.
+        if let Ok(metadata) = fs::metadata(&target) {
+            let _ = fs::set_permissions(&temporary, metadata.permissions());
+        }
         if let Err(error) = fs::rename(&temporary, &target) {
             let _ = fs::remove_file(&temporary);
             return Err(format!("replace {path}: {error}"));
@@ -342,9 +351,13 @@ fn scan(repo: &Path, extra_excludes: &[String]) -> Result<RepinReport, String> {
     let mut excludes: Vec<String> = DEFAULT_EXCLUDES.iter().map(|s| s.to_string()).collect();
     excludes.extend(extra_excludes.iter().cloned());
     let is_excluded = |path: &str| {
-        excludes
-            .iter()
-            .any(|prefix| path.starts_with(prefix.as_str()))
+        excludes.iter().any(|prefix| {
+            let prefix = prefix.trim_end_matches('/');
+            path == prefix
+                || path
+                    .strip_prefix(prefix)
+                    .is_some_and(|rest| rest.starts_with('/'))
+        })
     };
 
     let digests = snapshot::repin_digests(repo)?;
@@ -565,6 +578,7 @@ fn scan(repo: &Path, extra_excludes: &[String]) -> Result<RepinReport, String> {
 /// uninspected, which the report must never fold into a silent "clean".
 enum LoadError {
     Binary,
+    Symlink,
     TooLarge,
     Unreadable(String),
 }
@@ -573,19 +587,28 @@ impl LoadError {
     fn message(&self) -> String {
         match self {
             LoadError::Binary => "not valid UTF-8 (binary file)".to_string(),
+            LoadError::Symlink => "symbolic link (target is not scanned for pins)".to_string(),
             LoadError::TooLarge => format!("exceeds {MAX_FILE_BYTES} byte scan limit"),
             LoadError::Unreadable(detail) => format!("unreadable: {detail}"),
         }
     }
 
     fn gates_clean(&self) -> bool {
-        !matches!(self, LoadError::Binary)
+        !matches!(self, LoadError::Binary | LoadError::Symlink)
     }
 }
 
 fn load_text(repo: &Path, path: &str) -> Result<Vec<u8>, LoadError> {
     let full = repo.join(path);
-    let metadata = fs::metadata(&full).map_err(|error| LoadError::Unreadable(error.to_string()))?;
+    // `symlink_metadata` (unlike `metadata`) does not follow a symlink, so a
+    // tracked symlink is caught here instead of falling through to `is_file`
+    // on its *target*: if it were loaded and later rewritten, `flush` would
+    // rename a regular file on top of the link path, destroying the symlink.
+    let metadata =
+        fs::symlink_metadata(&full).map_err(|error| LoadError::Unreadable(error.to_string()))?;
+    if metadata.is_symlink() {
+        return Err(LoadError::Symlink);
+    }
     if !metadata.is_file() {
         return Err(LoadError::Unreadable("not a regular file".to_string()));
     }

--- a/crates/code-intel-cli/tests/repin.rs
+++ b/crates/code-intel-cli/tests/repin.rs
@@ -73,6 +73,17 @@ fn repin(repo: &Path, extra_args: &[&str]) -> Output {
     command.output().unwrap()
 }
 
+/// Like `repin`, but without `--json` — for asserting on `print_human`'s
+/// output, which the JSON-only `repin` helper never exercises.
+fn repin_text(repo: &Path, extra_args: &[&str]) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_code-intel"));
+    command.arg("repin").arg("--repo").arg(repo);
+    for arg in extra_args {
+        command.arg(arg);
+    }
+    command.output().unwrap()
+}
+
 fn json(output: &Output) -> Value {
     serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
         panic!(
@@ -429,4 +440,93 @@ fn oversized_file_is_reported_skipped_not_silently_clean() {
     let report = json(&output);
     assert_eq!(report["skipped"][0]["file"], "record.json");
     assert_eq!(report["skipped"][0]["gatesClean"], true);
+}
+
+#[test]
+fn binary_file_is_skipped_but_does_not_gate_clean() {
+    let tree = TempTree::new("repin-binary");
+    init_repo(&tree.0);
+    fs::write(tree.0.join("source.rs"), "fn a() {}\n").unwrap();
+    // 0xFF can never begin a valid UTF-8 sequence, so this is binary under
+    // any decoder — no text-editing tool could have produced it by accident.
+    fs::write(tree.0.join("blob.bin"), [0xffu8, 0xfe, 0x00, 0x80]).unwrap();
+    commit_all(&tree.0, "init source and a binary file");
+
+    // Nothing pins source.rs's digest anywhere, but a stale digest is what
+    // makes repin walk every tracked file looking for a reference to it —
+    // with nothing stale at all, the scan short-circuits on pass one before
+    // ever reaching blob.bin, and it would never be scanned or reported.
+    fs::write(tree.0.join("source.rs"), "fn a() { changed(); }\n").unwrap();
+
+    let output = repin(&tree.0, &[]);
+    assert!(
+        output.status.success(),
+        "a binary file must not gate clean: stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report = json(&output);
+    assert_eq!(report["clean"], true);
+    assert_eq!(report["skipped"][0]["file"], "blob.bin");
+    assert_eq!(report["skipped"][0]["gatesClean"], false);
+
+    // The human-readable form must mark it as informational too, not just
+    // the JSON `gatesClean` field.
+    let text_output = repin_text(&tree.0, &[]);
+    let stdout = String::from_utf8_lossy(&text_output.stdout);
+    assert!(
+        stdout.contains("skipped: blob.bin") && stdout.contains(", informational"),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
+fn human_output_reports_ambiguous_skipped_and_summary_counts() {
+    let tree = TempTree::new("repin-human");
+    init_repo(&tree.0);
+    // Two distinct paths, byte-identical content at HEAD: an ambiguous
+    // digest, same as duplicate_head_content_is_reported_ambiguous_not_silently_rewritten.
+    fs::write(tree.0.join("twin-a.rs"), "// stub\n").unwrap();
+    fs::write(tree.0.join("twin-b.rs"), "// stub\n").unwrap();
+    fs::write(tree.0.join("source.rs"), "fn a() {}\n").unwrap();
+    commit_all(&tree.0, "init identical twins and a source");
+
+    let shared_head = sha256_of(&tree.0.join("twin-a.rs"));
+    let source_head = sha256_of(&tree.0.join("source.rs"));
+    // A record padded past the scan cap, pinning both the shared (ambiguous)
+    // digest and the source digest: it can never be resynced (too large to
+    // scan), so it lands in `skipped` regardless of the ambiguous pin inside.
+    let padding = "x".repeat(5 * 1024 * 1024);
+    fs::write(
+        tree.0.join("record.json"),
+        format!(
+            r#"{{"padding":"{padding}","shared":"{shared_head}","source":{{"path":"source.rs","sha256":"{source_head}"}}}}"#
+        ),
+    )
+    .unwrap();
+    commit_all(&tree.0, "pin the shared digest and an oversized record");
+
+    // twin-a.rs's own digest is ambiguous, so changing it alone would never
+    // populate the rewrite set (an ambiguous digest is excluded from it) and
+    // the scan would short-circuit before ever reaching record.json. Also
+    // changing source.rs — an unambiguous digest — is what forces the walk.
+    fs::write(tree.0.join("twin-a.rs"), "// changed\n").unwrap();
+    fs::write(tree.0.join("source.rs"), "fn a() { changed(); }\n").unwrap();
+
+    let output = repin_text(&tree.0, &[]);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("ambiguous:") && stdout.contains("not resolved, resync by hand"),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("skipped: record.json"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("0 orphaned pin(s), 1 ambiguous digest(s), 1 skipped file(s)"),
+        "summary line must surface both counts: {stdout}"
+    );
 }


### PR DESCRIPTION
## Summary

Continues [#87](https://github.com/2233admin/code-intel-pipeline/pull/87), which merged (`2a98a67`) before its round-2 CodeRabbit review finished — that review's comments landed on an already-closed PR, so the fixes below never reached `main`. This PR carries just that diff, cherry-picked from `claudeMaster/native-code-evidence-repin-e57d85` (`1f83867`) onto current `main`.

Fixes:
- `is_excluded` now matches on a path-component boundary instead of a raw string prefix, so `--exclude vendor` no longer also excludes `vendorized/`.
- The summary line now reports ambiguous-digest and skipped-file counts alongside substitutions/files/orphans, so it never contradicts a nonzero exit caused solely by one of those two.
- `flush()` preserves the original file's permissions across the write-then-rename, which previously dropped them (e.g. an executable bit) since `fs::write` creates the temp file with default permissions.
- `load_text()` now uses `fs::symlink_metadata` and rejects symlinks before the regular-file check. `fs::metadata` previously followed the link, so a tracked symlink to a UTF-8 text file could be loaded and, if rewritten, `flush()` would rename a regular file on top of the link path, destroying the symlink. Symlinks get their own non-gating `LoadError::Symlink` (like `Binary`) rather than a gating `Unreadable`, since a symlink's own file can't hold a literal pin token.

Also adds coverage the previous round was missing: a binary tracked file's `LoadError::Binary` skip (non-gating), and one test exercising `print_human`'s ambiguous/skipped branches and the new summary counts (the shared test helper previously always passed `--json`).

## Test plan

- [x] `cargo build -p code-intel`
- [x] `cargo test -p code-intel --test repin` (11 passed)
- [x] `cargo test -p code-intel --locked` (full suite)
- [x] `cargo fmt -p code-intel -- --check`
- [x] `cargo check -p code-intel --locked`
- [x] `cargo clippy -p code-intel --all-targets --locked` (no new warnings)
- [x] `code-intel repin --report` against this repo: clean, no stale pins introduced
