### PR TITLE
fix(doctor): --require-understand 真的检查 Understand Anything，终结 fail-open 空转

### DIFF
--- a/crates/code-intel-cli/src/doctor_bootstrap/mod.rs
+++ b/crates/code-intel-cli/src/doctor_bootstrap/mod.rs
@@ -347,6 +347,20 @@ fn missing_list(
     if options.require_understand && !flag("/graphProvider/cargoFound") {
         missing.push("code-intel Rust runtime".to_string());
     }
+    // The two checks above only prove the *internal* graph provider ships in
+    // this checkout; inside the pipeline repo they are trivially true, which
+    // left `--require-understand` a fail-open no-op that never once consulted
+    // the `understandAnything` block it computes. The retired PowerShell probe
+    // had the same hole. Understand Anything ships either as an agent skill or
+    // as a plugin directory, so either one satisfies the requirement — this is
+    // the same "skill/plugin" wording the installer's own RequireUnderstand
+    // check remediates with.
+    if options.require_understand
+        && !flag("/understandAnything/skillFound")
+        && !flag("/understandAnything/pluginFound")
+    {
+        missing.push("Understand Anything skill or plugin".to_string());
+    }
     if checks["repo"].is_object() && !flag("/repo/exists") {
         missing.push("repo path".to_string());
     }
@@ -690,6 +704,7 @@ mod tests {
                 "sentrux pro auto-activation".to_string(),
                 "internal graph provider source".to_string(),
                 "code-intel Rust runtime".to_string(),
+                "Understand Anything skill or plugin".to_string(),
                 "repo path".to_string(),
                 "CODE_INTEL_HOME: directory does not exist (C:/nope)".to_string(),
             ]

--- a/crates/code-intel-cli/tests/doctor_envelope.rs
+++ b/crates/code-intel-cli/tests/doctor_envelope.rs
@@ -308,3 +308,111 @@ fn doctor_cli_reports_nonconforming_provider_and_manifest_drift_as_domain_failur
     assert!(!observation_text.contains(root.to_string_lossy().as_ref()));
     fs::remove_dir_all(root).ok();
 }
