### PR TITLE
fix(run): 发布名撞车给出独立退出码 73 与可解析 stdout，终结「exit 65 + 零字节」

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
           New-Item -ItemType Directory -Force $authority | Out-Null
           ./target/release/code-intel.exe run execute --repo . --out $staging --authority-root $authority --final-name ci-self-scan --manifest orchestration/integrations.json --doctor-require-repowise false
           if ($LASTEXITCODE -ne 0) {
-            throw "self-scan failed with exit code ${LASTEXITCODE}: 10 = architecture/domain gate failure, 70 = process failure; read the run manifest failures block"
+            throw "self-scan failed with exit code ${LASTEXITCODE}: 10 = architecture/domain gate failure, 70 = process failure, 73 = --final-name already published under the authority root; read the run manifest failures block"
           }
 
       - name: Validate any produced audit report (ai-safety-003)
@@ -424,7 +424,7 @@ jobs:
           New-Item -ItemType Directory -Force $authority | Out-Null
           & $binary run execute --repo . --out $staging --authority-root $authority --final-name ci-self-scan --manifest orchestration/integrations.json --doctor-require-repowise false
           if ($LASTEXITCODE -ne 0) {
-            throw "self-scan failed with exit code ${LASTEXITCODE}: 10 = architecture/domain gate failure, 70 = process failure; read the run manifest failures block"
+            throw "self-scan failed with exit code ${LASTEXITCODE}: 10 = architecture/domain gate failure, 70 = process failure, 73 = --final-name already published under the authority root; read the run manifest failures block"
           }
 
       - name: Validate any produced audit report (ai-safety-003)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
           New-Item -ItemType Directory -Force $authority | Out-Null
           ./target/release/code-intel.exe run execute --repo . --out $staging --authority-root $authority --final-name release-self-scan --manifest orchestration/integrations.json --doctor-require-repowise false
           if ($LASTEXITCODE -ne 0) {
-            throw "release candidate failed its own scan (exit ${LASTEXITCODE}: 10 = architecture/domain gate failure, 70 = process failure). A failing self-scan must never publish."
+            throw "release candidate failed its own scan (exit ${LASTEXITCODE}: 10 = architecture/domain gate failure, 70 = process failure, 73 = --final-name already published under the authority root). A failing self-scan must never publish."
           }
 
       - name: Validate any produced audit report (ai-safety-003)
@@ -298,7 +298,7 @@ jobs:
           New-Item -ItemType Directory -Force $authority | Out-Null
           ./target/release/code-intel run execute --repo . --out $staging --authority-root $authority --final-name release-self-scan --manifest orchestration/integrations.json --doctor-require-repowise false
           if ($LASTEXITCODE -ne 0) {
-            throw "release candidate failed its own scan (exit ${LASTEXITCODE}: 10 = architecture/domain gate failure, 70 = process failure). A failing self-scan must never publish."
+            throw "release candidate failed its own scan (exit ${LASTEXITCODE}: 10 = architecture/domain gate failure, 70 = process failure, 73 = --final-name already published under the authority root). A failing self-scan must never publish."
           }
 
       - name: Package

--- a/crates/code-intel-cli/src/authoritative_run/completion.rs
+++ b/crates/code-intel-cli/src/authoritative_run/completion.rs
@@ -150,14 +150,19 @@ fn map_index_error(error: crate::artifact_index::IndexError) -> crate::run_error
 
 fn map_commit_error(error: crate::run_commit::CommitError) -> crate::run_error::RunError {
     match error {
-        crate::run_commit::CommitError::Contract(message)
-        | crate::run_commit::CommitError::Collision(message) => {
+        crate::run_commit::CommitError::Contract(message) => {
             crate::run_error::RunError::contract(message)
         }
+        // Revalidating an already-committed handoff has no reachable collision
+        // today, but folding it into the `Contract` arm is exactly the mistake
+        // that made a taken publication name report as exit 65 on the kernel
+        // side. Keep the classification honest on both mappers.
+        crate::run_commit::CommitError::Collision(message) => {
+            crate::run_error::RunError::publication_collision(message)
+        }
         crate::run_commit::CommitError::HostIo(message) => crate::run_error::RunError::io(message),
-        crate::run_commit::CommitError::Interrupted(phase) => crate::run_error::RunError {
-            exit_code: 75,
-            message: format!("publication interrupted before {phase:?}"),
-        },
+        crate::run_commit::CommitError::Interrupted(phase) => {
+            crate::run_error::RunError::new(75, format!("publication interrupted before {phase:?}"))
+        }
     }
 }

--- a/crates/code-intel-cli/src/authoritative_run/execution_kernel.rs
+++ b/crates/code-intel-cli/src/authoritative_run/execution_kernel.rs
@@ -130,7 +130,15 @@ pub(crate) fn execute(request: RunRequest) -> Result<ExecutionResult, RunError> 
         &dag.run_root.join("run-manifest-ref.json"),
         &request.final_name,
     )
