### PR TITLE
chore(scope): SkillRise 判 out-of-scope + 文档计划优化点回填 #93/#104/#92

### DIFF
--- a/.out-of-scope/rl-trained-skill-curation.md
+++ b/.out-of-scope/rl-trained-skill-curation.md
@@ -1,0 +1,28 @@
+# Non-goal: RL-trained skill-document curation (SkillRise-style)
+
+## Non-goal
+
+Adopting or integrating [SkillRise](https://github.com/Within-yao/SkillRise) — or any RL
+training stack of its family (verl / verl-agent / GRPO-style trainers) — to train or host
+skill-document curation behavior. No code reuse, no vendored trainer, no gym-style task
+environments in this repo.
+
+## Why
+
+SkillRise is an end-to-end RL framework (verl fork: Python + Ray + vLLM + FSDP/Megatron)
+that trains a small policy to alternate Solve and Curate over ordered task sequences,
+rewarding the Curate step by gamma-discounted downstream task success. Evaluated
+2026-08-02: this pipeline is a Rust CLI for repository understanding, structural gates,
+and artifact handoff — it trains no models, has no GPU stack, and its evolving-document
+needs (skill docs, memory, handoff artifacts) are already served by plain curation.
+SkillRise's only increment over that practice is *training* the curate behavior via RL,
+which is inseparable from its training stack. Serves neither north-star axis (AI fast
+code understanding; write less unnecessary output), so per the yardstick it is cut.
+
+## Instead
+
+- Keep the one transferable idea without the stack: judge a distilled/curated document by
+  downstream task success, not by direct doc-quality review. Landed as the docs
+  acceptance arm proposal in #93 and the reclassification follow-up in #104.
+- If cross-task skill distillation ever becomes a product need, it is a prompting/eval
+  concern on existing artifacts, not a training concern.


### PR DESCRIPTION
## 内容

SkillRise(https://github.com/Within-yao/SkillRise)评估收敛:判 out-of-scope,登记 `.out-of-scope/rl-trained-skill-curation.md`。

- **是什么**:verl fork 的端到端 RL 框架(Python + Ray + vLLM),训 Qwen3-4B 在任务序列上交替 Solve/Curate,curate 按下游成功率折扣记分。
- **为什么砍**:本管线不训模型、无 GPU 栈;skill 文档进化已由现有 curation 实践覆盖;其增量(RL 训练 curate)离开其训练栈不存在。两条北极星都不服务。
- **可偷想法已回填**,不随仓丢失:
  - #93 评论:docs 臂——文档按下游成功率记分(冷启动 checklist 重放,出界查找次数为失败分)。
  - #104 评论:t3-cut sweep 判活标准错位(引用可达性 ≠ 测试绑定)+ INVENTORY.md 归档提醒 + repin 复用。
  - #92 评论:先修 #112/#113 假入口,recipe 必须可执行 + eval 断言。

Refs #93 #104 #92
