### PR TITLE
fix(gate): 禁用 quotePath 修非 ASCII 路径漏匹配 + hardened_git 单一声明

### DIFF
--- a/crates/code-intel-cli/src/change_risk/git.rs
+++ b/crates/code-intel-cli/src/change_risk/git.rs
@@ -18,7 +18,7 @@ const EMPTY_TREE: &str = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
 pub(super) fn resolve_repo_root() -> Result<PathBuf, RiskError> {
     let cwd = std::env::current_dir()
         .map_err(|error| RiskError::HostIo(format!("cannot resolve current directory: {error}")))?;
-    let output = super::hardened_git::command(&cwd)
+    let output = crate::hardened_git::command(&cwd)
         .args(["rev-parse", "--show-toplevel"])
         .output()
         .map_err(|error| RiskError::HostIo(format!("cannot launch Git: {error}")))?;
@@ -88,8 +88,19 @@ pub(super) fn diff_stats(repo: &Path, range: &str) -> Option<Vec<FileDiff>> {
 }
 
 fn run_git_diff_numstat(repo: &Path, range: &str) -> Option<Vec<FileDiff>> {
-    let output = super::hardened_git::command(repo)
-        .args(["diff", "--numstat", "--no-renames", range])
+    let output = crate::hardened_git::command(repo)
+        .args([
+            // Git C-quotes non-ASCII paths by default ("\346\226\207..."),
+            // which would never match the repository-relative keys this
+            // module looks paths up by. Applies to every parsed-path call
+            // site, not cosmetic ones.
+            "-c",
+            "core.quotePath=false",
+            "diff",
+            "--numstat",
+            "--no-renames",
+            range,
+        ])
         .output()
         .ok()?;
     if !output.status.success() {
@@ -130,7 +141,7 @@ fn normalize_path(path: &str) -> String {
 }
 
 pub(super) fn commit_unix_time(repo: &Path, rev: &str) -> Result<i64, RiskError> {
-    let output = super::hardened_git::command(repo)
+    let output = crate::hardened_git::command(repo)
         .args(["log", "-1", "--format=%ct", rev])
         .output()
         .map_err(|error| RiskError::HostIo(format!("cannot launch Git: {error}")))?;
@@ -151,7 +162,7 @@ pub(super) fn commit_unix_time(repo: &Path, rev: &str) -> Result<i64, RiskError>
 /// `diff_stats` already proved the range itself resolves.
 pub(super) fn commits_in_range(repo: &Path, range: &str) -> Vec<String> {
     let range = rev_list_range(range);
-    let Ok(output) = super::hardened_git::command(repo)
+    let Ok(output) = crate::hardened_git::command(repo)
         .args(["rev-list", &range])
         .output()
     else {
@@ -193,7 +204,7 @@ pub(super) fn sample_history(repo: &Path, start: &str, sample: u32) -> Vec<(Stri
     if sample == 0 {
         return Vec::new();
     }
-    let Ok(output) = super::hardened_git::command(repo)
+    let Ok(output) = crate::hardened_git::command(repo)
         .args([
             "log",
             "--no-merges",
@@ -240,8 +251,12 @@ pub(super) fn file_commit_history(
         return history;
     }
     let since_unix = anchor_unix - BUG_MAGNET_WINDOW_DAYS * 86_400;
-    let Ok(output) = super::hardened_git::command(repo)
+    let Ok(output) = crate::hardened_git::command(repo)
         .args([
+            // Same quotePath rule as run_git_diff_numstat: --name-only output
+            // is matched against `files` keys and must arrive unquoted.
+            "-c",
+            "core.quotePath=false",
             "log",
             &format!("--since=@{since_unix}"),
             &format!("--until=@{anchor_unix}"),

--- a/crates/code-intel-cli/src/change_risk/mod.rs
+++ b/crates/code-intel-cli/src/change_risk/mod.rs
@@ -47,9 +47,6 @@ use std::path::Path;
 
 use serde_json::Value;
 
-#[path = "../hardened_git.rs"]
-mod hardened_git;
-
 mod git;
 mod render;
 mod scoring;

--- a/crates/code-intel-cli/src/change_risk/tests.rs
+++ b/crates/code-intel-cli/src/change_risk/tests.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use super::git::{commits_in_range, tip_token};
+use super::git::{commits_in_range, diff_stats, tip_token};
 use super::signals::{is_source_file, is_test_file, looks_like_fix_subject};
 use super::*;
 
@@ -307,6 +307,26 @@ fn commits_in_range_normalizes_triple_dot_to_the_diffed_commit_set() {
     assert!(
         !excluded.contains(&base_only_commit),
         "a commit unique to the base side of a...b must not appear in the exclusion set: {excluded:?}"
+    );
+
+    std::fs::remove_dir_all(&repo).ok();
+}
+
+#[test]
+fn non_ascii_paths_arrive_unquoted_from_git() {
+    let repo = init_repo("quotepath");
+    write_file(&repo, "src/lib.rs", "fn base() {}\n");
+    commit(&repo, "base");
+    write_file(&repo, "src/统计模块.rs", "fn stats() {}\n");
+    commit(&repo, "add non-ascii source file");
+
+    let files = diff_stats(&repo, "HEAD^..HEAD").expect("diff should resolve");
+    let paths: Vec<&str> = files.iter().map(|(_, _, path)| path.as_str()).collect();
+    assert_eq!(
+        paths,
+        vec!["src/统计模块.rs"],
+        "with core.quotePath unset git C-quotes non-ASCII paths (\"src/\\347...\"), \
+         which never match repository-relative lookup keys"
     );
 
     std::fs::remove_dir_all(&repo).ok();


### PR DESCRIPTION
CodeRabbit 对 #102 的合并后追审两条，快速跟进：

1. **quotePath（Major，真 bug）**：`run_git_diff_numstat` / `file_commit_history` 解析路径输出时未禁用 `core.quotePath`——非 ASCII 文件名默认被 C 引号转义（`"src/\347\273\237..."`），永远匹配不上仓库相对路径键，非 ASCII 路径的历史/统计会漏。两处子进程加 `-c core.quotePath=false`，带中文文件名 fixture 回归测试 `non_ascii_paths_arrive_unquoted_from_git`。对中文用户仓库这是必修。
2. **模块声明收敛（nitpick）**：移除 `change_risk/mod.rs` 的 `#[path = "../hardened_git.rs"]` 二次声明（同文件双模块实例），全部改走 `crate::hardened_git`。

门禁：change_risk 12/12、全套测试无失败、`cargo fmt --check` 干净、权威 self-scan exit 0。

Refs #95