-    .map_err(map_commit_error)?;
+    .map_err(|error| {
+        publication_failure(
+            error,
+            &dag.manifest,
+            &publication_root,
+            &repo_name,
+            &request.final_name,
+        )
+    })?;
     Ok(ExecutionResult {
         outcome: dag.outcome,
         manifest: dag.manifest,
@@ -182,15 +190,76 @@ fn nest_authority_root(authority_root: &Path, repo_name: &str) -> Result<PathBuf
     Ok(nested)
 }
 
+/// Schema identity of the envelope printed on stdout when the run finished but
+/// could not be published. Deliberately *not* `code-intel-execution-result.v1`:
+/// that schema is closed around a committed publication and binds each outcome
+/// to its exit code, and nothing published is nothing published.
+pub(crate) const EXECUTION_FAILURE_SCHEMA: &str = "code-intel-execution-failure.v1";
+
+/// The publication step runs after the DAG has already done the entire
+/// analysis, so a failure here throws away a complete, valid run manifest.
+///
+/// Re-running the CI self-scan into an authority root that already held that
+/// `--final-name` used to exit 65 with zero bytes on stdout and a bare
+/// `promote staged run without replacement: <localized OS error>` on stderr —
+/// no run name, no destination, no remedy, and on a non-English host not even
+/// English. Two things are fixed here: the collision gets its own exit code and
+/// an actionable message, and the manifest survives as a parseable envelope
+/// instead of being discarded.
+fn publication_failure(
+    error: crate::run_commit::CommitError,
+    manifest: &Value,
+    publication_root: &Path,
+    repo: &str,
+    final_name: &str,
+) -> RunError {
+    let destination = publication_root.join(final_name);
+    let failed = match error {
+        crate::run_commit::CommitError::Collision(detail) => RunError::publication_collision(
+            format!(
+                "run \"{final_name}\" is already published at {}; choose a different --final-name or remove the existing publication ({detail})",
+                destination.display()
+            ),
+        ),
+        other => map_commit_error(other),
+    };
+    let mut failures = failures(manifest);
+    if let Some(process) = failures["process"].as_array_mut() {
+        process.push(json!({
+            "node":PUBLICATION_FAILURE_NODE,
+            "diagnostic":failed.message,
+        }));
+    }
+    let report = json!({
+        "schema":EXECUTION_FAILURE_SCHEMA,
+        "exitCode":failed.exit_code,
+        "failures":failures,
+        "manifest":manifest,
+        "publication":{
+            "status":"failed",
+            "name":final_name,
+            "repo":repo,
+            "path":destination,
+            "diagnostic":failed.message,
+        },
+    });
+    failed.with_report(report)
+}
+
+/// Reported in `failures.process` alongside real DAG node failures. Namespaced
+/// like a node id but deliberately not one: publication happens after the DAG.
+const PUBLICATION_FAILURE_NODE: &str = "run.publication";
+
 fn map_commit_error(error: crate::run_commit::CommitError) -> RunError {
     match error {
-        crate::run_commit::CommitError::Contract(message)
-        | crate::run_commit::CommitError::Collision(message) => RunError::contract(message),
+        crate::run_commit::CommitError::Contract(message) => RunError::contract(message),
+        crate::run_commit::CommitError::Collision(message) => {
+            RunError::publication_collision(message)
+        }
         crate::run_commit::CommitError::HostIo(message) => RunError::io(message),
-        crate::run_commit::CommitError::Interrupted(phase) => RunError {
-            exit_code: 75,
-            message: format!("publication interrupted before {phase:?}"),
-        },
+        crate::run_commit::CommitError::Interrupted(phase) => {
+            RunError::new(75, format!("publication interrupted before {phase:?}"))
+        }
     }
 }
 

--- a/crates/code-intel-cli/src/cli/command_catalog/routes/run_routes.rs
+++ b/crates/code-intel-cli/src/cli/command_catalog/routes/run_routes.rs
@@ -18,9 +18,15 @@ pub(super) const EXECUTE: super::RawRoute = super::RawRoute {
                 "code-intel-run-manifest.v1",
                 "code-intel-artifact-index.v1",
             ],
-            stdout_identities: &["code-intel-execution-result.v1"],
+            stdout_identities: &[
+                "code-intel-execution-result.v1",
+                "code-intel-execution-failure.v1",
+            ],
         },
