### PR TITLE
feat(gate): G1 -- computed honesty bit for repin's scan coverage

### DIFF
--- a/crates/code-intel-cli/src/evidence_outcome.rs
+++ b/crates/code-intel-cli/src/evidence_outcome.rs
@@ -1,0 +1,470 @@
+//! A completeness claim for one evidence-producing surface (a scan, a
+//! query, an enumeration) that a downstream reader can check rather than
+//! just trust. Gate G1 of the project charter (issue #139, tracked in
+//! #138): "the honesty bit is computed, not asserted."
+//!
+//! The motivating failure (#133): `code-intel repin --write --json`
+//! printed `"clean": true, "filesChanged": 0` while digests the scan never
+//! actually reached (`operationTrace[].source.sha256`, embedded
+//! `evidenceIds` suffixes) sat stale. Nothing in that report distinguished
+//! "I looked everywhere and it's clean" from "I looked nowhere" -- both
+//! render as the same three JSON tokens. A downstream agent reading
+//! silence as "fine" then writes code on a false premise.
+//!
+//! [`EvidenceOutcome::Complete`] closes that gap the only way a type
+//! system can: there is no constructor for it that does not take an
+//! [`EvidenceScope`]. You cannot write `EvidenceOutcome::Complete` in Rust
+//! without a scope value already in hand, any more than you can write
+//! `Some` without a payload.
+//!
+//! That alone cannot stop a hand-edited (or hand-written-by-a-different-
+//! code-path) JSON artifact from claiming `"status":"complete"` with no
+//! `"scope"` object at all -- which is exactly the shape #133's
+//! `clean:true` took: a bare assertion, no backing data, nothing to check
+//! it against. So [`EvidenceOutcome::from_json`] enforces the same rule at
+//! the deserialization boundary: a `"complete"` (or `"partial"`) status
+//! whose `scope` is missing, or whose scope is missing a required field,
+//! is a parse error, not a value with an empty scope silently filled in.
+//!
+//! A missing-scope check alone is not enough, though: the minimal, most
+//! realistic forgery is not "delete everything and write `complete`" but
+//! "flip the one field that says the status" -- exactly what #133's own
+//! bug did (one stale field, everything else untouched). Take a real
+//! `Partial` value, which already carries a genuine, fully-populated
+//! `scope`, and change only its `status` to `"complete"`: the scope is
+//! right there and well-formed, so a bare "does `scope` exist and have its
+//! fields?" check would accept it. What gives it away is the leftover
+//! `partialReason` (and `detail`/`paths`) fields a real `Complete` never
+//! has. `from_json` therefore also requires each status's JSON object to
+//! carry *exactly* its expected key set -- no leftovers from a different
+//! status -- the same discipline `content_contract::require_exact_keys`
+//! applies elsewhere in this crate.
+//! See the reverse test in `crates/code-intel-cli/tests/repin.rs`
+//! (`forged_complete_claim_without_scope_is_rejected`), which forges both
+//! ways: a `not-computed` report relabeled `complete` (missing `scope`
+//! entirely), and a `partial` report relabeled `complete` by touching only
+//! `status` (present, well-formed `scope`, but disqualifying leftovers).
+//!
+//! `repin.rs` is this type's first (and, as of this change, only) real
+//! consumer -- see its module docs for how `RepinReport` derives both its
+//! JSON `scanCoverage` field and its `clean`/exit-code verdict from the
+//! same stored [`EvidenceOutcome`] value, so the two can never read
+//! different data (the failure mode the charter calls out separately: an
+//! interval computed in one structure, a pass/fail decision read from
+//! another, and the two never meeting).
+
+use serde_json::{json, Value};
+
+/// The completeness state of one evidence surface. `Complete` is the only
+/// variant that lets a reader trust silence as "checked, and it's fine";
+/// the other two exist so a surface never has to lie its way into looking
+/// like `Complete` when it isn't.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum EvidenceOutcome {
+    /// The scan surface was fully enumerated and everything in it was
+    /// inspected. Carries the [`EvidenceScope`] it covers -- constructing
+    /// this variant without one is not possible in Rust, since it is a
+    /// required field, not an `Option`.
+    Complete(EvidenceScope),
+    /// The surface was only partly covered. `reason` says why (truncation,
+    /// a cap, an input that could not be read); `scope` says what *was*
+    /// covered despite that, so a reader can still tell how much ground
+    /// was actually inspected.
+    Partial {
+        reason: PartialReason,
+        scope: EvidenceScope,
+    },
+    /// The surface was never evaluated. `reason` says why it was skipped
+    /// (not attempted, or attempted over a vacuous / degenerate input).
+    NotComputed { reason: String },
+}
+
+/// What a `Complete` (or `Partial`) claim actually covers: which artifact
+/// types were consumed, which paths were enumerated and inspected, and
+/// which paths were deliberately left out of the surface (as opposed to
+/// paths that failed to load -- that gap belongs in
+/// `PartialReason::UnreadableInput` instead, because an intentional
+/// exclusion is not a coverage failure).
+///
+/// Deliberately does not derive `Default`: an all-empty scope should
+/// require writing out every field by hand, not a single `::default()`
+/// call, so a vacuous scope never appears by accident (or by someone
+/// reaching for the path of least resistance under review pressure).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct EvidenceScope {
+    pub(crate) artifact_types: Vec<String>,
+    pub(crate) scanned_paths: Vec<String>,
+    pub(crate) excluded_prefixes: Vec<String>,
+}
+
+/// Why an [`EvidenceOutcome::Partial`] is partial. Every variant carries
+/// its own detail rather than a bare tag, so `"partial, no reason given"`
+/// is not representable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PartialReason {
+    /// The surface was cut off partway through (a result stream, a walk
+    /// that stopped early) rather than reaching a natural end.
+    Truncated(String),
+    /// A configured limit was hit before the surface was fully covered.
+    CapHit(String),
+    /// One or more inputs inside the surface could not be read at all
+    /// (too large, not valid text, I/O error); the paths that failed.
+    UnreadableInput(Vec<String>),
+}
+
+impl EvidenceOutcome {
+    pub(crate) fn is_complete(&self) -> bool {
+        matches!(self, EvidenceOutcome::Complete(_))
+    }
+
+    /// A short human-readable summary, for text-mode output that needs to
+    /// say *why* a surface isn't `Complete` without dumping the full
+    /// `scanCoverage` JSON object.
+    pub(crate) fn describe(&self) -> String {
+        match self {
+            EvidenceOutcome::Complete(scope) => {
+                format!("complete ({} path(s) scanned)", scope.scanned_paths.len())
+            }
+            EvidenceOutcome::Partial { reason, scope } => format!(
+                "partial ({}; {} path(s) scanned)",
+                reason.describe(),
+                scope.scanned_paths.len()
+            ),
+            EvidenceOutcome::NotComputed { reason } => format!("not-computed ({reason})"),
+        }
+    }
+
+    pub(crate) fn to_json(&self) -> Value {
+        match self {
+            EvidenceOutcome::Complete(scope) => json!({
+                "status": "complete",
+                "scope": scope.to_json(),
+            }),
+            EvidenceOutcome::Partial { reason, scope } => {
+                let mut value = reason.to_json();
+                let object = value
+                    .as_object_mut()
+                    .expect("reason.to_json() is an object");
+                object.insert("status".to_string(), json!("partial"));
+                object.insert("scope".to_string(), scope.to_json());
+                value
+            }
+            EvidenceOutcome::NotComputed { reason } => json!({
+                "status": "not-computed",
+                "reason": reason,
+            }),
+        }
+    }
+
+    /// The inverse of [`Self::to_json`], and the enforcement point for
+    /// G1's exit condition. A `"status":"complete"` (or `"partial"`)
+    /// object that lacks a `"scope"`, or whose scope is missing a
+    /// required field, is rejected here rather than deserialized with an
+    /// empty scope silently substituted -- an empty scope would satisfy
+    /// the shape check while carrying none of the honesty a real scope
+    /// carries, which is precisely the gap this type exists to close.
+    pub(crate) fn from_json(value: &Value) -> Result<Self, String> {
+        let status = value
+            .get("status")
+            .and_then(Value::as_str)
+            .ok_or("evidence outcome missing \"status\"")?;
+        match status {
+            "complete" => {
+                require_exact_keys(
+                    value,
+                    &["status", "scope"],
+                    "a \"complete\" evidence outcome",
+                )?;
+                let scope = require_object(value, "scope")?;
+                Ok(EvidenceOutcome::Complete(EvidenceScope::from_json(scope)?))
+            }
+            "partial" => {
+                // The reason must be parsed *before* the key-shape check so
+                // the check knows which reason-specific key
+                // (`detail`/`paths`) is expected -- but parsing alone is not
+                // the gate here: a `Partial`'s object is a strict superset
+                // of a `Complete`'s (it has `scope` plus `partialReason` and
+                // its detail), so relabeling `status` to `"complete"` while
+                // leaving everything else in place must be caught by *this*
+                // status's own exact-key check, not by falling through to
+                // reuse the `"complete"` arm above.
+                //
+                // The expected key set is derived from `reason.to_json()`
+                // itself -- not a hand-maintained list keyed on the
+                // `PartialReason` variant -- so it can never drift out of
+                // sync with what `PartialReason::to_json` actually emits.
+                // A hand-maintained parallel table (e.g. matching on the
+                // variant to decide "detail" vs "paths") would still be
+                // exhaustive over the enum and compile fine even if a
+                // future edit to one variant's `to_json` went unmirrored
+                // there -- exhaustiveness catches a missing *variant*, not
+                // a drifted *shape*.
+                let reason = PartialReason::from_json(value)?;
+                let reason_json = reason.to_json();
+                let reason_keys = reason_json
+                    .as_object()
+                    .expect("PartialReason::to_json() is an object");
+                let mut expected_keys: Vec<&str> = vec!["status", "scope"];
+                expected_keys.extend(reason_keys.keys().map(String::as_str));
+                require_exact_keys(value, &expected_keys, "a \"partial\" evidence outcome")?;
+                let scope = require_object(value, "scope")?;
+                Ok(EvidenceOutcome::Partial {
+                    reason,
+                    scope: EvidenceScope::from_json(scope)?,
+                })
+            }
+            "not-computed" => {
+                require_exact_keys(
+                    value,
+                    &["status", "reason"],
+                    "a \"not-computed\" evidence outcome",
+                )?;
+                let reason = value
+                    .get("reason")
+                    .and_then(Value::as_str)
+                    .ok_or("\"not-computed\" requires a \"reason\"")?;
+                Ok(EvidenceOutcome::NotComputed {
+                    reason: reason.to_string(),
+                })
+            }
+            other => Err(format!("unknown evidence outcome status: {other}")),
+        }
+    }
+}
+
+impl EvidenceScope {
+    pub(crate) fn to_json(&self) -> Value {
+        json!({
+            "artifactTypes": self.artifact_types,
+            "scannedPaths": self.scanned_paths,
+            "excludedPrefixes": self.excluded_prefixes,
+        })
+    }
+
+    fn from_json(value: &Value) -> Result<Self, String> {
+        require_exact_keys(
+            value,
+            &["artifactTypes", "scannedPaths", "excludedPrefixes"],
+            "an evidence scope",
+        )?;
+        Ok(EvidenceScope {
+            artifact_types: required_string_array(value, "artifactTypes")?,
+            scanned_paths: required_string_array(value, "scannedPaths")?,
+            excluded_prefixes: required_string_array(value, "excludedPrefixes")?,
+        })
+    }
+}
+
+impl PartialReason {
+    fn to_json(&self) -> Value {
+        match self {
+            PartialReason::Truncated(detail) => json!({
+                "partialReason": "truncated",
+                "detail": detail,
+            }),
+            PartialReason::CapHit(detail) => json!({
+                "partialReason": "cap_hit",
+                "detail": detail,
+            }),
+            PartialReason::UnreadableInput(paths) => json!({
+                "partialReason": "unreadable_input",
+                "paths": paths,
+            }),
+        }
+    }
+
+    fn from_json(value: &Value) -> Result<Self, String> {
+        let reason = value
+            .get("partialReason")
+            .and_then(Value::as_str)
+            .ok_or("\"partial\" requires a \"partialReason\"")?;
+        match reason {
+            "truncated" => Ok(PartialReason::Truncated(required_string(value, "detail")?)),
+            "cap_hit" => Ok(PartialReason::CapHit(required_string(value, "detail")?)),
+            "unreadable_input" => Ok(PartialReason::UnreadableInput(required_string_array(
+                value, "paths",
+            )?)),
+            other => Err(format!("unknown partial reason: {other}")),
+        }
+    }
+
+    fn describe(&self) -> String {
+        match self {
+            PartialReason::Truncated(detail) => format!("truncated: {detail}"),
+            PartialReason::CapHit(detail) => format!("cap hit: {detail}"),
+            PartialReason::UnreadableInput(paths) => {
+                format!("unreadable input: {}", paths.join(", "))
+            }
+        }
+    }
+}
+
+/// Rejects any object whose key set is not *exactly* `keys` -- both a
+/// missing required key and an unexpected extra one are errors. The extra-
+/// key half is what catches a status-only forge: relabeling a real
+/// `Partial`'s `status` to `"complete"` leaves its `partialReason` (and
+/// `detail`/`paths`) sitting in the object, which this rejects even though
+/// every key `"complete"` itself requires is present and well-formed.
+fn require_exact_keys(value: &Value, keys: &[&str], context: &str) -> Result<(), String> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| format!("{context} must be an object"))?;
+    let actual: std::collections::BTreeSet<&str> = object.keys().map(String::as_str).collect();
+    let expected: std::collections::BTreeSet<&str> = keys.iter().copied().collect();
+    if actual == expected {
+        return Ok(());
+    }
+    let unexpected: Vec<&str> = actual.difference(&expected).copied().collect();
+    let missing: Vec<&str> = expected.difference(&actual).copied().collect();
+    Err(format!(
+        "{context} has the wrong fields (unexpected: {unexpected:?}, missing: {missing:?})"
+    ))
+}
+
+fn require_object<'a>(value: &'a Value, key: &str) -> Result<&'a Value, String> {
+    let found = value
+        .get(key)
+        .ok_or_else(|| format!("\"{key}\" is required"))?;
+    if found.is_object() {
+        Ok(found)
+    } else {
+        Err(format!("\"{key}\" must be an object"))
+    }
+}
+
+fn required_string(value: &Value, key: &str) -> Result<String, String> {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| format!("\"{key}\" must be a string"))
+}
+
+fn required_string_array(value: &Value, key: &str) -> Result<Vec<String>, String> {
+    value
+        .get(key)
+        .ok_or_else(|| format!("scope missing required field \"{key}\""))?
+        .as_array()
+        .ok_or_else(|| format!("scope field \"{key}\" must be an array"))?
+        .iter()
+        .map(|item| {
+            item.as_str()
+                .map(str::to_string)
+                .ok_or_else(|| format!("scope field \"{key}\" must contain only strings"))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scope(paths: &[&str]) -> EvidenceScope {
+        EvidenceScope {
+            artifact_types: vec!["tracked-text-file".to_string()],
+            scanned_paths: paths.iter().map(|p| p.to_string()).collect(),
+            excluded_prefixes: vec![],
+        }
+    }
+
+    #[test]
+    fn complete_round_trips_through_json() {
+        let outcome = EvidenceOutcome::Complete(scope(&["a.rs", "b.rs"]));
+        let round_tripped = EvidenceOutcome::from_json(&outcome.to_json()).unwrap();
+        assert_eq!(outcome, round_tripped);
+    }
+
+    #[test]
+    fn partial_round_trips_through_json() {
+        let outcome = EvidenceOutcome::Partial {
+            reason: PartialReason::UnreadableInput(vec!["big.json".to_string()]),
+            scope: scope(&["a.rs"]),
+        };
+        let round_tripped = EvidenceOutcome::from_json(&outcome.to_json()).unwrap();
+        assert_eq!(outcome, round_tripped);
+    }
+
+    #[test]
+    fn not_computed_round_trips_through_json() {
+        let outcome = EvidenceOutcome::NotComputed {
+            reason: "scan surface empty".to_string(),
+        };
+        let round_tripped = EvidenceOutcome::from_json(&outcome.to_json()).unwrap();
+        assert_eq!(outcome, round_tripped);
+    }
+
+    /// The core G1 assertion at the unit level: a `"complete"` claim with
+    /// no `scope` key at all must fail to parse, not silently become a
+    /// `Complete` with an empty scope.
+    #[test]
+    fn complete_without_scope_is_rejected() {
+        let forged = json!({ "status": "complete" });
+        assert!(EvidenceOutcome::from_json(&forged).is_err());
+    }
+
+    /// A `scope` object that is present but missing a required field (the
+    /// shape a careless partial refactor of a writer might produce) must
+    /// also be rejected, not defaulted.
+    #[test]
+    fn complete_with_incomplete_scope_is_rejected() {
+        let forged = json!({
+            "status": "complete",
+            "scope": { "artifactTypes": ["tracked-text-file"] },
+        });
+        assert!(EvidenceOutcome::from_json(&forged).is_err());
+    }
+
+    #[test]
+    fn partial_without_reason_is_rejected() {
+        let forged = json!({
+            "status": "partial",
+            "scope": {
+                "artifactTypes": [],
+                "scannedPaths": [],
+                "excludedPrefixes": [],
+            },
+        });
+        assert!(EvidenceOutcome::from_json(&forged).is_err());
+    }
+
+    #[test]
+    fn not_computed_without_reason_is_rejected() {
+        let forged = json!({ "status": "not-computed" });
+        assert!(EvidenceOutcome::from_json(&forged).is_err());
+    }
+
+    /// The forgery that actually matters: a real `Partial` already has a
+    /// genuine, fully-populated `scope` -- so touching only `status` is not
+    /// caught by "is `scope` present and complete?" at all. It must be
+    /// caught by the leftover `partialReason`/`paths` fields a real
+    /// `Complete` never has.
+    #[test]
+    fn partial_relabeled_complete_by_status_only_is_rejected() {
+        let partial = EvidenceOutcome::Partial {
+            reason: PartialReason::UnreadableInput(vec!["big.json".to_string()]),
+            scope: scope(&["a.rs"]),
+        };
+        let mut forged = partial.to_json();
+        assert!(
+            EvidenceOutcome::from_json(&forged).is_ok(),
+            "sanity: the real value must itself parse"
+        );
+        forged["status"] = json!("complete");
+        assert!(
+            EvidenceOutcome::from_json(&forged).is_err(),
+            "a complete claim forged from a partial by touching only status, \
+             leaving its real scope and partialReason/paths intact, must be rejected: {forged}"
+        );
+    }
+
+    /// The inverse direction, for completeness: a real `Complete`'s object
+    /// is missing the keys `"partial"` requires, so relabeling the other
+    /// way must fail too.
+    #[test]
+    fn complete_relabeled_partial_by_status_only_is_rejected() {
+        let complete = EvidenceOutcome::Complete(scope(&["a.rs"]));
+        let mut forged = complete.to_json();
+        forged["status"] = json!("partial");
+        assert!(EvidenceOutcome::from_json(&forged).is_err());
+    }
+}

--- a/crates/code-intel-cli/src/main.rs
+++ b/crates/code-intel-cli/src/main.rs
@@ -25,6 +25,7 @@ mod decision_port;
 mod decision_record;
 mod doctor_bootstrap;
 mod edit_impact;
+mod evidence_outcome;
 mod evidence_query;
 mod execution_policy;
 mod file_boundary;

--- a/crates/code-intel-cli/src/repin.rs
+++ b/crates/code-intel-cli/src/repin.rs
@@ -25,6 +25,7 @@ use std::path::{Path, PathBuf};
 
 use serde_json::{json, Value};
 
+use crate::evidence_outcome::{EvidenceOutcome, EvidenceScope, PartialReason};
 use crate::snapshot;
 
 const DEFAULT_EXCLUDES: [&str; 1] = ["orchestration/retirements/"];
@@ -191,16 +192,24 @@ pub(crate) struct RepinReport {
     ambiguous: Vec<AmbiguousSource>,
     skipped: Vec<SkippedFile>,
     rewritten: BTreeMap<String, Vec<u8>>,
+    /// Gate G1 (issue #139 / #138): whether the pin-staleness scan itself
+    /// covered its whole surface, computed once here from the same
+    /// `scan_targets` / `skipped` data every other field on this struct is
+    /// built from. `is_clean()` and the JSON `scanCoverage` field both read
+    /// this single value, so they cannot drift apart the way the charter
+    /// warns against (a pass/fail decision reading different data than the
+    /// interval it is supposed to be judging).
+    outcome: EvidenceOutcome,
 }
 
 impl RepinReport {
-    /// Orphaned pins, ambiguous digests, and gating skips are never touched
-    /// by `--write` — they need a human, not a resync — so they stay
-    /// "unresolved" even after a successful write.
+    /// Orphaned pins and ambiguous digests are never touched by `--write`
+    /// — they need a human, not a resync — so they stay "unresolved" even
+    /// after a successful write. An incomplete scan (`outcome` is not
+    /// `Complete`) is unresolved for the same reason a stale pin is: the
+    /// report cannot back up a "clean" claim over ground it never covered.
     fn has_unresolved(&self) -> bool {
-        !self.orphaned.is_empty()
-            || !self.ambiguous.is_empty()
-            || self.skipped.iter().any(|skip| skip.gates_clean)
+        !self.orphaned.is_empty() || !self.ambiguous.is_empty() || !self.outcome.is_complete()
     }
 
     fn is_clean(&self) -> bool {
@@ -220,6 +229,7 @@ impl RepinReport {
             "mode": if write { "write" } else { "report" },
             "passes": self.passes,
             "clean": self.is_clean(),
+            "scanCoverage": self.outcome.to_json(),
             "filesChanged": self.findings.len(),
             "totalSubstitutions": self.total_substitutions(),
             "stalePins": self.findings.iter().map(|finding| json!({
@@ -301,6 +311,9 @@ fn print_human(report: &RepinReport, write: bool) {
             if report.passes == 1 { "" } else { "es" }
         );
         return;
+    }
+    if !report.outcome.is_complete() {
+        println!("scan coverage: {}", report.outcome.describe());
     }
     let action = if write { "rewrote" } else { "found" };
     println!(
@@ -562,6 +575,8 @@ fn scan(repo: &Path, extra_excludes: &[String]) -> Result<RepinReport, String> {
         })
         .collect();
 
+    let outcome = scan_coverage(&scan_targets, &skipped, &excludes);
+
     Ok(RepinReport {
         passes,
         findings: file_findings,
@@ -569,7 +584,61 @@ fn scan(repo: &Path, extra_excludes: &[String]) -> Result<RepinReport, String> {
         ambiguous,
         skipped,
         rewritten,
+        outcome,
     })
+}
+
+/// Gate G1 (#139 / #138): compute the honesty bit for this scan from
+/// exactly the data every other part of the report is built from --
+/// `scan_targets` (what a full scan would have covered after exclusions)
+/// and `skipped` (what actually failed to load). No separate tally is
+/// kept anywhere else, so this can never drift from the report it
+/// describes.
+///
+/// An empty `scan_targets` is deliberately treated as `NotComputed`, not
+/// vacuously `Complete`: `--exclude`-ing away every tracked file (or
+/// pointing `--repo` at a tree with none) previously made `is_clean()`
+/// return `true` on zero files inspected, printing the same
+/// `clean: true, filesChanged: 0` shape as the #133 bug this type exists
+/// to prevent -- a scan that covered nothing must not read the same as a
+/// scan that covered everything and found it clean.
+fn scan_coverage(
+    scan_targets: &[String],
+    skipped: &[SkippedFile],
+    excludes: &[String],
+) -> EvidenceOutcome {
+    if scan_targets.is_empty() {
+        return EvidenceOutcome::NotComputed {
+            reason: "scan surface empty: no tracked file remained after exclusions".to_string(),
+        };
+    }
+    let scanned_paths: Vec<String> = scan_targets
+        .iter()
+        .filter(|path| !skipped.iter().any(|skip| &skip.path == *path))
+        .cloned()
+        .collect();
+    let scope = EvidenceScope {
+        artifact_types: vec!["tracked-text-file".to_string()],
+        scanned_paths,
+        excluded_prefixes: excludes.to_vec(),
+    };
+    // Binary/symlink skips are outside the "tracked-text-file" artifact
+    // type this scan declares, so their absence from `scanned_paths` is
+    // not a gap. Only skips that gate `clean` today (too large, unreadable)
+    // represent text this scan should have covered but could not.
+    let unreadable: Vec<String> = skipped
+        .iter()
+        .filter(|skip| skip.gates_clean)
+        .map(|skip| skip.path.clone())
+        .collect();
+    if unreadable.is_empty() {
+        EvidenceOutcome::Complete(scope)
+    } else {
+        EvidenceOutcome::Partial {
+            reason: PartialReason::UnreadableInput(unreadable),
+            scope,
+        }
+    }
 }
 
 /// Why a scan target's content wasn't inspected. `Binary` is routine and

--- a/crates/code-intel-cli/tests/cli_head_parity.rs
+++ b/crates/code-intel-cli/tests/cli_head_parity.rs
@@ -119,7 +119,10 @@ fn every_ordinary_case_matches_old_head_exactly() {
             .as_u64()
             .expect("exact parity case count") as usize
     );
-    assert_eq!(cases.len(), 51);
+    // One case ("repin clean success") moved from here into
+    // `intentionalDeltas` when gate G1 added `scanCoverage` to repin's
+    // report -- see `every_intentional_delta_is_documented_and_reproduced`.
+    assert_eq!(cases.len(), 50);
 
     let repo = FixtureRepository::create();
     for case in cases {
@@ -152,27 +155,63 @@ fn every_legacy_command_spelling_honors_trailing_help() {
     }
 }
 
+/// Every intentional CLI-output change since `sourceRevision` must be
+/// enumerated here by contract id pair, not just left to accumulate in the
+/// fixture: an unexpected third entry (or a missing expected one) fails
+/// this list before it can fail silently. Each entry's `new` bytes must
+/// also actually reproduce against a live run, the same guarantee
+/// `assert_exact_process_result` gives the plain (non-delta) cases.
+const EXPECTED_INTENTIONAL_DELTAS: &[(&str, &str)] = &[
+    ("text-format:help-full.v1", "text-format:help-full.v2"),
+    ("json-format:repin-report.v1", "json-format:repin-report.v2"),
+];
+
 #[test]
-fn full_help_v2_is_the_only_intentional_delta() {
+fn every_intentional_delta_is_documented_and_reproduced() {
     let fixture = head_parity_fixture();
     let deltas = fixture["intentionalDeltas"]
         .as_array()
         .expect("intentional deltas");
-    assert_eq!(deltas.len(), 1);
-    let delta = &deltas[0];
-    assert_eq!(delta["oldContractId"], "text-format:help-full.v1");
-    assert_eq!(delta["newContractId"], "text-format:help-full.v2");
-    assert_ne!(delta["old"]["stdoutUtf8"], delta["new"]["stdoutUtf8"]);
-    assert_eq!(delta["old"]["exitCode"], delta["new"]["exitCode"]);
-    assert_eq!(delta["old"]["stderrUtf8"], delta["new"]["stderrUtf8"]);
+    let seen: Vec<(String, String)> = deltas
+        .iter()
+        .map(|delta| {
+            (
+                delta["oldContractId"]
+                    .as_str()
+                    .expect("oldContractId")
+                    .to_string(),
+                delta["newContractId"]
+                    .as_str()
+                    .expect("newContractId")
+                    .to_string(),
+            )
+        })
+        .collect();
+    let expected: Vec<(String, String)> = EXPECTED_INTENTIONAL_DELTAS
+        .iter()
+        .map(|(old, new)| (old.to_string(), new.to_string()))
+        .collect();
+    assert_eq!(
+        seen, expected,
+        "intentionalDeltas must exactly match the documented, reviewed set \
+         (add to EXPECTED_INTENTIONAL_DELTAS alongside the fixture when a new one is intentional)"
+    );
 
     let repo = FixtureRepository::create();
-    assert_exact_process_result(
-        delta["name"].as_str().expect("delta name"),
-        delta["argv"].as_array().expect("delta argv"),
-        &delta["new"],
-        repo.path(),
-    );
+    for delta in deltas {
+        assert_ne!(
+            delta["old"]["stdoutUtf8"], delta["new"]["stdoutUtf8"],
+            "a delta whose bytes didn't actually change isn't a delta: {delta}"
+        );
+        assert_eq!(delta["old"]["exitCode"], delta["new"]["exitCode"]);
+        assert_eq!(delta["old"]["stderrUtf8"], delta["new"]["stderrUtf8"]);
+        assert_exact_process_result(
+            delta["name"].as_str().expect("delta name"),
+            delta["argv"].as_array().expect("delta argv"),
+            &delta["new"],
+            repo.path(),
+        );
+    }
 }
 
 fn commit_fixture(repo: &Path, message: &str) {

--- a/crates/code-intel-cli/tests/fixtures/cli-head-parity.v2.json
+++ b/crates/code-intel-cli/tests/fixtures/cli-head-parity.v2.json
@@ -23,7 +23,7 @@
     },
     "missingRepository": "__code_intel_parity_missing_repository_v1__"
   },
-  "exactParityCaseCount": 51,
+  "exactParityCaseCount": 50,
   "cases": [
     {
       "name": "version --version",
@@ -545,18 +545,6 @@
       "exitCode": 0,
       "stdoutUtf8": "{\"dirtyOverlay\":{\"digest\":null,\"ignoredPolicy\":\"excluded_by_git_ignore\",\"members\":{\"renamed\":[],\"staged\":[],\"trackedDeleted\":[],\"trackedModified\":[],\"typeChanged\":[],\"untracked\":[]},\"paths\":[],\"present\":false},\"repository\":{\"kind\":\"git\"},\"schema\":\"code-intel-repository-snapshot.v1\",\"snapshot\":{\"head\":\"8809d42490ea7764fac55d786a7161d3d78a0671\",\"identity\":\"ac651ecf1275d6739f4916a6d4b85eb60c0931a680fa4640e3ee3e75f4a0b752\",\"inputDigest\":\"5b9ad901925acc05311b75806b25b49b5cf119fd014540350c097892a2ce459b\",\"repoIdentity\":\"git-lineage-v1:010d9051cf8d01d08a92fcb2227c435bece1652f726ab7ef1087a7bfecd852c1\",\"scope\":[\".\"],\"workingTreePolicy\":\"head_only\"}}\n",
       "stderrUtf8": ""
-    },
-    {
-      "name": "repin clean success",
-      "argv": [
-        "repin",
-        "--repo",
-        "@fixture-repo@",
-        "--json"
-      ],
-      "exitCode": 0,
-      "stdoutUtf8": "{\n  \"ambiguousSources\": [],\n  \"clean\": true,\n  \"filesChanged\": 0,\n  \"mode\": \"report\",\n  \"orphanedPins\": [],\n  \"passes\": 1,\n  \"schema\": \"code-intel-repin-report.v1\",\n  \"skipped\": [],\n  \"stalePins\": [],\n  \"totalSubstitutions\": 0\n}\n",
-      "stderrUtf8": ""
     }
   ],
   "trailingHelpParity": {
@@ -608,6 +596,28 @@
       "new": {
         "exitCode": 0,
         "stdoutUtf8": "code-intel <command> [options]\n\nCommands:\n  --version|-V [--json]\n  help|--help|-h [--all]\n  resume --repo <path> [--artifact-root <path>] [--json]\n  classify --report <path> [--json]\n  sentrux-normalize --steps <report.json> [--out <sentrux-failures.json>]\n  sentrux-debt-register --failures <sentrux-failures.json> [--repo <path>] [--out <sentrux-debt-register.json>]\n  doctor [--artifact-root <path>] [--json]\n  doctor bootstrap [--repo <alias>] [--repo-path <path>] [--config <pipeline.config.json>] [--platform auto|windows|macos|linux] [--no-require-repowise] [--require-understand] [--json]\n  graph|understand --repo <path> [--language zh] [--full] [--write] [--json]\n  provider|providers [--action List|Plan|Validate|Invoke] [--provider repowise|understand] [--operation <name>] [--repo <path>] [--language zh] [--write] [--json]\n  provider repowise-adapt --request <native.json|-> --artifact-root <directory> --evaluated-at <unix-seconds> --max-age-seconds <seconds>\n  provider graph-adapt --request <native.json|-> --artifact-root <directory> --evaluated-at <unix-seconds> --max-age-seconds <seconds>\n  provider sentrux-adapt --request <native.json|-> --artifact-root <directory> --evaluated-at <unix-seconds> --max-age-seconds <seconds>\n  provider session-adapt --repo <repo> --trace <mindwalk-trace.json> [--hotspots <sentrux-hotspots-or-dsm.json>] [--out <session-evidence.json>] [--working-tree-policy head_only|explicit_overlay]\n  provider codenexus-adapt --request <native.json|-> --artifact-root <directory> --evaluated-at <unix-seconds> --max-age-seconds <seconds>\n  provider file-boundary --request <request.json> --out <result.json>\n  provider runtime-ci-evidence --artifact-root <directory> --request <request.json> --out <summary.json>\n  compatibility retirement-ticket lint --ticket <ticket.json> --evaluated-at <unix-seconds>\n  route|routes [--action List|Plan|Validate] [--provider repowise|understand] [--operation <name>] [--repo <path>] [--json]\n  sentrux <dsm|scan|health|check|gate|check_rules|gate_save> <path> [--no-ratchet]\n    (--no-ratchet: `check` only, skip the .sentrux/baseline.json ratchet)\n  capability exec <id> --request <request.json|-> --out <staging-dir> [--artifact-root <directory>] [--manifest <integrations.json>]\n  model inventory-validate --request <inventory.json> [--out <validated.json>]\n  model route --request <routing-request.json> [--out <routing-result.json>]\n  snapshot identity --repo <root> --working-tree-policy <head_only|explicit_overlay> [--scope <relative-path>]...\n  repin [--repo <root>] [--write] [--json] [--exclude <path-prefix>]...\n  evidence validate --request <request.json> --artifact-root <directory>\n  repository survival-scan --request <request.json|-> --artifact-root <directory>\n  audit --operation validate|render --repo <root> --report <report.json> [--format markdown|html]\n  audit --operation scope --repo <root> --since <git-ref>\n  artifact index --artifact-root <root> [--output <index.json>] [--operation rebuild|incremental] [--existing <index.json>]\n  artifact query --artifact-root <root> --repo <name> [--repo-path <path>] [--artifact-schema <schema>] [--type <artifact-type>] [--contains <text>] [--limit <1..100>]\n  change impact --artifact-root <root> --repo <name> --repo-path <checkout> --changed <relative-path> [--changed <relative-path>]... [--staleness current|advisory]\n  change risk <revspec> [--repo <path>] [--sample <N>] [--format json|text] (git-only defect-risk score, no prior run, no index)\n  edit impact --repo-path <checkout> --changed <relative-path> [--changed <relative-path>]... [--scope <directory>]... (working tree, no prior run, authority: none)\n  decision request-response --request <request.json|-> [--response <response.json>|--cancel <cancellation.json>] --now <unix-seconds> --branch <branch-id>...\n  decision record --resolution <resolution.json> --store <record-directory>\n  decision replay --query <query.json> --store <record-directory>\n  run execute --repo <repo-root> --out <run-staging-directory> --authority-root <publication-root> --final-name <name> [--profile default|strict|offline] [--manifest <integrations.json>] [--max-concurrency <n>] [--session-evidence <session-evidence.json>]\n  run dag-coordinate --repo <repo-root> --out <run-staging-directory> [--manifest <integrations.json>] [--max-concurrency <n>] [--session-evidence <session-evidence.json>]\n  run commit --source-root <A09-artifact-root> --authority-root <publication-root> --manifest-ref <artifact-ref.json> --final-name <name>\n  benchmark orientation --out <directory> [--repetitions <2..10>]\n  benchmark tools --corpus <corpus.json> --runs <runs.json> --artifact-root <directory> --out <directory>\n  governance ponytail-gate --request <request.json|->\n  orchestrate|orchestration [--action Validate|List|Plan] [--repo <path>] [--mode lite|normal|full] [--capability <name>] [--manifest <path>] [--json]\n",
+        "stderrUtf8": ""
+      }
+    },
+    {
+      "name": "repin clean success",
+      "argv": [
+        "repin",
+        "--repo",
+        "@fixture-repo@",
+        "--json"
+      ],
+      "reason": "Gate G1 (issue #139, tracked in #138): repin's completeness claim is now computed, not asserted -- \"complete\" cannot be reported without stating the scope it covers. #133 showed why: repin --write printed clean/filesChanged 0 while digests it never scanned were stale, and nothing in the report said what had (or had not) actually been looked at. `scanCoverage` makes that scope explicit (artifact types consumed, paths scanned, excluded prefixes) instead of the bare `clean` boolean alone.",
+      "oldContractId": "json-format:repin-report.v1",
+      "newContractId": "json-format:repin-report.v2",
+      "old": {
+        "exitCode": 0,
+        "stdoutUtf8": "{\n  \"ambiguousSources\": [],\n  \"clean\": true,\n  \"filesChanged\": 0,\n  \"mode\": \"report\",\n  \"orphanedPins\": [],\n  \"passes\": 1,\n  \"schema\": \"code-intel-repin-report.v1\",\n  \"skipped\": [],\n  \"stalePins\": [],\n  \"totalSubstitutions\": 0\n}\n",
+        "stderrUtf8": ""
+      },
+      "new": {
+        "exitCode": 0,
+        "stdoutUtf8": "{\n  \"ambiguousSources\": [],\n  \"clean\": true,\n  \"filesChanged\": 0,\n  \"mode\": \"report\",\n  \"orphanedPins\": [],\n  \"passes\": 1,\n  \"scanCoverage\": {\n    \"scope\": {\n      \"artifactTypes\": [\n        \"tracked-text-file\"\n      ],\n      \"excludedPrefixes\": [\n        \"orchestration/retirements/\"\n      ],\n      \"scannedPaths\": [\n        \"src/lib.rs\"\n      ]\n    },\n    \"status\": \"complete\"\n  },\n  \"schema\": \"code-intel-repin-report.v1\",\n  \"skipped\": [],\n  \"stalePins\": [],\n  \"totalSubstitutions\": 0\n}\n",
         "stderrUtf8": ""
       }
     }

--- a/crates/code-intel-cli/tests/repin.rs
+++ b/crates/code-intel-cli/tests/repin.rs
@@ -1,12 +1,16 @@
 #[path = "../src/content_contract.rs"]
 mod content_contract;
+#[path = "../src/evidence_outcome.rs"]
+mod evidence_outcome;
 
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use serde_json::Value;
+use serde_json::{json, Value};
+
+use evidence_outcome::EvidenceOutcome;
 
 struct TempTree(PathBuf);
 
@@ -528,5 +532,176 @@ fn human_output_reports_ambiguous_skipped_and_summary_counts() {
     assert!(
         stdout.contains("0 orphaned pin(s), 1 ambiguous digest(s), 1 skipped file(s)"),
         "summary line must surface both counts: {stdout}"
+    );
+}
+
+// --- Gate G1 (#139 / #138): the honesty bit is computed, not asserted. ---
+//
+// Before this change, `--exclude`-ing every tracked file out of the scan
+// surface (or pointing `--repo` at a tree with none at all) still printed
+// `"clean": true, "filesChanged": 0` -- the exact same shape #133 reported
+// as a real production bug: a report that is indistinguishable from a
+// genuine clean pass, over a surface it never actually looked at.
+
+#[test]
+fn empty_scan_surface_is_reported_not_computed_not_clean() {
+    let tree = TempTree::new("repin-empty-surface");
+    init_repo(&tree.0);
+    fs::write(tree.0.join("only.rs"), "fn a() {}\n").unwrap();
+    commit_all(&tree.0, "init the only tracked file");
+
+    // Excluding the only tracked file leaves nothing to scan at all --
+    // previously reported as a vacuous "clean".
+    let output = repin(&tree.0, &["--exclude", "only.rs"]);
+    let report = json(&output);
+    assert_eq!(
+        report["scanCoverage"]["status"], "not-computed",
+        "an empty scan surface must not claim any completeness status: {report}"
+    );
+    assert_eq!(
+        report["clean"], false,
+        "a scan that covered nothing must not be reported clean: {report}"
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "an uncomputed scan coverage must fail the gate, not exit 0: stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn real_scan_reports_complete_with_its_scope() {
+    let tree = TempTree::new("repin-complete-scope");
+    init_repo(&tree.0);
+    fs::write(tree.0.join("source.rs"), "fn a() {}\n").unwrap();
+    commit_all(&tree.0, "init");
+
+    let report = json(&repin(&tree.0, &[]));
+    assert_eq!(report["clean"], true);
+    assert_eq!(report["scanCoverage"]["status"], "complete");
+    let scanned: Vec<String> = report["scanCoverage"]["scope"]["scannedPaths"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    assert!(
+        scanned.contains(&"source.rs".to_string()),
+        "a genuine complete scan must name the paths it covered: {report}"
+    );
+    assert_eq!(
+        report["scanCoverage"]["scope"]["artifactTypes"][0],
+        "tracked-text-file"
+    );
+}
+
+#[test]
+fn oversized_input_reports_partial_coverage_not_complete() {
+    let tree = TempTree::new("repin-partial-scope");
+    init_repo(&tree.0);
+    fs::write(tree.0.join("source.rs"), "fn a() {}\n").unwrap();
+    let source_head = sha256_of(&tree.0.join("source.rs"));
+    let padding = "x".repeat(5 * 1024 * 1024);
+    fs::write(
+        tree.0.join("record.json"),
+        format!(
+            r#"{{"padding":"{padding}","source":{{"path":"source.rs","sha256":"{source_head}"}}}}"#
+        ),
+    )
+    .unwrap();
+    commit_all(&tree.0, "init source and an oversized record");
+
+    fs::write(tree.0.join("source.rs"), "fn a() { changed(); }\n").unwrap();
+
+    let report = json(&repin(&tree.0, &[]));
+    assert_eq!(report["scanCoverage"]["status"], "partial", "{report}");
+    assert_eq!(
+        report["scanCoverage"]["partialReason"], "unreadable_input",
+        "{report}"
+    );
+    let unreadable: Vec<String> = report["scanCoverage"]["paths"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    assert!(unreadable.contains(&"record.json".to_string()), "{report}");
+}
+
+/// The acceptance condition for G1, not a nice-to-have: take a report the
+/// system honestly produced as `not-computed`, forge only its `status`
+/// field to `"complete"` -- exactly what a careless writer, or a bad actor
+/// hand-editing a handed-off artifact, would do to make an unchecked
+/// surface look checked -- and prove parsing it back is rejected because
+/// no `scope` was supplied. If this test failed to fail on the forgery,
+/// G1 would not be built, no matter how the type looks.
+#[test]
+fn forged_complete_claim_without_scope_is_rejected() {
+    let tree = TempTree::new("repin-forged-complete");
+    init_repo(&tree.0);
+    fs::write(tree.0.join("only.rs"), "fn a() {}\n").unwrap();
+    commit_all(&tree.0, "init the only tracked file");
+
+    // A real, honestly produced `not-computed` outcome (same setup as
+    // `empty_scan_surface_is_reported_not_computed_not_clean`).
+    let report = json(&repin(&tree.0, &["--exclude", "only.rs"]));
+    let honest = report["scanCoverage"].clone();
+    assert_eq!(honest["status"], "not-computed");
+
+    // The system's own honest value parses back fine.
+    assert!(
+        EvidenceOutcome::from_json(&honest).is_ok(),
+        "the honestly produced outcome must itself parse: {honest}"
+    );
+
+    // Forge: flip only `status` to `"complete"`, exactly as a bug (or a
+    // careless hand-edit) that only ever touches a boolean/status field
+    // would. No `scope` is added -- because the whole point is that
+    // nothing on this path actually computed one.
+    let forged = json!({ "status": "complete" });
+    assert!(
+        EvidenceOutcome::from_json(&forged).is_err(),
+        "a complete claim forged without a scope must be rejected, not accepted"
+    );
+
+    // Also forge from a genuinely partial report the same way, to prove
+    // this is not an artifact of the not-computed case specifically.
+    let tree2 = TempTree::new("repin-forged-complete-from-partial");
+    init_repo(&tree2.0);
+    fs::write(tree2.0.join("source.rs"), "fn a() {}\n").unwrap();
+    let source_head = sha256_of(&tree2.0.join("source.rs"));
+    let padding = "x".repeat(5 * 1024 * 1024);
+    fs::write(
+        tree2.0.join("record.json"),
+        format!(
+            r#"{{"padding":"{padding}","source":{{"path":"source.rs","sha256":"{source_head}"}}}}"#
+        ),
+    )
+    .unwrap();
+    commit_all(&tree2.0, "init source and an oversized record");
+    fs::write(tree2.0.join("source.rs"), "fn a() { changed(); }\n").unwrap();
+
+    let partial_report = json(&repin(&tree2.0, &[]));
+    let partial = partial_report["scanCoverage"].clone();
+    assert_eq!(partial["status"], "partial");
+    assert!(EvidenceOutcome::from_json(&partial).is_ok());
+
+    // Forge by copying the real scope's *shape* but dropping one required
+    // field -- the kind of partial refactor that would slip through review
+    // if the parser were not strict about it.
+    // The minimal, realistic forgery: flip *only* `status`. Leave the
+    // Partial's real (well-formed) `scope` and its `partialReason`/`paths`
+    // fields completely untouched -- this is the shape #133's own bug took
+    // (one field changed, nothing else), and it is the case a naive
+    // "does `scope` exist?" check would miss: the scope object is right
+    // there, fully populated, just borrowed from a claim that never
+    // actually achieved completeness.
+    let mut forged_from_partial = partial.clone();
+    forged_from_partial["status"] = json!("complete");
+    assert!(
+        EvidenceOutcome::from_json(&forged_from_partial).is_err(),
+        "a `partial` report relabeled `complete` by touching only `status` \
+         must be rejected even though its (borrowed) scope object is well-formed: {forged_from_partial}"
     );
 }


### PR DESCRIPTION
## What

Gate G1 of the project charter (#139, tracked in #138): the honesty bit is
computed, not asserted.

Adds `EvidenceOutcome` (`crates/code-intel-cli/src/evidence_outcome.rs`) — a
completeness claim for one evidence-producing surface, with three states:

- `Complete(EvidenceScope)` — the surface was fully enumerated. The only
  constructor for this variant takes an `EvidenceScope` (artifact types
  consumed, paths scanned, excluded prefixes); there is no way to build a
  `Complete` in Rust without one.
- `Partial { reason: PartialReason, scope: EvidenceScope }` — reason is
  `Truncated`, `CapHit`, or `UnreadableInput(paths)`; scope says what *was*
  covered despite the gap.
- `NotComputed { reason: String }` — the surface was never evaluated, and why.

Applied end to end to **one real surface**: `repin`'s scan-coverage claim.

## Why repin, not the risk/context truncation surfaces

I read `evidence_query.rs`, `change_risk/`, `hospital_diagnosis.rs`, and
`repin.rs` before choosing. The risk/context "callers/co-change/tests-to-run"
truncation pattern described in #138's body doesn't exist as code in this
repo today — I grepped for `callers_total`, `tests_to_run`, `cochange`, etc.
and found no matches; that description characterizes a different product's
existing shape, not something already broken here. `change_risk`'s caps
(`FILES_TOUCHED_CAP`, `LINES_CHANGED_CAP`) saturate a *score*, not a coverage
claim — there's no "clean"-style pass/fail bit being asserted there today.

`repin` is where the silent-lie failure mode is real and already reported
(#133): `repin --write --json` printed `"clean": true, "filesChanged": 0`
while digests it never scanned were stale. Reading `repin.rs` end to end, I
found and reproduced a second, cheaper instance of the *same shape* today,
independent of #133's own root cause (which is about digest tracking across
commits, not about scan enumeration — a separate, larger fix):

```
# exclude the only tracked file out of the scan surface
$ code-intel repin --repo <repo-with-one-file> --exclude only.rs --json
{ "clean": true, "filesChanged": 0, ... }   # exit 0
```

A scan that covered **zero files** reported exactly the same `clean: true`
shape as a scan that covered everything and found it clean — the report
gives a downstream reader no way to tell "checked, and it's fine" from
"never checked." That's the concrete proof-of-need for this surface.

`repin.rs` was also not the concurrently-edited file (`native_code_evidence.rs`
chunk-emission work is untouched by this PR — confirmed via `git diff --stat`
before push).

## What changed in repin

`RepinReport` now stores one `EvidenceOutcome`, computed once in
`scan_coverage()` from the exact same `scan_targets` / `skipped` data every
other field on the report is built from:

- Empty `scan_targets` after exclusions → `NotComputed` (the bug above).
- Any `gates_clean` skip (too-large / unreadable input) → `Partial` with
  `UnreadableInput` and the paths that couldn't be read.
- Otherwise → `Complete`, with the scope (`artifact_types: ["tracked-text-file"]`,
  the scanned paths, the exclude prefixes).

Both the JSON `scanCoverage` field and `is_clean()`/`has_unresolved()` (which
drives the exit code) read this one stored value — they cannot read
different data, which is the specific anti-pattern the charter calls out
(an interval computed in one structure, a pass/fail decision read from
another, and the two never meeting).

## The reverse test — proof it actually fails when forged

`forged_complete_claim_without_scope_is_rejected` in
`crates/code-intel-cli/tests/repin.rs`, plus unit tests in
`evidence_outcome.rs`. Two forgeries, not one:

1. A real `not-computed` report (from the empty-scan-surface case above),
   `status` flipped to `"complete"` with no `scope` added at all.
2. **The realistic one**: a real `partial` report (oversized-input case),
   `status` flipped to `"complete"` — leaving its genuine, fully-populated
   `scope` and its `partialReason`/`paths` fields completely untouched. This
   is the shape #133's own bug took: one field changed, everything else
   left alone. A bare "does `scope` exist and have its fields?" check would
   **accept** this forgery, because the scope really is there and really is
   well-formed (just borrowed from a claim that never achieved completeness).
   `from_json` catches it with an exact-key-set check per status — a
   `Partial`'s object is a strict superset of a `Complete`'s, so the leftover
   `partialReason`/`detail`/`paths` fields fail the check.

I verified this test is not vacuous by breaking the fix and confirming the
test fails to fail: with the exact-key check temporarily removed,
`EvidenceOutcome::from_json` on the forged-from-partial JSON returned
`Ok(Complete(...))` instead of `Err(...)`, and both the integration test and
the unit test failed as expected. Re-added the check, both pass again.

## Same-source requirement (#4)

`is_clean()` / `has_unresolved()` and the `scanCoverage` JSON field both read
`RepinReport.outcome` — one field, computed once in `scan_coverage()`. No
second tally exists anywhere in the module.

## Surfaces that still lack the honesty bit (explicitly not done here)

- **`evidence_query.rs`'s `coverage.status`** (`"complete"`/`"partial"` string,
  computed via if/else, no `EvidenceScope`, no enforced construction rule) —
  the closest existing analog to what this PR builds, and the most obvious
  next candidate to migrate onto `EvidenceOutcome`.
- **`change_risk`'s saturating caps** (`FILES_TOUCHED_CAP`, `LINES_CHANGED_CAP`,
  `BUG_MAGNET_CAP`, `CHURN_CAP`) — silently saturate a score; no coverage
  claim exists to convert yet, but a "did we see the whole diff shape or did
  we cap out" bit would fit this type.
- **`snapshot.rs`'s `"[truncated]"` bounded-preview helper** — same
  truncation shape, unconverted.
- **G2 (detector registry + gating function) and #138 section C (N-agent
  arbitration / in-flight-change registry)** — not started; this PR is scoped
  to G1's type and one proof surface only, per the charter's own layering.
- Did not touch `capability_inventory.rs` / `sentrux_analysis.rs` (the other
  bug-magnet hotspots) — out of scope for this change, not examined for
  this pattern.

## Testing

- `cargo test --workspace --locked`: 2958 passed, 0 failed.
- `cargo fmt --check`: clean.
- `code-intel sentrux check .`: all rules passed, god-file count unchanged
  (33 -> 33), no degradation against `.sentrux/baseline.json`.

Refs #139 #138 #133
