### PR TITLE
docs(internalization): OpenSpec 记录核实——MIT + v1.7.0 证据入账 (#156)

### DIFF
--- a/crates/code-intel-cli/tests/internalization_record.rs
+++ b/crates/code-intel-cli/tests/internalization_record.rs
@@ -1755,7 +1755,67 @@ fn ticket_r12_unverified_greenfield_plugin_is_retired_from_production() {
 #[test]
 fn ticket_r13_openspec_record_is_measured_removable_and_fail_closed() {
     let record = advisory_candidate("openspec");
-    assert_research_candidate(&record, "internalization.openspec-record");
+    assert_eq!(record["id"], "internalization.openspec-record");
+    assert_eq!(record["lifecycle"]["status"], "research");
+    assert_eq!(record["adoption"]["rung"], "reimplement");
+    assert_eq!(record["subject"]["license"]["id"], "MIT");
+    assert!(record["subject"]["source"]["revision"]
+        .as_str()
+        .unwrap()
+        .contains("4e16790d90d8f54d4773ad9a5e71a57cd9f1e86b"));
+
+    // Issue #156 admitted license (MIT), release status (v1.7.0, active),
+    // and the pinned upstream commit, so this record can no longer share
+    // `assert_research_candidate`: that helper hard-asserts the
+    // fully-unverified shape (`UNKNOWN-RESEARCH-ONLY`, `unverified-upstream`,
+    // open license/upstream-revision gaps) that the other 12 research
+    // candidates still have and this one no longer does. `gap:openspec:
+    // update-check` and `gap:openspec:security-review` stay open — no
+    // maintenance-attestation or security/supply-chain evidence was
+    // gathered in this pass — so the record still fails closed for
+    // production, same as before.
+    let evidence_ids = known(&record);
+    let gaps = evidence_ids
+        .iter()
+        .filter(|id| id.starts_with("gap:"))
+        .cloned()
+        .collect::<Vec<_>>();
+    let admitted = evidence_ids
+        .into_iter()
+        .filter(|id| !id.starts_with("gap:"))
+        .collect::<Vec<_>>();
+    let evaluated_at = 1_785_801_600u64; // 2026-08-04, matches the refreshed necessityEvidence.checkedAt
+    let evaluation =
+        internalization_record::evaluate_record(&record, evaluated_at, &admitted, &[]).unwrap();
+    assert_eq!(evaluation["researchAllowed"], true);
+    assert_eq!(evaluation["productionEnabled"], false);
+    assert_eq!(evaluation["consumedAuthorityEventId"], Value::Null);
+    let diagnostics = evaluation["diagnostics"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|diagnostic| diagnostic.as_str().unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(diagnostics.contains("unknown evidence"));
+    assert_eq!(gaps.len(), 2, "{gaps:?}");
+
+    let record_text = serde_json::to_string(&record).unwrap();
+    for closed in ["gap:openspec:license", "gap:openspec:upstream-revision"] {
+        assert!(!record_text.contains(closed), "{closed} must be closed");
+    }
+    for open in ["gap:openspec:update-check", "gap:openspec:security-review"] {
+        assert!(record_text.contains(open), "{open} must stay declared");
+    }
+
+    let reuse = internalization_record::project_reuse_record(&record, &evaluation).unwrap();
+    let notice = internalization_record::project_notice_provenance(&record, &evaluation).unwrap();
+    assert_eq!(reuse["productionEnabled"], false);
+    assert!(notice["noticeText"].as_str().unwrap().contains("MIT"));
+    assert_checked_schema(&record, "code-intel-internalization-record.v1.schema.json");
+    assert_checked_schema(&reuse, "code-intel-reuse-record.v1.schema.json");
+    assert_checked_schema(&notice, "code-intel-notice-provenance.v1.schema.json");
+
     let atom = fs::read_to_string(root().join("legacy/OpenSpec-Detector.ps1")).unwrap();
     assert_eq!(atom.matches("openspec-opsx").count(), 5);
     assert_eq!(record["economics"]["benefit"]["value"], 5);

--- a/docs/internalization-advisory-candidates.md
+++ b/docs/internalization-advisory-candidates.md
@@ -17,7 +17,7 @@ evidence, so the engine emits diagnostics and keeps `productionEnabled=false`.
 | `internalization.graph-record` | B02 adapter and conformance SHA-256 plus separately traced internal and external implementations | external revision/license/runtime/conformance, maintenance/security, representative utility/cost, exit and retirement proof |
 | `internalization.sentrux-record` | B03 adapter and conformance SHA-256 plus registered adapter/runtime operations | upstream revision/license, Windows/plugin conformance, maintenance/security, representative value/cost, shim retirement proof |
 | `internalization.codenexus-record` | B04 adapter and conformance SHA-256 plus full/lite swap and registered production operations | full-provider revision/license/runtime/security/maintenance, measured localization value/cost, exit and lite retirement proof |
-| `internalization.openspec-record` | 5 `openspec-opsx` occurrences in the current advisory atom | upstream revision, license, update, security |
+| `internalization.openspec-record` | 5 `openspec-opsx` occurrences in the current advisory atom | update, security (upstream revision and license admitted 2026-08-04, issue #156) |
 | `internalization.spec-kit-record` | 8 `spec-kit` occurrences in the current advisory atom | upstream revision, license, update, security |
 | `internalization.matt-flow-record` | 1 matt-flow candidate branch | upstream revision, license, update, security |
 | `internalization.gstack-record` | 1 gstack candidate branch | canonical source, upstream revision, license, update, security |

--- a/docs/openspec-detector.md
+++ b/docs/openspec-detector.md
@@ -32,7 +32,7 @@
 
 | 工具 | 来源 | 特点 | 适合场景 |
 |------|------|------|----------|
-| **OpenSpec OPSX** | Fission-AI/OpenSpec | 流动迭代式 spec 工作流，actions 非 phases（propose/explore/apply/sync/archive），artifact 链 proposal→specs→design→tasks→implement，`openspec init` 生成 `.claude/skills` | 存量 (brownfield) 项目做持续变更管理 |
+| **OpenSpec OPSX** | Fission-AI/OpenSpec | 流动迭代式 spec 工作流，artifact 链 proposal→specs→design→tasks→implement；入口是 `/opsx:propose "your idea"` slash command，需 `openspec init --tools <list>`（约 30 种可选值，如 claude/codex/cursor，或 `all`）显式安装才落地工具文件，`--tools none` 实测（v1.7.0）不生成任何工具文件；`propose/explore/apply/sync` 是 OPSX 叠加在 1.7.0 CLI 命令面（`change/archive/spec/validate/status/instructions` 等）之上的 slash-command 命名而非独立子命令，其中只有 `archive` 同时也是 CLI 子命令 | 存量 (brownfield) 项目做持续变更管理 |
 | **spec-kit** | github/spec-kit | `.specify/` 结构 + `/specify /plan /tasks` + `constitution.md`，Spec-Driven Development 起步套件 | 从零起步 (greenfield) 的 0→1 构建 |
 
 **选型规则**：

--- a/orchestration/internalization/openspec.json
+++ b/orchestration/internalization/openspec.json
@@ -2,11 +2,11 @@
   "schema": "code-intel-internalization-record.v1",
   "id": "internalization.openspec-record",
   "projectId": "code-intel-pipeline",
-  "subject": { "name": "OpenSpec OPSX advisory candidate", "kind": "design_reference", "source": { "uri": "https://github.com/Fission-AI/OpenSpec", "revision": "unverified-upstream; local-atom-sha256:03d9cbed70d83c59f7d9540fccc606ce0b2723135efd2c5e32943d367008a199" }, "license": { "id": "UNKNOWN-RESEARCH-ONLY", "obligations": ["do not distribute, vendor, invoke, or production-enable until the exact upstream revision and license text are verified", "retain this provenance and gap notice while the candidate remains in research"] } },
+  "subject": { "name": "OpenSpec OPSX advisory candidate", "kind": "design_reference", "source": { "uri": "https://github.com/Fission-AI/OpenSpec", "revision": "upstream-commit:4e16790d90d8f54d4773ad9a5e71a57cd9f1e86b (tag v1.7.0, tag-object:bb2f3e5287872d7cae7074964fc2f39cde0d5022, committed 2026-07-29T01:25:23Z); local-atom-sha256:03d9cbed70d83c59f7d9540fccc606ce0b2723135efd2c5e32943d367008a199" }, "license": { "id": "MIT", "obligations": ["MIT confirmed 2026-08-04 via gh api repos/Fission-AI/OpenSpec (spdx_id: MIT); this closes the license compliance blocker only and is not an adoption decision — it does not grant dependency, vendoring, invocation, or production-enable authority under the reimplement rung and owned boundary", "retain this provenance and gap notice while the candidate remains in research"] } },
   "adoption": {
     "rung": "reimplement",
     "ownedBoundary": ["pipeline-owned advisory candidate data and recommendation rules only", "no OpenSpec runtime dependency", "no openspec init, filesystem initialization, commitment, or adoption authority"],
-    "necessityEvidence": { "evidenceIds": ["local:reference-capability-map:openspec-row", "gap:openspec:upstream-revision", "gap:openspec:license"], "checkedAt": 1783900800, "expiresAt": 1791676800 },
+    "necessityEvidence": { "evidenceIds": ["local:reference-capability-map:openspec-row", "local:i156:openspec-upstream-commit-v1.7.0", "local:i156:openspec-license-mit", "local:i156:openspec-release-active"], "checkedAt": 1785801600, "expiresAt": 1791676800 },
     "compatibilityEvidence": { "evidenceIds": ["local:b06:proposal-effects-empty", "local:b06:no-auto-init-boundary"], "checkedAt": 1783900800, "expiresAt": 1791676800 },
     "conformanceEvidence": { "evidenceIds": ["local:atom:openspec-opsx-five-occurrences", "local:b06:a01-envelope-parity"], "checkedAt": 1783900800, "expiresAt": 1791676800 }
   },
@@ -20,13 +20,13 @@
     "maintenanceEvidence": { "evidenceIds": ["gap:openspec:update-check"], "checkedAt": 1783900800, "expiresAt": 1791676800 },
     "securityEvidence": { "evidenceIds": ["gap:openspec:security-review"], "checkedAt": 1783900800, "expiresAt": 1791676800 }
   },
-  "update": { "policy": "Before 2026-10-11, verify the upstream commit, LICENSE, release status, and candidate semantics; keep research-only until all checks are admitted", "nextCheckAt": 1791676800, "evidence": { "evidenceIds": ["gap:openspec:update-check"], "checkedAt": 1783900800, "expiresAt": 1791676800 } },
+  "update": { "policy": "Upstream commit, LICENSE, and release status were verified 2026-08-04 ahead of the 2026-10-11 deadline (see adoption.necessityEvidence); MIT clarity resolves the license compliance blocker only and is not by itself an adoption reason under the reimplement rung. Before 2026-10-11, still complete the security/supply-chain review and the maintenance update-check attestation; keep research-only until those are admitted", "nextCheckAt": 1791676800, "evidence": { "evidenceIds": ["gap:openspec:update-check"], "checkedAt": 1783900800, "expiresAt": 1791676800 } },
   "ownedModifications": [
     { "path": "legacy/OpenSpec-Detector.ps1", "description": "Pipeline-owned OpenSpec candidate detection and advisory rendering; does not contain or invoke the upstream runtime", "evidenceIds": ["local:atom:openspec-opsx-five-occurrences", "local:b06:no-auto-init-boundary"] }
   ],
   "rollback": { "strategy": "delete this candidate record and remove the OpenSpec alternative from candidate data without changing the advisory schema or authority boundary", "evidence": { "evidenceIds": ["local:b06:candidate-removal-boundary"], "checkedAt": 1783900800, "expiresAt": 1791676800 } },
   "exit": { "strategy": "replace the reference with a pinned, licensed candidate record or retire it while retaining audit provenance", "replacementCriteria": ["replacement has exact upstream revision and verified license obligations", "replacement passes proposal conformance and no-auto-init tests"], "evidence": { "evidenceIds": ["local:b06:candidate-removal-boundary"], "checkedAt": 1783900800, "expiresAt": 1791676800 } },
   "retirement": { "status": "candidate", "triggers": ["upstream provenance or license remains unverifiable at next check", "candidate no longer contributes unique measured advisory value", "security or maintenance evidence cannot be admitted"], "evidence": { "evidenceIds": ["local:record:openspec"], "checkedAt": 1783900800, "expiresAt": 1791676800 } },
-  "lifecycle": { "previousStatus": null, "status": "research", "effectiveAt": 1783900800, "replacementRecordId": null, "evidenceIds": ["local:record:openspec", "gap:openspec:upstream-revision", "gap:openspec:license"], "authorityEvent": null },
+  "lifecycle": { "previousStatus": null, "status": "research", "effectiveAt": 1783900800, "replacementRecordId": null, "evidenceIds": ["local:record:openspec", "local:i156:openspec-upstream-commit-v1.7.0", "local:i156:openspec-license-mit", "local:i156:openspec-release-active"], "authorityEvent": null },
   "provenance": { "recordedAt": 1783900800, "recordedBy": "dependency-expert" }
 }


### PR DESCRIPTION
把 OpenSpec 内化记录里堵着的两项证据提前采到并入账。`nextCheckAt` 是 2026-10-11，本次**不是补票**，是核实成本已经降到接近零。

## 采到的外部证据（2026-08-04，`gh api repos/Fission-AI/OpenSpec`）

| 项 | 值 |
| --- | --- |
| license | **MIT**（`spdx_id: MIT`） |
| archived | `false` |
| latest release | **v1.7.0**，2026-07-29 |
| pushed_at | 2026-08-03 |
| upstream commit | `4e16790d90d8f54d4773ad9a5e71a57cd9f1e86b`（tag-object `bb2f3e5287872d7cae7074964fc2f39cde0d5022`） |

## 关了什么，留了什么

| gap | 处理 |
| --- | --- |
| `gap:openspec:license` | **关**，MIT 已证实 |
| `gap:openspec:upstream-revision` | **关**，commit sha 已 pin |
| `gap:openspec:update-check` | **留**，维护性 attestation 本轮未独立取证 |
| `gap:openspec:security-review` | **留**，未做安全/供应链审查 |

没有清空 gap 数组。`update.policy` 改写成明说还欠这两项。

## 关键判断：许可清楚 ≠ 可以依赖

`adoption.rung: reimplement` 与 `ownedBoundary` 的三句——

```
"pipeline-owned advisory candidate data and recommendation rules only",
"no OpenSpec runtime dependency",
"no openspec init, filesystem initialization, commitment, or adoption authority"
```

——**零改动**，`lifecycle.status` 仍为 `research`。license 义务条款里显式写死了这条，防止后来人把两件事混成一件：

> MIT confirmed 2026-08-04 …; this closes the license compliance blocker only and is not an adoption decision — it does not grant dependency, vendoring, invocation, or production-enable authority under the reimplement rung and owned boundary

本 PR 全程未在本仓执行 `openspec init`——记录自己的边界禁止。

## 测试：不削弱共享 helper

共享 helper `assert_research_candidate` 硬断言完全未核实的形状（`UNKNOWN-RESEARCH-ONLY` + `unverified-upstream` + 开着的 license/upstream-revision gap），与本次改动天然冲突。

**没有改那个 helper**——另外 12 条仍完全未核实的记录保持满强度保护。只把 openspec 那一个 ticket 测试改写成直接断言新状态，而且断言更严：

- `productionEnabled == false`（fail-closed 性质原样保留）
- 恰好剩 2 个 gap
- 按名字断言哪两个必须消失、哪两个必须还在
- 三个 `assert_checked_schema` 全部保留

先例：`tests/ast_grep_internalization.rs` 里同样越过「完全未核实」但仍留在 `research` 的记录。

## 文档漂移（实测修正）

`docs/openspec-detector.md` 原文写「`openspec init` 生成 `.claude/skills`」。1.7.0 实测：

- `--tools none` **不生成任何工具文件**；工具文件需显式 `--tools <list>`（约 30 种可选值，或 `all`）
- 入口是 `/opsx:propose "your idea"` slash command
- `propose/explore/apply/sync` 是 OPSX 叠在 1.7.0 CLI 命令面之上的 slash-command 命名，**不是独立子命令**；其中只有 `archive` 两边都存在

**选型规则没动**——在临时干净仓跑 1.7.0 的 `openspec init --tools none` 产出仍是 `openspec/{changes/,changes/archive/,config.yaml,specs/}`，所以「有 `openspec/` 目录 → `already_adopted`」依然成立。

顺手更新 `docs/internalization-advisory-candidates.md` 表里已过期的那一行。

## 门禁

| 项 | 结果 |
| --- | --- |
| `cargo fmt --check` | clean |
| `cargo test -p code-intel` | 2979 passed / 52 suites |
| `repin --write --json` | `filesChanged: 0`（两个新 hex 都是 40 位，避开 64-hex pin 规则） |
| `repin --json` 复跑 | `clean: true`、`stalePins: []`、`scanCoverage.status: "complete"` |

Refs #156 #103 #55