-        exit_contract: super::ExitContract::Exact(&[0, 10, 20, 64, 65, 70, 74]),
+        // 73 (EX_CANTCREAT): the run succeeded but `--final-name` is already
+        // published under the authority root. Distinct from 65 so a caller can
+        // tell "your arguments were wrong" from "that name is taken".
+        exit_contract: super::ExitContract::Exact(&[0, 10, 20, 64, 65, 70, 73, 74]),
         retirement_condition:
             "retain as the stable explicit production spelling; retire only by versioned replacement",
     },

--- a/crates/code-intel-cli/src/run_cli.rs
+++ b/crates/code-intel-cli/src/run_cli.rs
@@ -24,6 +24,14 @@ pub(crate) fn run_raw(raw: &[String]) -> i32 {
             result.exit_code
         }
         Err(error) => {
+            // A failure that already owns a run manifest prints it, so stdout
+            // stays parseable instead of going silent after a full analysis.
+            if let Some(report) = &error.report {
+                println!(
+                    "{}",
+                    serde_json::to_string(report).expect("run failure report serializes")
+                );
+            }
             eprintln!("{}", error.message);
             error.exit_code
         }

--- a/crates/code-intel-cli/src/run_error.rs
+++ b/crates/code-intel-cli/src/run_error.rs
@@ -1,21 +1,48 @@
-#[derive(Clone, Debug, PartialEq, Eq)]
+/// A run failure: the process exit code, the operator-facing message, and —
+/// when the failure happened late enough that a real run manifest already
+/// exists — a machine-readable envelope to print on stdout.
+///
+/// `report` exists because publication failures land *after* the DAG has done
+/// the entire analysis. Exiting with only a stderr line throws that manifest
+/// away and leaves the caller nothing to parse; carrying it here lets the CLI
+/// seam emit it without every intermediate layer having to thread a second
+/// return value.
+#[derive(Clone, Debug, PartialEq)]
 pub(crate) struct RunError {
     pub(crate) exit_code: i32,
     pub(crate) message: String,
+    pub(crate) report: Option<serde_json::Value>,
 }
 
 impl RunError {
-    pub(crate) fn contract(message: impl Into<String>) -> Self {
+    pub(crate) fn new(exit_code: i32, message: impl Into<String>) -> Self {
         Self {
-            exit_code: 65,
+            exit_code,
             message: message.into(),
+            report: None,
         }
     }
 
+    pub(crate) fn contract(message: impl Into<String>) -> Self {
+        Self::new(65, message)
+    }
+
     pub(crate) fn io(message: impl Into<String>) -> Self {
-        Self {
-            exit_code: 74,
-            message: message.into(),
-        }
+        Self::new(74, message)
+    }
+
+    /// The requested publication name is already taken under the authority
+    /// root. Distinct from `contract` (65) because the caller's arguments were
+    /// well-formed and the run itself succeeded — only the destination was
+    /// occupied — and distinct from `io` (74) because nothing is wrong with the
+    /// host. 73 is `EX_CANTCREAT` in the sysexits vocabulary the rest of these
+    /// codes follow: cannot create the output.
+    pub(crate) fn publication_collision(message: impl Into<String>) -> Self {
+        Self::new(73, message)
+    }
+
+    pub(crate) fn with_report(mut self, report: serde_json::Value) -> Self {
+        self.report = Some(report);
+        self
     }
 }

--- a/crates/code-intel-cli/tests/run_execute_publication.rs
+++ b/crates/code-intel-cli/tests/run_execute_publication.rs
@@ -16,7 +16,7 @@ use std::process::{Command, Output};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use serde_json::Value;
+use serde_json::{json, Value};
 
 fn binary() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_code-intel"))
@@ -108,8 +108,21 @@ fn run_execute(root: &Path, repo: &Path, authority: &Path, final_name: &str) -> 
 }
 
 fn run_execute_output(root: &Path, repo: &Path, authority: &Path, final_name: &str) -> Output {
+    run_execute_staged(root, repo, authority, final_name, final_name)
+}
+
+/// Same as `run_execute_output` but with the staging directory named
+/// independently of `--final-name`, so a test can publish the *same* name
+/// twice without the second attempt tripping over the first one's staging.
+fn run_execute_staged(
+    root: &Path,
+    repo: &Path,
+    authority: &Path,
+    final_name: &str,
+    staging_label: &str,
+) -> Output {
     let doctor_tools = doctor_tool_fixture(root);
-    let staging = root.join(format!("stage-{final_name}"));
+    let staging = root.join(format!("stage-{staging_label}"));
     Command::new(binary())
         .args(["run", "execute", "--repo"])
         .arg(repo)
@@ -273,6 +286,120 @@ fn run_execute_does_not_double_nest_when_authority_root_already_ends_with_repo_n
     );
 
     fs::remove_dir_all(&root).ok();