+
+/// A pipeline checkout shaped like the real one: `legacy/` plus the crate
+/// files `graphProvider` probes for, so `sourceFound`/`cargoFound` are both
+/// true. That is the whole point — those two are the only things
+/// `--require-understand` used to check, and inside a checkout they are
+/// trivially satisfied.
+fn pipeline_scratch(root: &Path) {
+    let crate_src = root.join("crates").join("code-intel-cli").join("src");
+    fs::create_dir_all(&crate_src).unwrap();
+    fs::create_dir_all(root.join("legacy")).unwrap();
+    fs::write(crate_src.join("graph.rs"), "// graph provider\n").unwrap();
+    fs::write(
+        root.join("crates")
+            .join("code-intel-cli")
+            .join("Cargo.toml"),
+        "[package]\n",
+    )
+    .unwrap();
+}
+
+fn doctor_bootstrap(pipeline_root: &Path, home: &Path) -> Value {
+    let output = Command::new(env!("CARGO_BIN_EXE_code-intel"))
+        .args(["doctor", "bootstrap", "--pipeline-root"])
+        .arg(pipeline_root)
+        .args(["--no-require-repowise", "--require-understand", "--json"])
+        // The probe derives the Understand Anything candidates from the home
+        // directory, so pinning it is what makes this test independent of
+        // whatever the developer or CI runner happens to have installed.
+        .env("USERPROFILE", home)
+        .env("HOME", home)
+        .output()
+        .expect("doctor bootstrap");
+    serde_json::from_slice(&output.stdout).expect("bootstrap JSON")
+}
+
+/// Regression: `--require-understand` was a fail-open no-op. It gated only on
+/// `/graphProvider/{sourceFound,cargoFound}` — both trivially true in a
+/// checkout — and never once read the `understandAnything` block the very same
+/// document publishes, so the flag answered `ok: true, missing: []` on a
+/// machine reporting `skillFound: false, pluginFound: false`.
+#[test]
+fn require_understand_reports_missing_understand_anything() {
+    let root = temp_dir();
+    let pipeline = root.join("pipeline");
+    let home = root.join("home");
+    pipeline_scratch(&pipeline);
+    fs::create_dir_all(&home).unwrap();
+
+    let absent = doctor_bootstrap(&pipeline, &home);
+    // Precondition: the checks the flag *used* to rely on are both satisfied,
+    // so nothing but the Understand Anything check can fail this run.
+    assert_eq!(
+        absent["checks"]["graphProvider"]["sourceFound"],
+        json!(true)
+    );
+    assert_eq!(absent["checks"]["graphProvider"]["cargoFound"], json!(true));
+    assert_eq!(
+        absent["checks"]["understandAnything"]["skillFound"],
+        json!(false)
+    );
+    assert_eq!(
+        absent["checks"]["understandAnything"]["pluginFound"],
+        json!(false)
+    );
+    assert_eq!(absent["strict"]["requireUnderstand"], json!(true));
+
+    // An installed skill satisfies the requirement, so the check cannot be a
+    // blanket failure that merely looks like enforcement.
+    let skill = home.join(".claude").join("skills").join("understand");
+    fs::create_dir_all(&skill).unwrap();
+    fs::write(skill.join("SKILL.md"), "# understand\n").unwrap();
+    let present = doctor_bootstrap(&pipeline, &home);
+    assert_eq!(
+        present["checks"]["understandAnything"]["skillFound"],
+        json!(true)
+    );
+
+    // A differential rather than a bare membership check: the scratch root is
+    // deliberately incomplete in other ways (no pipeline script, no config),
+    // so the honest claim is that installing Understand Anything removes
+    // exactly one entry and changes nothing else.
+    let entries = |observation: &Value| {
+        observation["missing"]
+            .as_array()
+            .expect("missing array")
+            .iter()
+            .map(|entry| entry.as_str().expect("missing entry").to_string())
+            .collect::<Vec<_>>()
+    };
+    let (before, after) = (entries(&absent), entries(&present));
+    let removed = before
+        .iter()
+        .filter(|entry| !after.contains(entry))
+        .cloned()
+        .collect::<Vec<_>>();
+    assert_eq!(
+        removed,
+        vec!["Understand Anything skill or plugin".to_string()],
+        "installing the skill must clear exactly the understand requirement\n\
+         before={before:?}\nafter={after:?}"
+    );
+    assert!(
+        after.iter().all(|entry| before.contains(entry)),
+        "installing the skill must not introduce new missing entries"
+    );
+
+    fs::remove_dir_all(root).ok();
+}

