### PR TITLE
fix(exit-codes): stop treating sentrux gate findings as pipeline failure (#130)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Breaking (exit code semantics, #130):** `run-code-intel.ps1` no longer exits `1` when Sentrux's architecture/quality gate reports findings (debt) in the target repo. A parseable `sentrux gate` finding was previously indistinguishable from a genuine tool crash — both forced exit `1` with `FAILED` as the last line, even though every artifact (`report.json`, `summary.md`, `hospital.md`, `sentrux-debt-register.json`, ...) was produced intact. Exit codes are now layered: `0` clean, `1` pipeline genuinely did not complete, `2` pipeline completed with gate findings (success-with-findings). `report.summary.gateFindings` is a new counter. `invoke-code-intel.ps1` and `test-code-intel-pipeline.ps1` treat exit `2` as success by default (`test-code-intel-pipeline.ps1` gains an opt-in `-RequireCleanGates` switch for callers that need the old strict behavior). On non-zero exits, artifact paths are restated as the last thing printed. See `docs/artifact-data-contract.md#exit-code-contract-issue-130`.
+
 ## [0.2.0] — 2026-07-02
 
 The "understand any repo, cheaply" release. Docs generation now runs on any

--- a/docs/artifact-data-contract.md
+++ b/docs/artifact-data-contract.md
@@ -16,6 +16,16 @@ An artifact run is one timestamped directory for one target repository:
 
 Do not hand-edit artifact runs. Regenerate them with `invoke-code-intel.ps1` or `run-code-intel.ps1`.
 
+## Exit Code Contract (issue #130)
+
+`run-code-intel.ps1` and `invoke-code-intel.ps1` use a layered exit code, not a binary success/failure signal:
+
+- `0` -- clean run: no effective failures, no gate findings.
+- `1` -- the pipeline genuinely did not complete (tool crash, missing artifacts, an unrecoverable step, or any categorized failure other than a parseable sentrux gate finding). Treat as failed.
+- `2` -- the pipeline completed successfully and Sentrux's architecture/quality gate reported findings (debt) in the target repo -- see `sentrux-debt-register.json`. This is the gate doing its job and must be treated as success-with-findings, not failure. `report.summary.gateFindings` carries the count.
+
+Consumers must branch on the exit code, not just `-ne 0`: exit `2` still means every artifact (`report.json`, `summary.md`, `understanding.md`, `hospital.md`, `sentrux-debt-register.json`, etc.) was produced intact and should be read. On both non-zero exit paths, the artifact paths are restated as the last lines printed, specifically so a terminal-tail read (or an agent that only inspects the last line) does not mistake artifact-bearing gate findings for a bare crash.
+
 ## Files
 
 Machine-authoritative files:
@@ -92,6 +102,7 @@ Artifact consumers must preserve these fields:
 
 - `report.summary.failed`
 - `report.summary.effectiveFailed`
+- `report.summary.gateFindings`
 - `report.summary.manualRequired`
 - `report.summary.failureCategories.providerQuota`
 - `report.summary.failureCategories.localToolError`

--- a/invoke-code-intel.ps1
+++ b/invoke-code-intel.ps1
@@ -68,6 +68,7 @@ function Invoke-OneRepo {
         return [pscustomobject][ordered]@{
             repo = $label
             ok = $false
+            status = "FAILED"
             stage = "doctor"
             exitCode = $LASTEXITCODE
         }
@@ -100,10 +101,20 @@ function Invoke-OneRepo {
         }
     }
 
+    # run-code-intel.ps1 exit codes (issue #130): 0 = clean, 2 = pipeline completed but
+    # Sentrux's architecture/quality gate reported findings (debt) in the target repo --
+    # that is success-with-findings, not a failure -- 1 = the pipeline genuinely did not
+    # complete. Only 1 (or anything outside {0,1,2}) is a real failure here.
     $code = $LASTEXITCODE
+    $status = switch ($code) {
+        0 { "OK" }
+        2 { "FINDINGS" }
+        default { "FAILED" }
+    }
     return [pscustomobject][ordered]@{
         repo = $label
-        ok = $code -eq 0
+        ok = ($code -eq 0 -or $code -eq 2)
+        status = $status
         stage = "pipeline"
         exitCode = $code
     }
@@ -182,12 +193,20 @@ if (-not $NoIndexUpdate -and (Test-Path -LiteralPath $indexer -PathType Leaf)) {
 
 Write-Host "Code intel invoke: batch summary"
 foreach ($result in $results) {
-    $mark = if ($result.ok) { "OK" } else { "FAILED" }
+    $mark = if ($result.PSObject.Properties["status"]) { [string]$result.status } elseif ($result.ok) { "OK" } else { "FAILED" }
     Write-Host "$mark $($result.repo) stage=$($result.stage) exit=$($result.exitCode)"
 }
 
+# Layered batch exit code, mirroring run-code-intel.ps1's own exit-code semantics
+# (issue #130): 1 if any repo genuinely failed, 2 if none failed but at least one
+# reported gate findings (Sentrux architecture/quality debt -- success, not failure),
+# 0 if every repo is clean.
 $failed = @($results | Where-Object { -not $_.ok })
 if ($failed.Count -gt 0) {
     exit 1
+}
+$findings = @($results | Where-Object { [string]$_.status -eq "FINDINGS" })
+if ($findings.Count -gt 0) {
+    exit 2
 }
 exit 0

--- a/run-code-intel.ps1
+++ b/run-code-intel.ps1
@@ -3239,6 +3239,63 @@ function Get-CodeIntelSentruxDebtSummary {
     }
 }
 
+# Exit-code semantics (issue #130): a "sentrux gate" step that fails with a parseable
+# gate:* record (Complex functions / God files / Cycles / Coupling / Quality before->after)
+# is the architecture/quality gate doing its job -- it found and reported debt in the
+# TARGET repo. That is pipeline OUTPUT, not a pipeline FAILURE, and must not be conflated
+# with a genuine tool crash (sentrux missing, unparseable output, etc.).
+#
+# $Failures.gate (see New-CodeIntelSentruxFailures) is already non-null exactly when a
+# gate:* record was successfully parsed from the "sentrux gate" step's stdout, so it is
+# the authoritative crash-vs-finding discriminator: null means the step failed without
+# producing any recognizable gate output (a real failure), non-null means Sentrux ran to
+# completion and reported a structural metric.
+#
+# NOTE: this exemption intentionally covers only "sentrux gate" (gate:* records). The
+# "sentrux check" step (max_cc, check:* records) keeps its prior blocking-based behavior;
+# broadening the fix to "sentrux check" crashes is a separate, not-yet-scoped concern.
+function Get-CodeIntelSentruxNonGateBlockingCount {
+    param([object]$DebtRegister)
+
+    if ($null -eq $DebtRegister) { return 0 }
+    return @($DebtRegister.entries | Where-Object { [bool]$_.blocking -and [string]$_.source -ne "sentrux gate" }).Count
+}
+
+function Get-CodeIntelSentruxGateFindingsCount {
+    param([object]$DebtRegister)
+
+    if ($null -eq $DebtRegister) { return 0 }
+    return @($DebtRegister.entries | Where-Object { [bool]$_.blocking -and [string]$_.source -eq "sentrux gate" }).Count
+}
+
+function Get-CodeIntelSentruxEffectiveFailedSteps {
+    param(
+        [object[]]$FailedSteps,
+        [object]$Failures,
+        [object]$DebtRegister
+    )
+
+    $nonGateBlocking = Get-CodeIntelSentruxNonGateBlockingCount -DebtRegister $DebtRegister
+    return @($FailedSteps | Where-Object {
+        $category = Get-StepFailureCategory $_
+        if ($null -eq $category) { return $true }
+        # $category is always a plain string (see Get-StepFailureCategory), so compare it
+        # directly. (An earlier version of this check went through
+        # Get-CodeIntelObjectValue $category "category", which always returned $null for a
+        # plain string and made the comparison unconditionally true -- every categorized
+        # failure, not just sentrux_fail, was treated as an effective failure and the
+        # blocking-based branch below never ran. Fixed here so the gate-vs-crash
+        # distinction actually takes effect.)
+        if ([string]$category -ne "sentrux_fail") { return $true }
+        if ([string]$_.name -like "sentrux gate*") {
+            # Only a gate step that produced no parseable gate:* record at all (crash /
+            # unexpected output) still counts as an effective (exit 1) failure.
+            return ($null -eq $Failures.gate)
+        }
+        return ($nonGateBlocking -gt 0)
+    })
+}
+
 $configData = $null
 if ([string]::IsNullOrWhiteSpace($Config)) {
     $Config = Join-Path $PSScriptRoot "pipeline.config.json"
@@ -3798,12 +3855,7 @@ $effectiveFailureCounts = [ordered]@{
     graphMissing = [int]$failureCounts.graphMissing
     sentruxFail = [int]$preliminarySentruxDebtRegister.summary.blocking
 }
-$effectiveFailed = @($failed | Where-Object {
-    $category = Get-StepFailureCategory $_
-    if ($null -eq $category) { return $true }
-    if ([string](Get-CodeIntelObjectValue $category "category") -ne "sentrux_fail") { return $true }
-    return ([int]$preliminarySentruxDebtRegister.summary.blocking -gt 0)
-})
+$effectiveFailed = @(Get-CodeIntelSentruxEffectiveFailedSteps -FailedSteps $failed -Failures $preliminarySentruxFailures -DebtRegister $preliminarySentruxDebtRegister)
 $githubResearch = New-GitHubSolutionResearchNotApplicable
 if ((-not $SkipGitHubResearch) -and (Test-GitHubSolutionResearchRequired $effectiveFailureCounts)) {
     $githubResearchScript = Join-Path $PSScriptRoot "Invoke-GitHubSolutionResearch.ps1"
@@ -4073,12 +4125,8 @@ $sentruxDebtRegister = New-CodeIntelSentruxDebtRegister `
     -RunTimestamp $timestamp `
     -OutputPath $sentruxDebtRegisterPath
 $effectiveFailureCounts["sentruxFail"] = [int]$sentruxDebtRegister.summary.blocking
-$effectiveFailed = @($failed | Where-Object {
-    $category = Get-StepFailureCategory $_
-    if ($null -eq $category) { return $true }
-    if ([string](Get-CodeIntelObjectValue $category "category") -ne "sentrux_fail") { return $true }
-    return ([int]$sentruxDebtRegister.summary.blocking -gt 0)
-})
+$effectiveFailed = @(Get-CodeIntelSentruxEffectiveFailedSteps -FailedSteps $failed -Failures $sentruxFailures -DebtRegister $sentruxDebtRegister)
+$gateFindings = Get-CodeIntelSentruxGateFindingsCount -DebtRegister $sentruxDebtRegister
 $sentruxInsight["failures"] = Get-CodeIntelSentruxFailureSummary -Failures $sentruxFailures -Path $sentruxFailuresPath
 $sentruxInsight["debtRegister"] = Get-CodeIntelSentruxDebtSummary -DebtRegister $sentruxDebtRegister -Path $sentruxDebtRegisterPath
 $sentruxInsight["authoritativePrimaryTarget"] = Get-CodeIntelSentruxPrimaryTargetText -Failures $sentruxFailures
@@ -4227,6 +4275,7 @@ researchRequired = $hospitalReport.triage.research_required
     summary = [ordered]@{
         failed = $failed.Count
         effectiveFailed = $effectiveFailed.Count
+        gateFindings = $gateFindings
         manualRequired = $manual.Count
         passed = @($steps | Where-Object { $_.status -eq "passed" }).Count
         skipped = @($steps | Where-Object { $_.status -eq "skipped" }).Count
@@ -4285,6 +4334,7 @@ $summaryLines = @(
     "- Passed: $(@($steps | Where-Object { $_.status -eq 'passed' }).Count)",
     "- Failed: $($failed.Count)",
     "- Effective failed: $($effectiveFailed.Count)",
+    "- Gate findings: $gateFindings",
     "- Manual required: $($manual.Count)",
     "- Skipped: $(@($steps | Where-Object { $_.status -eq 'skipped' }).Count)",
     "- Provider quota: $($failureCounts.providerQuota)",
@@ -4482,11 +4532,13 @@ $understandingLines = @(
     "- sentrux_fail: $($failureCounts.sentruxFail)",
     "- effective_sentrux_fail: $($effectiveFailureCounts.sentruxFail)",
     "- effective_failed: $($effectiveFailed.Count)",
+    "- gate_findings: $gateFindings",
     "",
     "## Human Inspection Required",
     "- If Repomix status is ``ok``, read ``repomix-output.*`` first for whole-repo orientation; otherwise read ``summary.md`` first.",
     "- If `graph_missing > 0`, run: ``$understandCommand``",
     "- If ``sentrux_fail > 0``, inspect Sentrux output in ``report.json`` before saving a new baseline.",
+    "- If ``gate_findings > 0`` and ``effective_failed`` is 0, the pipeline completed and Sentrux's architecture/quality gate reported debt (see sentrux-debt-register.json); this is expected gate output, not a pipeline failure (exit code 2).",
     "- If ``provider_quota > 0``, treat it as an upstream quota/rate issue, not a local indexing failure.",
     "- If ``local_tool_error > 0``, inspect command output and PATH/tool installation before changing repo code.",
     "",
@@ -4507,9 +4559,38 @@ Write-Host "Hospital: $hospitalMarkdownPath"
 if ($manual.Count -gt 0) {
     Write-Host "Manual step required: $understandCommand"
 }
+
+# Exit-code semantics (issue #130):
+#   0 = clean run, no failures, no gate findings.
+#   1 = pipeline genuinely did not complete (tool crash, missing artifacts, unrecoverable
+#       step) -- $effectiveFailed excludes parseable sentrux gate:* debt reports, so this
+#       is reserved for real breakage.
+#   2 = pipeline completed successfully AND the Sentrux architecture/quality gate reported
+#       findings (debt) in the target repo. That is the gate doing its job, not a failure --
+#       callers should treat this as success-with-findings, not FAILED.
+# On both non-zero paths, artifact paths are restated as the LAST thing printed so a
+# terminal-tail read (or an agent that only reads the last line) sees where the complete
+# artifacts are instead of just the word FAILED.
 if ($effectiveFailed.Count -gt 0) {
     Write-Host "Failed steps: $($failed.Count)"
     Write-Host "Effective failed steps: $($effectiveFailed.Count)"
+    Write-Host "Gate findings (informational, not counted as failures): $gateFindings"
+    Write-Host ""
+    Write-Host "PIPELINE DID NOT COMPLETE (exit 1) -- inspect the failed step(s) above, not just the gate findings. Artifacts produced so far:"
+    Write-Host "Report: $reportPath"
+    Write-Host "Summary: $summaryPath"
+    Write-Host "Understanding: $understandingPath"
+    Write-Host "Hospital: $hospitalMarkdownPath"
     exit 1
+}
+if ($gateFindings -gt 0) {
+    Write-Host "Gate findings: $gateFindings"
+    Write-Host ""
+    Write-Host "PIPELINE COMPLETED WITH GATE FINDINGS (exit 2) -- Sentrux reported architecture/quality debt in sentrux-debt-register.json; this is expected gate output, not a failure. Artifacts:"
+    Write-Host "Report: $reportPath"
+    Write-Host "Summary: $summaryPath"
+    Write-Host "Understanding: $understandingPath"
+    Write-Host "Hospital: $hospitalMarkdownPath"
+    exit 2
 }
 exit 0

--- a/test-code-intel-pipeline.ps1
+++ b/test-code-intel-pipeline.ps1
@@ -19,7 +19,13 @@ param(
     [switch]$AllowGraphMissing,
     [switch]$SkipSentruxCheck,
     [switch]$SkipSentruxGate,
-    [switch]$SkipGitHubResearch
+    [switch]$SkipGitHubResearch,
+
+    # Opt-in: by default, a pipeline exit code of 2 (Sentrux gate reported architecture/
+    # quality findings, pipeline otherwise completed -- see issue #130) is treated as a
+    # passing contract-test run, same as exit 0. Pass this switch for callers that
+    # legitimately need "any gate finding fails the test" behavior.
+    [switch]$RequireCleanGates
 )
 
 Set-StrictMode -Version Latest
@@ -137,7 +143,7 @@ foreach ($key in $requiredCategories) {
 if ($missingCategories.Count -gt 0) {
     throw "Missing failure category counters: $($missingCategories -join ', ')"
 }
-$requiredSummaryFields = @("effectiveFailed", "effectiveFailureCategories", "blockingSentruxDebt", "knownSentruxDebt")
+$requiredSummaryFields = @("effectiveFailed", "effectiveFailureCategories", "blockingSentruxDebt", "knownSentruxDebt", "gateFindings")
 $missingSummaryFields = @()
 foreach ($key in $requiredSummaryFields) {
     if ($null -eq $report.summary.PSObject.Properties[$key]) {
@@ -154,7 +160,18 @@ $graphMissingOnly = (
     [int]$report.summary.effectiveFailureCategories.sentruxFail -eq 0
 )
 $pipelineFailureMessage = ""
-if ($pipelineExitCode -ne 0 -and -not ($AllowGraphMissing -and $graphMissingOnly)) {
+if ($pipelineExitCode -eq 2) {
+    # Issue #130: exit 2 means the pipeline completed and Sentrux's architecture/quality
+    # gate reported findings (debt) in the target repo. That is success-with-findings, not
+    # a contract-test failure -- unless the caller explicitly opted into strict
+    # gate-clean behavior via -RequireCleanGates.
+    Write-Host "Pipeline exit code: 2 (gate findings; pipeline completed)"
+    Write-Host "Gate findings: $($report.summary.gateFindings)"
+    if ($RequireCleanGates) {
+        $pipelineFailureMessage = "Pipeline reported $($report.summary.gateFindings) Sentrux gate finding(s) for repo: $label (-RequireCleanGates set)"
+    }
+}
+elseif ($pipelineExitCode -ne 0 -and -not ($AllowGraphMissing -and $graphMissingOnly)) {
     $failedSteps = @($report.steps | Where-Object { $_.status -eq "failed" } | ForEach-Object {
         [ordered]@{
             name = $_.name
@@ -451,6 +468,7 @@ $result = [ordered]@{
     steps = $report.steps.Count
     failed = $report.summary.failed
     effectiveFailed = $report.summary.effectiveFailed
+    gateFindings = $report.summary.gateFindings
     manualRequired = $report.summary.manualRequired
     failureCategories = $report.summary.failureCategories
     effectiveFailureCategories = $report.summary.effectiveFailureCategories


### PR DESCRIPTION
## Summary

Fixes #130 (see the 2026-08-03 comment on that issue for the full field report). `run-code-intel.ps1` exited `1` whenever a `sentrux gate` step reported an architecture/quality finding (e.g. `god_files 23 -> 25`) in the **target repo** — identical to a genuine tool crash. Real repro: `invoke-code-intel.ps1 -Repo k-atana -Mode normal` -> `Passed 5 / Failed 1 / Skipped 1`, last line `FAILED k-atana stage=pipeline exit=1`, even though every artifact (report.json, summary.md, hospital.md, sentrux-debt-register.json, surgery-plan.md, 62MB repomix pack, ...) was produced intact. An agent that reads the exit code and the last printed line discarded a complete run.

**Root cause (deeper than the issue text describes):** the `$effectiveFailed` category filter did `[string](Get-CodeIntelObjectValue $category "category") -ne "sentrux_fail"`, but `$category` is always a plain string (`Get-StepFailureCategory` returns `"sentrux_fail"`/`"graph_missing"`/etc. or `$null`), never an object with a `.category` property. `Get-CodeIntelObjectValue` on a plain string always returns `$null`, so the comparison was unconditionally `true` and the blocking-based branch below it was **dead code** — every categorized failure, not just sentrux, was unconditionally an "effective failure" regardless of the debt register's `blocking` value. Fixed as part of this change since the new gate-vs-crash distinction depends on that branch actually running.

## Old vs new exit-code table

| Exit | Old meaning | New meaning |
|---|---|---|
| `0` | clean | clean: no failures, no gate findings |
| `1` | any effective failure, **including a sentrux gate finding** | pipeline genuinely did not complete (tool crash, missing artifacts, unrecoverable step, or a `sentrux gate` step that produced no parseable output at all) |
| `2` | *(did not exist)* | pipeline **completed**; Sentrux's architecture/quality gate reported findings (debt) in the target repo — output, not failure |

The gate-vs-crash discriminator is `$sentruxFailures.gate` (already existed, `New-CodeIntelSentruxFailures`): non-null exactly when a `gate:*` record was successfully parsed from `sentrux gate`'s stdout. Non-null -> finding (exit 2 territory, counted via new `gateFindings`, not `effectiveFailed`). Null -> the step failed without producing any recognizable gate output -> real crash -> stays in `effectiveFailed` (exit 1).

Scope: this exemption covers only `sentrux gate` (`gate:*` records). `sentrux check` (`check:*`, max_cc) keeps its prior blocking-based behavior — the same crash-vs-finding polarity issue plausibly exists there too, but the issue and this fix are scoped to `gate:*`; noted as a follow-up, not fixed here.

The Sentrux debt register's own `blocking` field (`new_debt`/`worsened_debt` classification, used for baseline-save guidance) is **unchanged** — `test-sentrux-failure-normalization.ps1` locks in `blocking >= 1` for worsened gate debt, and that's a legitimate, separate concept ("is this new/worsened debt for baseline purposes") from "did the pipeline process complete" (this PR's concern).

A real, non-obvious follow-on effect: fixing the dead-code bug also means `sentrux check`'s own **known/informational** debt (e.g. this repo's own historical `Get-CodeEvidenceSymbols` max_cc case) no longer forces exit 1 by itself — previously it always did (the bug made the distinction moot); now it correctly follows the debt register's own pre-existing "informational does not block" policy. Disclosing this since it's a real behavior change, even though it's just the codebase's own stated policy finally taking effect.

## Every consumer of this exit code, and what changed

- **`invoke-code-intel.ps1`** — `Invoke-OneRepo` now returns `status = "OK"/"FINDINGS"/"FAILED"` alongside `ok` (`ok = ($code -eq 0 -or $code -eq 2)`). Batch summary prints the `status` label instead of a binary OK/FAILED, so exit 2 shows as `FINDINGS`, not `FAILED`. Top-level batch exit code is layered the same way (1 if any repo failed, 2 if any repo has findings-only, 0 otherwise).
- **`test-code-intel-pipeline.ps1`** (contract test) — exit `2` is treated as a passing run by default (prints the gate-findings count instead of throwing). Added **opt-in** `-RequireCleanGates` switch for callers that need the old "any gate finding fails" behavior. Extended `$requiredSummaryFields` with `gateFindings` (added, not renamed/removed — `effectiveFailed`, `effectiveFailureCategories`, `blockingSentruxDebt`, `knownSentruxDebt` all still present per the existing contract test).
- **`.github/workflows/ci.yml` / `release.yml`** — both call `test-code-intel-pipeline.ps1` with `-SkipSentruxGate`, so the gate step never runs and exit 2 can never fire in CI today. No change needed; verified this invocation still passes clean (see Testing).
- **Three benchmark scripts** (`Invoke-CccSliceBenchmark.ps1`, `Invoke-CodeEvidenceABTest.ps1`, `Invoke-NativeRetrievalBenchmark.ps1`) — all call `run-code-intel.ps1` with `-SkipSentrux`, same reasoning, no change needed.
- Grepped the whole repo for `LASTEXITCODE`, `exit 1`, `exit 0`, and `.github/` — no other consumer reads `run-code-intel.ps1`'s or `invoke-code-intel.ps1`'s exit code.

## Other changes

- Both `$effectiveFailed` computations (preliminary and final) now go through one shared helper, `Get-CodeIntelSentruxEffectiveFailedSteps`, so they stay consistent (the task explicitly flagged both sites for inspection).
- Call sites wrap the helper's result in `@(...)`. Without this, PowerShell's function-return semantics unwrap an **empty** array result to `$null` across the function boundary, and every later `.Count` read on `$effectiveFailed` throws `PropertyNotFoundException` under `Set-StrictMode -Version Latest`. Found this by bisecting a real crash that only reproduced with the new call sites wired up — the original inline `@($failed | Where-Object {...})` never had this problem because the `@()` wrap happened at the assignment site itself, not across a function call.
- On both non-zero exit paths, artifact paths (Report/Summary/Understanding/Hospital) are restated as the **last** thing printed, so a terminal-tail read doesn't just see `FAILED`/the word count.
- `docs/artifact-data-contract.md`: new "Exit Code Contract" section + `gateFindings` added to the required routing-fields list.
- `CHANGELOG.md`: `[Unreleased]` entry documenting the breaking change.

## Testing

- `.\test-code-intel-pipeline.ps1 -RepoPath . -SkipRepowise -AllowGraphMissing -SkipSentruxGate -SkipGitHubResearch -Mode normal` (the exact CI `ci.yml` invocation) — **passes clean**: `pipelineExitCode: 0`, `failed: 1` (raw `sentrux check` tool exit), `effectiveFailed: 0`, `gateFindings: 0`, `ok: true`.
- Real end-to-end run: `.\invoke-code-intel.ps1 -Repo k-atana -Mode normal` (read-only against `D:\projects\k-atana`, confirmed unmodified — the only dirty files in that repo predate this run by hours). Result:
  ```
  Gate findings: 1
  PIPELINE COMPLETED WITH GATE FINDINGS (exit 2) -- Sentrux reported architecture/quality debt in sentrux-debt-register.json; this is expected gate output, not a failure. Artifacts:
  Report: ...\report.json
  Summary: ...\summary.md
  Understanding: ...\understanding.md
  Hospital: ...\hospital.md
  ...
  FINDINGS k-atana stage=pipeline exit=2
  ```
  Before this fix, the last line was `FAILED k-atana stage=pipeline exit=1`. Confirmed: exit code `2`, artifact paths are the last thing printed, `invoke-code-intel.ps1`'s batch summary now says `FINDINGS`, not `FAILED`.
- `Set-StrictMode`/parser check on all three touched `.ps1` files: no parse errors.
