### PR TITLE
chore(gitignore): ignore local .gstack/ tool scratch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ Thumbs.db
 
 # Local command scratch
 -o
+.gstack/


### PR DESCRIPTION
会话收尾卫生单：.gitignore 增加 `.gstack/`（gstack 工具本地暂存，与既有 .repowise.backup-* 忽略同类）。

本会话的实质交付已全部经由独立 PR 合入：#102 #107 #108 #109 #110 #116 #117（v0.7.0-beta.3 已发布），以及进行中的 fix/t6-* 三分支。本 PR 仅含这一行。