### PR TITLE
feat(gate): change risk 加 --repo 旗标，对齐兄弟命令约定

### DIFF
--- a/crates/code-intel-cli/src/change_risk/git.rs
+++ b/crates/code-intel-cli/src/change_risk/git.rs
@@ -18,21 +18,32 @@ const EMPTY_TREE: &str = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
 pub(super) fn resolve_repo_root() -> Result<PathBuf, RiskError> {
     let cwd = std::env::current_dir()
         .map_err(|error| RiskError::HostIo(format!("cannot resolve current directory: {error}")))?;
-    let output = crate::hardened_git::command(&cwd)
+    resolve_repo_root_from(&cwd)
+}
+
+/// Resolves `start`'s Git repository root under the same "walk up to the
+/// toplevel, fail closed if it is not a Git repository" contract
+/// `resolve_repo_root` applies to the current directory. Backs an explicit
+/// `--repo <path>` (issue #114): every sibling subcommand (`run execute
+/// --repo`, `audit --repo`, `snapshot identity --repo`) takes an explicit
+/// repo path rather than always trusting the CWD, and this closes that gap
+/// for `change risk` without changing the CWD-derived default at all.
+pub(super) fn resolve_repo_root_from(start: &Path) -> Result<PathBuf, RiskError> {
+    let output = crate::hardened_git::command(start)
         .args(["rev-parse", "--show-toplevel"])
         .output()
         .map_err(|error| RiskError::HostIo(format!("cannot launch Git: {error}")))?;
     if !output.status.success() {
         return Err(RiskError::Contract(format!(
             "not a Git repository: {}",
-            cwd.display()
+            start.display()
         )));
     }
     let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
     if path.is_empty() {
         return Err(RiskError::Contract(format!(
             "not a Git repository: {}",
-            cwd.display()
+            start.display()
         )));
     }
     Ok(PathBuf::from(path))

--- a/crates/code-intel-cli/src/change_risk/mod.rs
+++ b/crates/code-intel-cli/src/change_risk/mod.rs
@@ -43,7 +43,7 @@
 //! documented scoring constants every submodule draws from.
 
 use std::collections::BTreeSet;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use serde_json::Value;
 
@@ -54,7 +54,8 @@ mod signals;
 #[cfg(test)]
 mod tests;
 
-const USAGE: &str = "usage: change risk <revspec> [--sample <N>] [--format json|text]";
+const USAGE: &str =
+    "usage: change risk <revspec> [--repo <path>] [--sample <N>] [--format json|text]";
 
 /// Baseline size when `--sample` is not given: enough commits to form a
 /// stable percentile without walking arbitrarily deep into history on every
@@ -144,6 +145,10 @@ struct Cli {
     revspec: String,
     sample: u32,
     format: Format,
+    /// Explicit repo root, from `--repo <path>` (issue #114). `None` means
+    /// "keep resolving from the current directory" — the pre-existing
+    /// default behavior, unchanged when the flag is absent.
+    repo: Option<PathBuf>,
 }
 
 impl Cli {
@@ -154,6 +159,7 @@ impl Cli {
         let mut revspec: Option<String> = None;
         let mut sample: Option<u32> = None;
         let mut format: Option<Format> = None;
+        let mut repo: Option<PathBuf> = None;
         let mut index = 1;
         while index < raw.len() {
             let token = raw[index].as_str();
@@ -188,6 +194,14 @@ impl Cli {
                     set_once(&mut format, parsed, "--format")?;
                     index += 2;
                 }
+                "--repo" => {
+                    let value = raw
+                        .get(index + 1)
+                        .filter(|value| !value.is_empty() && !value.starts_with("--"))
+                        .ok_or_else(|| RiskError::Contract("--repo requires one value".into()))?;
+                    set_once(&mut repo, PathBuf::from(value), "--repo")?;
+                    index += 2;
+                }
                 token if token.starts_with("--") => {
                     return Err(RiskError::Contract(format!(
                         "unknown change risk argument: {token}"
@@ -208,6 +222,7 @@ impl Cli {
             revspec,
             sample: sample.unwrap_or(DEFAULT_SAMPLE),
             format: format.unwrap_or(Format::Json),
+            repo,
         })
     }
 }
@@ -221,7 +236,10 @@ fn set_once<T>(slot: &mut Option<T>, value: T, flag: &str) -> Result<(), RiskErr
 }
 
 fn run(cli: Cli) -> Result<(Value, Format), RiskError> {
-    let repo = git::resolve_repo_root()?;
+    let repo = match &cli.repo {
+        Some(path) => git::resolve_repo_root_from(path)?,
+        None => git::resolve_repo_root()?,
+    };
     let value = execute(&repo, &cli.revspec, cli.sample)?;
     Ok((value, cli.format))
 }
@@ -298,6 +316,7 @@ fn execute(repo: &Path, revspec: &str, sample_requested: u32) -> Result<Value, R
     let files = git::diff_stats(repo, &endpoint.range).unwrap_or_default();
     if files.is_empty() {
         return Ok(render::build_report(
+            repo,
             revspec,
             None,
             Vec::new(),
@@ -339,6 +358,7 @@ fn execute(repo: &Path, revspec: &str, sample_requested: u32) -> Result<Value, R
     let percentile = scoring::compute_percentile(target.score, &baseline_scores);
     let target_files = target.files.clone();
     Ok(render::build_report(
+        repo,
         revspec,
         Some(&target),
         target_files,

--- a/crates/code-intel-cli/src/change_risk/render.rs
+++ b/crates/code-intel-cli/src/change_risk/render.rs
@@ -2,6 +2,8 @@
 //! rendering derived from it (`render_text`). Both are pure functions of
 //! already-scored data — nothing here touches `git` or recomputes a signal.
 
+use std::path::Path;
+
 use serde_json::{json, Value};
 
 use super::scoring::{level_for_percentile, round2};
@@ -10,7 +12,9 @@ use super::{
     WEIGHT_DIFF_SHAPE, WEIGHT_TEST_ASYMMETRY,
 };
 
+#[allow(clippy::too_many_arguments)]
 pub(super) fn build_report(
+    repo: &Path,
     revspec: &str,
     scored: Option<&Scored>,
     files_value: Vec<Value>,
@@ -63,6 +67,11 @@ pub(super) fn build_report(
     });
     let mut result = json!({
         "schema": "code-intel-change-risk.v1",
+        // Resolved Git root the score was computed against — always
+        // present, whether it came from `--repo <path>` or (absent that
+        // flag) the current directory, so a caller never has to guess which
+        // repository a saved report was scored from (issue #114).
+        "repo": repo.display().to_string(),
         "revspec": revspec,
         "score": score,
         "risk_percentile": percentile,
@@ -80,6 +89,7 @@ pub(super) fn build_report(
 /// never recomputed — so `--format text` cannot drift from `--format json`.
 pub(super) fn render_text(value: &Value) -> String {
     let mut lines = Vec::new();
+    lines.push(format!("repo: {}", value["repo"].as_str().unwrap_or("")));
     lines.push(format!(
         "revspec: {}",
         value["revspec"].as_str().unwrap_or("")

--- a/crates/code-intel-cli/src/change_risk/tests.rs
+++ b/crates/code-intel-cli/src/change_risk/tests.rs
@@ -3,20 +3,29 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use super::git::{commits_in_range, diff_stats, tip_token};
+use super::git::{commits_in_range, diff_stats, resolve_repo_root_from, tip_token};
 use super::signals::{is_source_file, is_test_file, looks_like_fix_subject};
 use super::*;
 
-fn init_repo(name: &str) -> PathBuf {
+/// A fresh, empty temp directory namespaced the same way `init_repo` names
+/// its repos, but without running `git init` — the starting point for both
+/// a to-be-initialized repo and (for the invalid-`--repo` test) a directory
+/// that must never look like one.
+fn temp_dir_for(name: &str) -> PathBuf {
     let nonce = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_nanos();
-    let repo = std::env::temp_dir().join(format!(
+    let dir = std::env::temp_dir().join(format!(
         "code-intel-change-risk-{name}-{nonce}-{}",
         std::process::id()
     ));
-    std::fs::create_dir_all(&repo).unwrap();
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn init_repo(name: &str) -> PathBuf {
+    let repo = temp_dir_for(name);
     for args in [
         vec!["init", "--quiet"],
         vec!["config", "user.name", "Change Risk Test"],
@@ -330,4 +339,73 @@ fn non_ascii_paths_arrive_unquoted_from_git() {
     );
 
     std::fs::remove_dir_all(&repo).ok();
+}
+
+#[test]
+fn repo_flag_scores_a_fixture_repo_from_an_unrelated_cwd() {
+    let repo = init_repo("repo-flag");
+    write_file(&repo, "crates/demo/src/lib.rs", "pub fn demo() {}\n");
+    commit(&repo, "feat: seed demo crate");
+    write_file(
+        &repo,
+        "crates/demo/src/lib.rs",
+        "pub fn demo() { println!(\"hi\"); }\n",
+    );
+    commit(&repo, "fix: correct demo output");
+
+    // Deliberately do not touch this test process's own current directory:
+    // it stays wherever `cargo test` started it (this crate's own
+    // checkout), a repository entirely unrelated to the fixture just
+    // created above. `--repo` must steer scoring at the fixture instead
+    // (issue #114) — through the same entry point (`run_raw`) `main.rs`
+    // actually dispatches to, not just the internal helpers.
+    let args: Vec<String> = vec![
+        "risk".to_string(),
+        "HEAD~1..HEAD".to_string(),
+        "--repo".to_string(),
+        repo.to_string_lossy().into_owned(),
+    ];
+
+    assert_eq!(
+        run_raw(&args),
+        0,
+        "the real change-risk entry point should succeed with --repo pointed at the fixture"
+    );
+
+    // `run_raw` only returns an exit code; re-run the identical parse+run
+    // chain it delegates to internally (`Cli::parse(raw).and_then(run)`) to
+    // inspect the report content it printed.
+    let cli = Cli::parse(&args).expect("--repo should parse");
+    let (value, _format) = run(cli).expect("scoring the fixture through --repo should succeed");
+
+    let expected_repo = resolve_repo_root_from(&repo)
+        .expect("the fixture resolves its own Git root")
+        .display()
+        .to_string();
+    assert_eq!(value["repo"], expected_repo);
+    assert!(value.get("warning").is_none());
+    assert_eq!(value["files"].as_array().unwrap().len(), 1);
+
+    std::fs::remove_dir_all(&repo).ok();
+}
+
+#[test]
+fn repo_flag_rejects_a_path_that_is_not_a_git_repository() {
+    let not_a_repo = temp_dir_for("repo-flag-not-a-repo");
+
+    let args: Vec<String> = vec![
+        "risk".to_string(),
+        "HEAD~1..HEAD".to_string(),
+        "--repo".to_string(),
+        not_a_repo.to_string_lossy().into_owned(),
+    ];
+
+    assert_eq!(
+        run_raw(&args),
+        65,
+        "an invalid --repo must fail with the same Contract exit code (65) as every other \
+         change-risk argument error, e.g. an unresolvable --sample or --format"
+    );
+
+    std::fs::remove_dir_all(&not_a_repo).ok();
 }

--- a/crates/code-intel-cli/src/main.rs
+++ b/crates/code-intel-cli/src/main.rs
@@ -1697,7 +1697,7 @@ Commands:
   artifact index --artifact-root <root> [--output <index.json>] [--operation rebuild|incremental] [--existing <index.json>]
   artifact query --artifact-root <root> --repo <name> [--repo-path <path>] [--artifact-schema <schema>] [--type <artifact-type>] [--contains <text>] [--limit <1..100>]
   change impact --artifact-root <root> --repo <name> --repo-path <checkout> --changed <relative-path> [--changed <relative-path>]... [--staleness current|advisory]
-  change risk <revspec> [--sample <N>] [--format json|text] (git-only defect-risk score, no prior run, no index)
+  change risk <revspec> [--repo <path>] [--sample <N>] [--format json|text] (git-only defect-risk score, no prior run, no index)
   edit impact --repo-path <checkout> --changed <relative-path> [--changed <relative-path>]... [--scope <directory>]... (working tree, no prior run, authority: none)
   decision request-response --request <request.json|-> [--response <response.json>|--cancel <cancellation.json>] --now <unix-seconds> --branch <branch-id>...
   decision record --resolution <resolution.json> --store <record-directory>


### PR DESCRIPTION
冷启动摩擦 F4 修复（#114）：`change risk` 新增可选 `--repo <path>`（旗标名对齐 run execute/audit），显式解析目标仓 git 根；非 git 路径给 Contract 错误（exit 65）；缺省保持原 CWD 行为。JSON 输出新增 `repo` 字段（machine-first），text 视图派生。

测试 2830 全绿（change_risk 14/14，含跨 CWD 评分与非法路径两新测）；fmt/clippy 干净；权威 self-scan exit 0。已实测：`--repo . --format json` 返回 resolved root。

Refs #114 #99