+}
+
+/// Dogfood finding F2-publish-collision-no-json. CI's self-scan hard-codes
+/// `--final-name ci-self-scan`, so re-running it into an authority root that
+/// already holds that publication is the ordinary case, not an exotic one. It
+/// used to exit **65** — the same code a malformed argument gets — after ~90s
+/// of full analysis, print **zero bytes** on stdout, and put a bare
+/// `promote staged run without replacement: <localized OS error>` on stderr:
+/// no run name, no destination path, no remedy, and on a non-English host not
+/// even English. The completed manifest was simply discarded.
+#[test]
+fn republishing_a_taken_final_name_reports_a_distinct_code_and_a_parseable_envelope() {
+    let root = temp_dir("republish-collision");
+    let repo = fixture_repo(&root);
+    let authority = root.join("authority");
+    fs::create_dir_all(&authority).expect("fixture authority root");
+
+    let (first, _) = run_execute(&root, &repo, &authority, "ci-self-scan");
+    assert_eq!(
+        first.status.code(),
+        Some(0),
+        "first publication must succeed: stderr={}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+    let published = authority.join("fixture-repo").join("ci-self-scan");
+
+    let second = run_execute_staged(&root, &repo, &authority, "ci-self-scan", "second-attempt");
+    assert_eq!(
+        second.status.code(),
+        Some(73),
+        "a taken publication name must not share exit 65 with malformed input: stdout={} stderr={}",
+        String::from_utf8_lossy(&second.stdout),
+        String::from_utf8_lossy(&second.stderr)
+    );
+
+    // stdout stays machine-readable: the run really did complete, and its
+    // manifest is the expensive part that used to be thrown away.
+    let report: Value = serde_json::from_slice(&second.stdout).unwrap_or_else(|error| {
+        panic!(
+            "collision printed nothing parseable on stdout: {error}\nstdout={}\nstderr={}",
+            String::from_utf8_lossy(&second.stdout),
+            String::from_utf8_lossy(&second.stderr)
+        )
+    });
+    assert_eq!(report["schema"], "code-intel-execution-failure.v1");
+    assert_eq!(report["exitCode"], 73);
+    assert_eq!(report["publication"]["status"], "failed");
+    assert_eq!(report["publication"]["name"], "ci-self-scan");
+    assert_eq!(report["publication"]["repo"], "fixture-repo");
+    assert_eq!(
+        report["publication"]["path"],
+        Value::String(published.display().to_string())
+    );
+    assert_eq!(report["manifest"]["outcome"], "completed");
+    let process = report["failures"]["process"]
+        .as_array()
+        .expect("failures.process array");
+    assert_eq!(process.len(), 1, "report={report}");
+    assert_eq!(process[0]["node"], "run.publication");
+
+    // The operator-facing message must name what collided, where, and what to
+    // do — not just relay the host's localized rename errno.
+    let diagnostic = process[0]["diagnostic"]
+        .as_str()
+        .expect("publication diagnostic");
+    let stderr = String::from_utf8_lossy(&second.stderr).to_string();
+    for expected in [
+        "ci-self-scan",
+        &published.display().to_string(),
+        "--final-name",
+    ] {
+        assert!(
+            diagnostic.contains(expected),
+            "diagnostic omits {expected}: {diagnostic}"
+        );
+        assert!(
+            stderr.contains(expected),
+            "stderr omits {expected}: {stderr}"
+        );
+    }
+
+    // The publication that was already there is untouched.
+    assert!(published.join("run-complete.json").is_file());
+
+    fs::remove_dir_all(&root).ok();
+}
+
+/// The stdout envelope above is a declared contract, not an ad hoc blob: it
+/// must validate against the checked-in closed schema the route advertises.
+#[test]
+fn checked_in_execution_failure_schema_is_closed_and_pins_the_collision_exit_code() {
+    let schema: Value = serde_json::from_str(include_str!(
+        "../../../orchestration/schemas/code-intel-execution-failure.v1.schema.json"
+    ))
+    .expect("execution failure schema JSON");
+    assert_eq!(schema["$id"], "code-intel-execution-failure.v1.schema.json");
+    assert_eq!(schema["additionalProperties"], false);
+    assert_eq!(
+        schema["properties"]["schema"]["const"],
+        "code-intel-execution-failure.v1"
+    );
+    assert_eq!(schema["properties"]["exitCode"]["enum"], json!([73]));
+    assert_eq!(
+        schema["properties"]["publication"]["additionalProperties"],
+        false
+    );
+    assert_eq!(
+        schema["properties"]["publication"]["properties"]["status"]["const"],
+        "failed"
+    );
+    assert_eq!(
+        schema["properties"]["failures"]["additionalProperties"],
+        false
+    );
 }
 
 #[test]

--- a/docs/execution-kernel-architecture.md
+++ b/docs/execution-kernel-architecture.md
@@ -35,6 +35,13 @@ the only runtime source for:
 - `domain_unknown` -> exit 20;
 - `process_failed` or `incomplete` -> exit 70.
 
+A run that completes but cannot be published is not an outcome — nothing was published. When
+`--final-name` is already taken under the authority root, `run execute` exits `73`
+(`EX_CANTCREAT`), names the run, the destination path, and the remedy on stderr, and prints the
+completed manifest on stdout as `code-intel-execution-failure.v1` so ~90s of analysis is not
+discarded silently. `73` is distinct from `65` (malformed input) precisely because the caller's
+arguments were well-formed and the run itself succeeded.
+
 The existing `code-intel-run-manifest.v1` schema and Artifact Ref envelope remain unchanged.
 Immediately after DAG completion, the private controller adds exactly one
 `repository.iteration` Artifact Ref. Its payload uses

--- a/orchestration/integrations.json
+++ b/orchestration/integrations.json
@@ -1153,7 +1153,8 @@
         "orchestration/schemas/code-intel-run-manifest.v1.schema.json",
         "orchestration/schemas/code-intel-repository-iteration-provenance.v1.schema.json",
         "orchestration/schemas/code-intel-run-commit.v1.schema.json",
-        "orchestration/schemas/code-intel-execution-result.v1.schema.json"
+        "orchestration/schemas/code-intel-execution-result.v1.schema.json",
+        "orchestration/schemas/code-intel-execution-failure.v1.schema.json"
       ],
       "extensionPoint": "Run profiles compile into one immutable ExecutionPolicy. Capability adapters execute behind A01 envelopes; the private controller alone binds repository.iteration provenance to the run, snapshot, repository key, and publication name before marker-last publication."
     },

