### PR TITLE
fix(doctor): probe ast-grep so bootstrap stops reporting ok on a machine where edit.ast-grep-plan cannot run

### DIFF
--- a/crates/code-intel-cli/src/doctor_bootstrap/mod.rs
+++ b/crates/code-intel-cli/src/doctor_bootstrap/mod.rs
@@ -122,6 +122,14 @@ pub(crate) fn observe(options: &Options) -> Result<Value, String> {
         probe::probe_tool("repowise", options.require_repowise, prefix),
         probe::probe_tool("repomix", false, prefix),
         probe::probe_tool("sentrux", !builtin_sentrux, prefix),
+        // `edit.ast-grep-plan` ships as a production capability whose runtime
+        // adapter resolves `ast-grep` through `tool_path`, so a machine
+        // without it only finds out at capability-exec time, as
+        // `Unavailable("start ast-grep: ...")`. Optional because
+        // `orchestration/toolchain-versions.v1.json` declares ast-grep
+        // `required: false` — but observed, so the doctor stops omitting a
+        // tool a shipped capability cannot run without.
+        probe::probe_tool("ast-grep", false, prefix),
     ];
 
     let sentrux_core = probe::probe_command_output(
@@ -742,7 +750,7 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(
             names,
-            vec!["rg", "git", "python", "repowise", "repomix", "sentrux"]
+            vec!["rg", "git", "python", "repowise", "repomix", "sentrux", "ast-grep"]
         );
         fs::remove_dir_all(root).ok();
     }

--- a/crates/code-intel-cli/tests/doctor_bootstrap_cli.rs
+++ b/crates/code-intel-cli/tests/doctor_bootstrap_cli.rs
@@ -248,6 +248,60 @@ fn the_pipeline_root_defaults_to_the_checkout_the_caller_stands_in() {
     fs::remove_dir_all(root).ok();
 }
 
