### PR TITLE
fix(skill): SKILL.md 产物阅读顺序对齐主入口真实输出——按 artifact type 查（#122）

### DIFF
--- a/skills/code-intel-pipeline/SKILL.md
+++ b/skills/code-intel-pipeline/SKILL.md
@@ -50,15 +50,27 @@ code-intel "<repo-path>"
 Use `--mode lite` for local-only core evidence. Use `--mode full` only when every optional provider
 must be present. Do not call the legacy PowerShell pipeline.
 
-Read generated artifacts in this order:
+The committed run directory is content-addressed: `run-complete.json` plus `objects/sha256/<hash>`
+blobs. Report file names never exist there — `summary.md`, `understanding.md`, and `report.json`
+are produced only by the legacy runner, and hospital output lives under artifact `type` identities
+read through `artifact query --artifact-root <root> --repo <name>` (the run prints its publication
+path as `<artifact-root>/<repo-name>/<run-id>`).
 
-1. `summary.md`
-2. `hospital.md`
-3. `understanding.md`
-4. `report.json` or `hospital-report.json` when a failure or machine-readable detail matters
-5. `surgery-plan.md` when the hospital report selects `surgery_plan`
+Read a published run in this order:
 
-Report the artifact directory, outcome, first failing category, supporting evidence, and next
+1. The command-line summary (add `--json` for the machine form): overall outcome, publication
+   path, and the first failing node with its diagnostic.
+2. `artifact query --type code_evidence.agent_slice` for ranked file and symbol navigation.
+3. `artifact query --type diagnosis.hospital-view` for the governance read, or
+   `--type diagnosis.hospital` when machine-readable detail matters.
+4. `artifact query --type diagnosis.surgery-plan-view` when the hospital report selects
+   `surgery_plan`.
+
+The `diagnosis.*` artifacts exist only in `--mode` normal or full; `--mode lite` publishes core
+evidence only (`code_evidence.*`, `inventory.files`, `repository.snapshot`, `doctor.observation`)
+and no hospital report.
+
+Report the publication path, outcome, first failing category, supporting evidence, and next
 action. Do not describe a partial or domain-failed run as clean.
 
 ## Apply provider boundaries


### PR DESCRIPTION
SKILL.md「Run the pipeline」让读者跑主入口，产物阅读列表却是 `summary.md` / `hospital.md` / `understanding.md` / `report.json` / `surgery-plan.md`——其中 summary / understanding / report 是旧兼容 runner 独有产物（README「输出在哪里」明确列为主入口不产出），其余的名字在主入口已提交 run（content-addressed，`run-complete.json` + `objects/sha256/*`）里也不存在磁盘文件。本 PR 把该列表重写为按 artifact `type` 经 `artifact query` 读，对齐 #121 修正后 README 的「读报告顺序（主入口）」；#121 的 SKILL.md 改动只加全链路指引节、不动这份列表（不同 hunk，无冲突）。

铁律执行——列表里每个 type 都来自本机新鲜真跑（release build @ 958d10a）：

- 干净 clone 上 `code-intel <repo> --json` normal 模式 exit 0 / outcome=completed，7 节点全 succeeded；manifest 枚举出的全部 type 与新列表一致（`code_evidence.agent_slice`、`diagnosis.hospital`、`diagnosis.hospital-view`、`diagnosis.surgery-plan`、`diagnosis.surgery-plan-view`…）。
- `artifact query --type diagnosis.hospital-view / diagnosis.surgery-plan-view / code_evidence.agent_slice` 各返回 1 条 verified 匹配（"A07-committed bytes passed registered schema, digest, and snapshot verification"），preview 即 hospital report / surgery plan 正文。
- `--mode lite` 真跑确认只有 repo.snapshot / inventory.rg / doctor / evidence.native-code 四节点——列表下方补了一句 lite 无 `diagnosis.*` 的边界。
- 已提交 run 目录实测只有 `run-complete.json` + `objects/`，无任何报告文件名。

门禁：`python tests/test_skill_package.py -v` 18/18 OK；权威 self-scan（`run execute --manifest orchestration/integrations.json --final-name pre-push-self-scan`）exit 0、publication committed。

核实过程顺带实测出主入口三个环境缺陷（worktree sentrux 空诊断挂、长 artifact-root os error 3、`.repowise` 撑爆 graph 8MB），已单独立 #123，不在本 PR 范围。

Closes #122. Refs #121 #113.