--- a/orchestration/schemas/code-intel-execution-failure.v1.schema.json
+++ b/orchestration/schemas/code-intel-execution-failure.v1.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "code-intel-execution-failure.v1.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "exitCode", "failures", "manifest", "publication"],
+  "properties": {
+    "schema": { "const": "code-intel-execution-failure.v1" },
+    "exitCode": { "enum": [73] },
+    "failures": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["process", "domain"],
+      "properties": {
+        "process": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["node", "diagnostic"],
+            "properties": {
+              "node": { "type": "string", "minLength": 1 },
+              "diagnostic": { "type": "string" }
+            }
+          }
+        },
+        "domain": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["node", "verdict"],
+            "properties": {
+              "node": { "type": "string", "minLength": 1 },
+              "verdict": { "type": "string", "minLength": 1 }
+            }
+          }
+        }
+      }
+    },
+    "manifest": {
+      "$ref": "code-intel-run-manifest.v1.schema.json"
+    },
+    "publication": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "name", "repo", "path", "diagnostic"],
+      "properties": {
+        "status": { "const": "failed" },
+        "name": { "type": "string", "minLength": 1 },
+        "repo": { "type": "string", "minLength": 1 },
+        "path": { "type": "string", "minLength": 1 },
+        "diagnostic": { "type": "string", "minLength": 1 }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 问题

CI self-scan 写死 `--final-name ci-self-scan`，所以「再跑一次进同一个 `--authority-root`」是常态而非异常。在 `origin/main` 上把 CI 那条命令原样跑两遍：

```
ROUND 1 exit=0  stdout_bytes=5110  stderr=
ROUND 2 exit=65 stdout_bytes=0     stderr=promote staged run without replacement: 当文件已存在时，无法创建该文件。 (os error 183)
```

跑完整整一轮 ~90s 分析之后：退出码 **65**（和参数写错完全同码）、stdout **零字节**、stderr 只有一行 —— 不报 run 名、不报目标路径、不给补救办法，在非英语宿主上甚至不是英文。已经跑出来的完整 manifest 直接丢弃。

**根因**：`execution_kernel.rs::map_commit_error` 把 `CommitError::Collision` 和 `Contract` 塞进同一个 arm 折叠成 `RunError::contract`（65），而隔壁 `Interrupted` 却有自己的退出码和格式化消息。

> 对 finding 的两处更正：真正可达的位置是 `authoritative_run/execution_kernel.rs:185`，不是 finding 写的 `authoritative_run/completion.rs:151`（两份 mapper 当时逐字节相同；completion 那份今天不可达 —— `validate_committed_run` 产生不了 Collision）。两处都已纠正。另外 finding 说 `failures.process`「从未被填充」也不准确 —— DAG 节点 process 失败时它是会填的；这条路径上缺的是**整个 stdout**。

## 改动

- **`Collision` 独立成 arm，独立退出码 73**（`EX_CANTCREAT`，与周围 64/65/74/75 同属 sysexits 口径）。调用方现在能区分「你参数写错了」和「这个名字被占了」—— 后者参数完全合法、run 本身也成功了。
- **消息可执行**，原始 OS 错误保留在括号内：
  ```
  run "ci-self-scan" is already published at <authority-root>/<repo>/ci-self-scan;
  choose a different --final-name or remove the existing publication
  (promote staged run without replacement: … (os error 183))
  ```
- **stdout 保持可解析**：失败路径打印 `code-intel-execution-failure.v1`，带完整 run manifest，以及 `failures.process` 里 node 为 `run.publication` 的条目。这轮 run 最贵的产出不再被静默丢弃。

### 为什么新开 schema 而不复用 `code-intel-execution-result.v1`

finding 建议直接复用成功信封。但那个 schema 是围绕**已提交的 publication** 封闭的（`publication.status` 是 `const: "committed"`），并用 4 路 `oneOf` 把每个 outcome 绑死到退出码。复用就意味着为了塞进失败路径去撑松这些约束 —— 那是削弱既有契约。没发布就是没发布，这里改为发一个独立的封闭信封，成功契约一个字节没动。

新 schema 已入库、封闭，并且用 `Test-Json` 对真实输出验证通过。

### 一并对齐的契约面

- `run_routes.rs`：`exit_contract` `+73`，`stdout_identities` `+code-intel-execution-failure.v1`。
- `orchestration/integrations.json`：新 schema 进 `run.execute` 的 `artifactContract`。
- `ci.yml` / `release.yml`：throw 文案原本只写了 `10` 和 `70`，这正是 65 落在无文档地带的原因；现补上 `73`。（只动字符串，未碰任何门禁逻辑。）
- `docs/execution-kernel-architecture.md`：退出码一节补上「跑完但没发布成」这一档。

## 验证

**Revert 证明** —— 生产源码回退到 `origin/main`、只保留测试：

```
---- republishing_a_taken_final_name_reports_a_distinct_code_and_a_parseable_envelope ----
assertion `left == right` failed: a taken publication name must not share exit 65
with malformed input: stdout= stderr=promote staged run without replacement:
当文件已存在时，无法创建该文件。 (os error 183)
  left: Some(65)
 right: Some(73)
test result: FAILED. 4 passed; 1 failed;
```

测试复现的正是 finding 的原始证据。恢复后 5 passed。

- `cargo test --workspace --locked`：**2960 passed**（51 suites），0 failed
- `cargo fmt --check`：clean
- 本分支上跑权威 self-scan（`run execute --repo . --manifest orchestration/integrations.json`）：**exit 0**、`outcome=completed`、domain 与 process 失败均为空
- 第二次 self-scan 打进同一个 authority root —— 即 finding 描述的场景：**exit 73**、stdout 9085 字节且通过新 schema 校验、stderr 可执行、原有 publication 完好未动

没有削弱、豁免或改名任何门禁。

Refs: dogfood `F2-publish-collision-no-json`