--- a/orchestration/integrations.json
+++ b/orchestration/integrations.json
@@ -286,7 +286,7 @@
           "version": "1.0.0",
           "toolchainDigests": [
             "c4379b9fa2d7cbc6b39bd08e200cc2ed685da0eb30e99f86facc49e8040fd4d9",
-            "ef26c267155fdbf93b30fbbdedff6f4923ea291eabb1d42e76915d31ff493f99",
+            "c3934819ca5d50e4966f80d56f5950bfc56394779eaf02eae050243fedd73885",
             "7db9e80857f3c65aada25041986cb5cb3b50b95fa69de794d55ad38fd4a8d8d4",
             "78f88f1aaa3f77d28fbadf2bf8fd1c5e5a6b99a4728457262b19baabff2c8a80",
             "c9842468b904868391ff0fd2bb5d9627f4d61ab5f39fa01513dc409d0d2b484d",


### PR DESCRIPTION
## 问题

`--require-understand` / `--doctor-require-understand` 从来没有检查过 Understand Anything。

`missing_list`（`crates/code-intel-cli/src/doctor_bootstrap/mod.rs`）里唯一消费 `options.require_understand` 的两个分支只看 `/graphProvider/sourceFound` 和 `/graphProvider/cargoFound`。这两个检查的是 `crates/code-intel-cli/src/graph.rs` 和 `crates/code-intel-cli/Cargo.toml` 在不在 —— 在 pipeline checkout 内部恒真。而同一份文档里算出来的 `understandAnything` 块（skill / plugin 探测）被发布之后再也没有任何人读过。

复现（修复前，本机没装 Understand Anything）:

```
$ code-intel doctor bootstrap --repo-path . --no-require-repowise --require-understand --json
$ echo $?
0
```

```json
"ok": true,
"missing": [],
"strict": { "requireRepowise": false, "requireUnderstand": true },
"checks": {
  "understandAnything": { "skillFound": false, "skillPath": "", "pluginFound": false, "pluginPath": "" }
}
```

同一份文档一边说 `ok: true`，一边说什么都没找到。

被退休的 PowerShell 探针有同样的洞（`archive/check-code-intel-tools.ps1` 里 `$RequireUnderstand` 也只 gate `graphProvider`，`understandAnything` 只进输出不进 `$missing`），Rust 端口把缺陷一起忠实搬运了过来。

## 口径依据

按 installer 自己的 `RequireUnderstand` 检查对齐 —— `legacy/install-code-intel-pipeline.ps1:1227` 用完全相同的候选路径把 "skill:Understand Anything" 标成 required，补救文案是 "Install or link the Understand Anything skill/plugin"。Understand Anything 以 agent skill 或 plugin 目录两种形态发布，**任一存在即满足**，两者皆无才进 `missing`。

## 改动

- `missing_list` 增加一条分支：`require_understand` 且 skill/plugin 都没找到 → push `"Understand Anything skill or plugin"`。
- 现有两条 `graphProvider` 检查**原样保留**，不把当前的绿灯换成错误的红灯。
- 检查严格 opt-in：不带旗标的默认路径一个字节没变（仍退出 0，已验证）。
- `toolchainDigests` 随 `mod.rs` 改动 repin，并用 `sha256sum` 手工核对（#133 说 repin 对部分 digest 盲）。

修复后同一条命令：退出 **1**、`ok: false`、`missing: ["Understand Anything skill or plugin"]`，与它自己发布的 `understandAnything` 块一致。

## 测试

两条测试，都验证过 revert 即红：

1. `require_understand_reports_missing_understand_anything`（`tests/doctor_envelope.rs`）—— 端到端跑真实二进制。用 `USERPROFILE`/`HOME` 指向 scratch home 使探测结果**确定**，不依赖开发机/CI runner 上装了什么。scratch pipeline root 特意把 `graph.rs` + `Cargo.toml` 造出来，让旧的两条检查都为真 —— 正是要证明只有它们拦不住。断言是**差分**式的（scratch root 本来就缺 pipeline script / config）：装上 skill 后 `missing` 恰好少掉一条、且不多出任何一条。

   Revert 后失败：
   ```
   installing the skill must clear exactly the understand requirement
   before=["pipeline script", "pipeline config"]
   after=["pipeline script", "pipeline config"]
     left: []
    right: ["Understand Anything skill or plugin"]
   ```

2. `missing_list_preserves_the_retired_scripts_wording_and_order`（既有单测，按 finding 建议扩展）—— 锁住新条目的措辞与顺序。Revert 后同样失败。

## 门禁

- `cargo test --workspace --locked`：**2959 passed**（51 suites）
- `cargo fmt --check`：clean
- 权威 self-scan（`run execute ... --final-name dogfood-self-scan`）：`outcome: completed`, `exitCode: 0`, `failures: []` —— god-file 棘轮通过（`mod.rs` 786 非空行 / 上限 800，未新增函数）

没有削弱、豁免或改名任何门禁。

## 范围外（已知、未改）

`render_human` 的 "external Understand fallback" 那一行用的是 **AND**（`skillFound && pluginFound`）判 OK/MISSING，与本 PR 采用的 OR 口径不一致 —— 只装 skill 的机器上读者会看到 MISSING 而 `missing` 列表是空的。这是修复前就存在的展示层不一致，与本 finding 无关，没有一并改动。