+/// Regression (F4): `orchestration/integrations.json` ships
+/// `edit.ast-grep-plan` with a `runtimeAdapter`, and that adapter resolves
+/// `ast-grep` through `tool_path` before shelling out to it. The doctor's
+/// probe list was hardcoded without it, so a machine with no ast-grep got
+/// `ok: true, missing: []` and only learned the truth at capability-exec
+/// time as `Unavailable("start ast-grep: ...")`.
+///
+/// The manifest read is the point: this asserts the probe list against the
+/// capability that actually needs the tool, so retiring `edit.ast-grep-plan`
+/// relaxes the test instead of leaving a restated constant behind.
+#[test]
+fn the_probe_list_covers_the_external_tool_a_shipped_capability_shells_out_to() {
+    let manifest: Value = serde_json::from_str(
+        &fs::read_to_string(pipeline_root().join("orchestration/integrations.json"))
+            .expect("read integrations manifest"),
+    )
+    .expect("integrations manifest is JSON");
+    let ships_ast_grep_plan = manifest["integrations"]
+        .as_array()
+        .expect("integrations array")
+        .iter()
+        .any(|entry| entry["id"] == "edit.ast-grep-plan" && entry["runtimeAdapter"].is_string());
+    assert!(
+        ships_ast_grep_plan,
+        "edit.ast-grep-plan is no longer a shipped runtime capability; drop this test rather than weakening it"
+    );
+
+    let repo = temp_dir("ast-grep");
+    let (_, observation, _) = doctor(&[
+        "--repo-path",
+        repo.to_str().unwrap(),
+        "--no-require-repowise",
+        "--json",
+    ]);
+    let probed = observation["checks"]["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .find(|tool| tool["name"] == "ast-grep")
+        .unwrap_or_else(|| {
+            panic!(
+                "doctor bootstrap never probes ast-grep: {}",
+                observation["checks"]["tools"]
+            )
+        })
+        .clone();
+    // Optional, matching the `required: false` that
+    // `orchestration/toolchain-versions.v1.json` already declares for it — the
+    // fix is that the doctor reports on the tool, not that it starts failing.
+    assert_eq!(probed["required"], json!(false));
+    assert!(probed["found"].is_boolean());
+    fs::remove_dir_all(repo).ok();
+}
+
 #[test]
 fn an_unknown_flag_fails_closed_without_emitting_an_observation() {
     let (code, observation, stderr) = doctor(&["--not-a-flag"]);

--- a/orchestration/integrations.json
+++ b/orchestration/integrations.json
@@ -286,7 +286,7 @@
           "version": "1.0.0",
           "toolchainDigests": [
             "c4379b9fa2d7cbc6b39bd08e200cc2ed685da0eb30e99f86facc49e8040fd4d9",
-            "b4b6fc64473de6bc6c3c37385ed9ecc6bc2a08fb61d1efae6449542f774a7eb3",
+            "ef26c267155fdbf93b30fbbdedff6f4923ea291eabb1d42e76915d31ff493f99",
             "7db9e80857f3c65aada25041986cb5cb3b50b95fa69de794d55ad38fd4a8d8d4",
             "78f88f1aaa3f77d28fbadf2bf8fd1c5e5a6b99a4728457262b19baabff2c8a80",
             "c9842468b904868391ff0fd2bb5d9627f4d61ab5f39fa01513dc409d0d2b484d",


### PR DESCRIPTION
## The finding

`code-intel doctor bootstrap --repo-path . --no-require-repowise --require-provider-conformance --json` returned `"ok": true`, `"missing": []`, and a `tools` array of exactly six entries: `rg`, `git`, `python`, `repowise`, `repomix`, `sentrux`. The probe list is hardcoded in `crates/code-intel-cli/src/doctor_bootstrap/mod.rs` and contained no `ast-grep`.

That is a blind spot with three independent confirmations in this tree:

- `orchestration/integrations.json` ships `edit.ast-grep-plan` as a capability with `runtimeAdapter: edit.ast-grep-plan.compat`.
- `crates/code-intel-cli/src/structured_edit.rs` resolves `tool_path::resolve("ast-grep")` and shells out to `ast-grep --version`; a machine without it fails at capability-exec time with `AdapterError::Unavailable("start ast-grep: ...")`.
- `.github/workflows/ci.yml` installs a sha256-pinned ast-grep 0.42.3 in **both** jobs and throws on a version mismatch, and `orchestration/toolchain-versions.v1.json` carries an `ast-grep` entry with a `command` probe.

So CI treated ast-grep as a hard dependency while the doctor treated it as nonexistent.

## The fix

One probe added to the `tools` vector, `required: false`.

Optional is the honest setting, not a softening: `orchestration/toolchain-versions.v1.json` already declares `ast-grep` with `"required": false`, and `integrations.json` declares `edit.ast-grep-plan` with `"required": false`. Making it required would have flipped the doctor red on every installed machine without ast-grep — a gate change, not a bug fix. What changes is that the observation now *reports* the tool: `found` plus a resolved `source` path, and a `MISSING ast-grep` line in the human rendering when it is absent, instead of silently omitting it.

No existing green turns red, and no gate was weakened, waived, or relabelled.

## Tests

Two, both of which fail if the one-line probe is reverted:

1. `doctor_bootstrap::tests::observation_carries_the_v1_contract_and_every_retired_check` — the existing tool-name-order assertion gains `"ast-grep"`.
2. `the_probe_list_covers_the_external_tool_a_shipped_capability_shells_out_to` (new, `tests/doctor_bootstrap_cli.rs`) — reads the shipped `orchestration/integrations.json`, confirms `edit.ast-grep-plan` is still a runtime capability, and only then requires the probe list to cover it. The manifest read is the point: retiring the capability relaxes the test instead of leaving a restated constant behind.

**Revert proof.** With `probe::probe_tool("ast-grep", false, prefix)` removed and nothing else changed:

```
test the_probe_list_covers_the_external_tool_a_shipped_capability_shells_out_to ... FAILED
  doctor bootstrap never probes ast-grep: [rg, git, python, repowise, repomix, sentrux]

test doctor_bootstrap::tests::observation_carries_the_v1_contract_and_every_retired_check ... FAILED
  left:  ["rg", "git", "python", "repowise", "repomix", "sentrux"]
  right: ["rg", "git", "python", "repowise", "repomix", "sentrux", "ast-grep"]
```

Restored, both pass.

## Digest re-pin

`capabilityDeclaration.implementation.toolchainDigests` for the `doctor` capability pins `doctor_bootstrap/mod.rs`. Re-pinned by hand (`b4b6fc64… -> ef26c267…`) and verified with sha256, per the known `repin --write` blind spot (#133). `registry_toolchain_digests_bind_the_adapter_and_dispatch_sources` caught the stale pin and now passes.

## Verification

- `cargo test --workspace --locked` — 2959 passed, 51 suites, fully green.
- `cargo fmt -p code-intel -- --check` — clean.
- Authoritative self-scan (`run execute --repo . --manifest orchestration/integrations.json --doctor-require-repowise false`) — exit 0, `"failures": {"domain": [], "process": []}`, all 8 nodes `verdict: pass`.
- God-file ratchet checked by hand before editing: `mod.rs` sits at 25 recognised functions, and the rule is `functions > 25 && loc > 400`. Adding *any* new `fn` to that file — including a test fn — would have made it a god file and tripped the ratchet. That is why the new test lives in `tests/doctor_bootstrap_cli.rs` and the in-file change is a comment plus one expression. Post-change: `mod.rs` loc 779 / 25 fns, `doctor_bootstrap_cli.rs` loc 312 / 11 fns — neither trips it.

## Post-fix output

```json
{"found": true, "name": "ast-grep", "required": false,
 "source": "...\\Scripts\\ast-grep.exe"}
```

Seven entries now, and the doctor answers for a tool a shipped capability cannot run without.

Refs the dogfooding finding `F4-doctor-blind-to-ast-grep`. Do not merge without review.
