### PR TITLE
feat(honesty): 扫描面具名排除闸门——覆盖率从体感变计算，38 个失踪文件归位 (#152)

### DIFF
--- a/crates/code-intel-cli/src/file_gate/mod.rs
+++ b/crates/code-intel-cli/src/file_gate/mod.rs
@@ -1,0 +1,234 @@
+//! Shared candidate-file gate engine for `sentrux scan` and `sentrux dsm`
+//! (issue #152).
+//!
+//! Issue #148 C2 measured a real self-scan where `sentrux scan` reported
+//! `"files": 277` and `sentrux dsm` reported `"included_files": 315` on the
+//! *same tree*, with only 2 exclusions ever named. 38 files vanished with no
+//! attribution, because each command grew its own file-collection walk with
+//! its own exclusion rules, and the two quietly drifted:
+//!
+//!   - `sentrux dsm`'s old `excluded_reason` matched `tools` / `vendor` /
+//!     `third_party` / `external` only against the *first* path segment
+//!     (`parts.first()`), so `legacy/tools/*.ps1` was invisible to that
+//!     check and silently counted as included. `sentrux scan`'s
+//!     `SKIP_DIRECTORIES` had always matched at any depth. On this
+//!     repository's own tree that one gap alone accounted for 39 files
+//!     (measured empirically while implementing this fix).
+//!   - `sentrux dsm`'s `SOURCE_EXTENSIONS` (14 extensions) was missing
+//!     `cpp` / `c` / `h` / `hpp`, which `sentrux scan`'s `CODE_EXTENSIONS`
+//!     (18 extensions) already recognised, so a matching file was dropped
+//!     with no count anywhere -- not included, not excluded, just absent.
+//!
+//! Both gaps are silent-drop bugs: a file that should have been walked
+//! simply never became a decision at all in one of the two commands. The
+//! fix in this module is not "reconcile the two numbers" but "make the two
+//! commands call the same function": `sentrux_gate::measure_project` and
+//! `sentrux_analysis::source_inventory` both call [`evaluate`] on the same
+//! tree with the same [`GateConfig`], so their file counts are one
+//! computation, not two separately maintained ones that happen to agree
+//! today. A future edit to the exclusion rules only has one place to make
+//! it, so the 277/315 split is now structurally impossible, not merely
+//! fixed once.
+//!
+//! # The gate chain
+//!
+//! Every candidate file gets exactly one [`GateDecision`]: `{path, decision,
+//! gate, source}`. Gate names are part of the JSON contract
+//! ([`GateReport::to_json`]), not a log string. [`GATE_ORDER`] is the
+//! declared precedence -- first match wins:
+//!
+//! 1. `unsupported_ext` -- extension not in [`CODE_EXTENSIONS`]. Checked
+//!    first because it is a free, in-memory string comparison: there is no
+//!    reason to pay for path-matching or file I/O on a file that is
+//!    excluded regardless of anything else.
+//! 2. `user_include` -- explicit user override. If the path matches a
+//!    configured include pattern, the file is *tentatively* included,
+//!    which grants immunity from the two path-based exclude gates below
+//!    (`user_exclude`, `default_path`) and from `repository_ignored` --
+//!    that is what "explicit include un-excludes" means. It does **not**
+//!    grant immunity from `binary` (see below): forcing a genuinely binary
+//!    file to "included" would make downstream content reads
+//!    (`fs::read_to_string` in `sentrux_analysis`) fail the whole run, and
+//!    no reasonable include pattern is meant to promise "treat this
+//!    binary blob as source text".
+//! 3. `user_exclude` -- explicit deny pattern (skipped if step 2 already
+//!    granted tentative inclusion).
+//! 4. `default_path` -- built-in default directory/path exclusions (skipped
+//!    if step 2 already granted tentative inclusion): [`DEFAULT_EXCLUDE_DIRS`]
+//!    matched at *any* path depth (the depth-scoping bug fix above), plus
+//!    the generic "any hidden directory" rule and the bundled/static-asset
+//!    leaf-name rule `sentrux scan` already had.
+//! 5. `oversized` -- file bigger than [`MAX_FILE_BYTES`] (skipped if step 2
+//!    already granted tentative inclusion). Named separately from
+//!    `default_path` because the reason a huge file is excluded is its
+//!    size, not its location; folding it into `default_path` would make a
+//!    decision record lie about why a specific file was dropped.
+//! 6. `repository_ignored` -- gitignored, or untracked and not visible to
+//!    ripgrep (skipped if step 2 already granted tentative inclusion).
+//!    Sourced from the project's own checked-in `.gitignore`, so its
+//!    `source` is `"project"`, not `"built_in"` -- see [`SOURCE_PROJECT`].
+//! 7. `binary` -- the file's content looks binary (a NUL byte in the first
+//!    `BINARY_SNIFF_BYTES` bytes). Checked *last*, deliberately: every
+//!    gate above it is a cheap in-memory or path check that can rule a
+//!    candidate out for free, so content is read only for files that would
+//!    otherwise be included -- and this is the one gate `user_include`
+//!    cannot override, protecting the UTF-8 content reads downstream.
+//! 8. `default_include` -- nothing above matched; an ordinary recognised
+//!    source file.
+//!
+//! # The identity
+//!
+//! `candidates == included + sum(excluded by gate)` by construction: every
+//! candidate produces exactly one [`GateDecision`], partitioned into
+//! exactly the two buckets. [`GateReport::verify_identity`] checks this
+//! structurally rather than trusting the arithmetic, so an actual coding
+//! defect (a candidate silently skipped, one double-recorded) fails the
+//! command outright -- fail-closed, not a warning execution continues past
+//! (issue #152 requirement 3). [`evaluate`] calls it before returning, so
+//! no caller can forget to check.
+//!
+//! # Where each gate's rule comes from
+//!
+//! [`SOURCE_BUILT_IN`] / [`SOURCE_PROJECT`] declare which layer supplied the
+//! rule that decided a candidate (issue #152 requirement 5). Today there are
+//! two live layers: the hardcoded defaults in [`rules`] (`built_in`), and
+//! the repository's own `.gitignore` (`project`, via `repository_ignored`).
+//! [`GateConfig::user_exclude`] / [`GateConfig::user_include`] are real,
+//! ordered, tested gates -- see `tests` -- but no project config file or CLI
+//! flag reads into them yet, so [`GateConfig::built_in`] always constructs
+//! them empty. Every real run's `user_exclude` / `user_include` gate count
+//! is honestly 0 until a config surface is wired; the gate chain and JSON
+//! contract already have the slot reserved rather than needing another
+//! contract change when one lands. There is deliberately no `invocation`
+//! source constant yet: no CLI flag exists to populate one (see the
+//! code-intel-pipeline#152 implementation report).
+//!
+//! ## Layout
+//!
+//! Originally one file; split (still issue #152, before landing) once it
+//! crossed this repository's own `loc > 800` monolith rule -- the honesty
+//! fix cannot itself ship as the thing it polices. [`rules`] holds the gate
+//! names, shared extension/directory data, and the pure per-candidate
+//! predicates; [`walk`] holds the filesystem traversal and the `rg`/`git`
+//! integration behind `repository_ignored`; [`report`] holds [`GateReport`],
+//! the identity check, and the JSON projection. This file keeps the gate
+//! order rationale above and the single [`evaluate`] entry point that ties
+//! the three together -- the same split shape `change_risk` and
+//! `change_agenda` already use (`git`/`signals`/`scoring`/`render`,
+//! `cochange`/`cluster`/`render`).
+
+use std::path::Path;
+
+mod report;
+mod rules;
+#[cfg(test)]
+mod tests;
+mod walk;
+
+pub(crate) use report::GateReport;
+use rules::{default_path_match, extension_of, is_oversized, looks_binary, matches_pattern};
+pub(crate) use rules::{
+    Decision, GateConfig, GateDecision, CODE_EXTENSIONS, GATE_BINARY, GATE_DEFAULT_INCLUDE,
+    GATE_DEFAULT_PATH, GATE_OVERSIZED, GATE_REPOSITORY_IGNORED, GATE_UNSUPPORTED_EXT,
+    GATE_USER_EXCLUDE, GATE_USER_INCLUDE, SOURCE_BUILT_IN, SOURCE_PROJECT,
+};
+use walk::{governed_visible_files, walk_candidates};
+
+/// Evaluate every candidate file under `repo` against the shared gate chain
+/// and return the full per-candidate decision record. Both `sentrux scan`
+/// (`sentrux_gate::measure_project`) and `sentrux dsm`
+/// (`sentrux_analysis::source_inventory`) call this same function on the
+/// same tree with the same config, so their file counts are the same
+/// computation, not two separately maintained ones that happen to agree
+/// today (issue #148 C2).
+pub(crate) fn evaluate(repo: &Path, config: &GateConfig) -> Result<GateReport, String> {
+    let mut candidates = Vec::new();
+    walk_candidates(repo, repo, &mut candidates)?;
+    candidates.sort();
+    candidates.dedup();
+
+    let governed_visible = governed_visible_files(repo);
+
+    let mut decisions = Vec::with_capacity(candidates.len());
+    let mut included = Vec::new();
+    for relative in &candidates {
+        let extension = extension_of(relative);
+        let decision = if !CODE_EXTENSIONS.contains(&extension.as_str()) {
+            GateDecision {
+                path: relative.clone(),
+                decision: Decision::Excluded,
+                gate: GATE_UNSUPPORTED_EXT,
+                source: SOURCE_BUILT_IN,
+            }
+        } else {
+            let user_included = matches_pattern(relative, &config.user_include);
+            if !user_included && matches_pattern(relative, &config.user_exclude) {
+                GateDecision {
+                    path: relative.clone(),
+                    decision: Decision::Excluded,
+                    gate: GATE_USER_EXCLUDE,
+                    source: SOURCE_BUILT_IN,
+                }
+            } else if !user_included && default_path_match(relative) {
+                GateDecision {
+                    path: relative.clone(),
+                    decision: Decision::Excluded,
+                    gate: GATE_DEFAULT_PATH,
+                    source: SOURCE_BUILT_IN,
+                }
+            } else if !user_included && is_oversized(repo, relative) {
+                GateDecision {
+                    path: relative.clone(),
+                    decision: Decision::Excluded,
+                    gate: GATE_OVERSIZED,
+                    source: SOURCE_BUILT_IN,
+                }
+            } else if !user_included
+                && governed_visible
+                    .as_ref()
+                    .is_some_and(|visible| !visible.contains(relative))
+            {
+                GateDecision {
+                    path: relative.clone(),
+                    decision: Decision::Excluded,
+                    gate: GATE_REPOSITORY_IGNORED,
+                    source: SOURCE_PROJECT,
+                }
+            } else if looks_binary(&repo.join(relative)) {
+                GateDecision {
+                    path: relative.clone(),
+                    decision: Decision::Excluded,
+                    gate: GATE_BINARY,
+                    source: SOURCE_BUILT_IN,
+                }
+            } else if user_included {
+                GateDecision {
+                    path: relative.clone(),
+                    decision: Decision::Included,
+                    gate: GATE_USER_INCLUDE,
+                    source: SOURCE_BUILT_IN,
+                }
+            } else {
+                GateDecision {
+                    path: relative.clone(),
+                    decision: Decision::Included,
+                    gate: GATE_DEFAULT_INCLUDE,
+                    source: SOURCE_BUILT_IN,
+                }
+            }
+        };
+        if decision.decision == Decision::Included {
+            included.push(relative.clone());
+        }
+        decisions.push(decision);
+    }
+    included.sort();
+
+    let report = GateReport {
+        candidates: candidates.len() as i64,
+        included,
+        decisions,
+    };
+    report.verify_identity()?;
+    Ok(report)
+}

--- a/crates/code-intel-cli/src/file_gate/report.rs
+++ b/crates/code-intel-cli/src/file_gate/report.rs
@@ -1,0 +1,107 @@
+//! The per-run decision record: [`GateReport`], the fail-closed identity
+//! check (issue #152 requirement 3), and the JSON contract both `sentrux
+//! scan` and `sentrux dsm` embed verbatim (requirement 1, requirement 4).
+
+use std::collections::BTreeMap;
+
+use serde_json::{json, Value};
+
+use super::rules::{Decision, GateDecision, GATE_ORDER};
+
+impl GateDecision {
+    fn to_json(&self) -> Value {
+        json!({
+            "path": self.path,
+            "decision": self.decision.as_str(),
+            "gate": self.gate,
+            "source": self.source,
+        })
+    }
+}
+
+/// The full per-candidate decision record for one [`super::evaluate`] run.
+pub(crate) struct GateReport {
+    pub(crate) candidates: i64,
+    /// Sorted relative paths with `decision == Included`.
+    pub(crate) included: Vec<String>,
+    /// One entry per candidate, in candidate-sorted order.
+    pub(crate) decisions: Vec<GateDecision>,
+}
+
+impl GateReport {
+    /// `candidates == included + sum(excluded by gate)` (issue #152
+    /// requirement 3), checked structurally: every candidate must have
+    /// produced exactly one decision, and the decisions must partition
+    /// exactly into the `included` list and the excluded remainder. A
+    /// mismatch is a coding defect in this module (a candidate silently
+    /// skipped, one double-recorded), and it fails the caller's command
+    /// outright rather than emitting a quietly wrong count.
+    pub(crate) fn verify_identity(&self) -> Result<(), String> {
+        if self.decisions.len() as i64 != self.candidates {
+            return Err(format!(
+                "sentrux file-gate identity violated: {} candidates walked but {} decisions recorded",
+                self.candidates,
+                self.decisions.len()
+            ));
+        }
+        let included_count = self
+            .decisions
+            .iter()
+            .filter(|decision| decision.decision == Decision::Included)
+            .count() as i64;
+        let excluded_count = self.decisions.len() as i64 - included_count;
+        if included_count != self.included.len() as i64 {
+            return Err(format!(
+                "sentrux file-gate identity violated: {included_count} decisions marked included but {} paths in the included set",
+                self.included.len()
+            ));
+        }
+        if self.candidates != included_count + excluded_count {
+            return Err(format!(
+                "sentrux file-gate identity violated: candidates {} != included {included_count} + excluded {excluded_count}",
+                self.candidates
+            ));
+        }
+        Ok(())
+    }
+
+    /// Per-gate rollup in [`GATE_ORDER`], each carrying the `source` layer
+    /// that produced it (issue #152 requirement 5). Gates with zero matches
+    /// this run are omitted rather than printed as a hollow `0`.
+    pub(crate) fn by_gate(&self) -> Vec<Value> {
+        let mut counts: BTreeMap<&'static str, (i64, &'static str, &'static str)> = BTreeMap::new();
+        for decision in &self.decisions {
+            let entry = counts.entry(decision.gate).or_insert((
+                0,
+                decision.source,
+                decision.decision.as_str(),
+            ));
+            entry.0 += 1;
+        }
+        GATE_ORDER
+            .iter()
+            .filter_map(|gate| {
+                counts.get(gate).map(|(files, source, decision)| {
+                    json!({
+                        "gate": gate,
+                        "source": source,
+                        "decision": decision,
+                        "files": files,
+                    })
+                })
+            })
+            .collect()
+    }
+
+    pub(crate) fn to_json(&self) -> Value {
+        json!({
+            "schema": "code-intel-file-gate.v1",
+            "gate_order": GATE_ORDER,
+            "candidates": self.candidates,
+            "included": self.included.len() as i64,
+            "excluded": self.candidates - self.included.len() as i64,
+            "by_gate": self.by_gate(),
+            "decisions": self.decisions.iter().map(GateDecision::to_json).collect::<Vec<_>>(),
+        })
+    }
+}

--- a/crates/code-intel-cli/src/file_gate/rules.rs
+++ b/crates/code-intel-cli/src/file_gate/rules.rs
@@ -1,0 +1,204 @@
+//! Gate names, the shared extension/directory rule data, the per-candidate
+//! types, and the pure (no filesystem walking) predicate logic that decides
+//! whether one candidate path or file matches one gate. `mod.rs::evaluate`
+//! is the only caller of the non-`pub(crate)` items here; see that file for
+//! the declared evaluation order.
+
+use std::fs;
+use std::io::Read;
+use std::path::Path;
+
+pub(crate) const GATE_UNSUPPORTED_EXT: &str = "unsupported_ext";
+pub(crate) const GATE_USER_INCLUDE: &str = "user_include";
+pub(crate) const GATE_USER_EXCLUDE: &str = "user_exclude";
+pub(crate) const GATE_DEFAULT_PATH: &str = "default_path";
+pub(crate) const GATE_OVERSIZED: &str = "oversized";
+pub(crate) const GATE_REPOSITORY_IGNORED: &str = "repository_ignored";
+pub(crate) const GATE_BINARY: &str = "binary";
+pub(crate) const GATE_DEFAULT_INCLUDE: &str = "default_include";
+
+/// Declared precedence, first match wins. See the module doc on
+/// `file_gate::mod` for the full rationale behind this exact order.
+pub(crate) const GATE_ORDER: [&str; 8] = [
+    GATE_UNSUPPORTED_EXT,
+    GATE_USER_INCLUDE,
+    GATE_USER_EXCLUDE,
+    GATE_DEFAULT_PATH,
+    GATE_OVERSIZED,
+    GATE_REPOSITORY_IGNORED,
+    GATE_BINARY,
+    GATE_DEFAULT_INCLUDE,
+];
+
+pub(crate) const SOURCE_BUILT_IN: &str = "built_in";
+pub(crate) const SOURCE_PROJECT: &str = "project";
+
+/// The canonical, shared set of source-code extensions (no leading dot,
+/// lowercase). Union of what `sentrux scan` and `sentrux dsm` each
+/// recognised separately before #152: `sentrux dsm`'s list was missing
+/// `cpp`/`c`/`h`/`hpp`, silently dropping such files with no accounting at
+/// all. `every_extension_is_only_classified_once` guards against silent
+/// duplication.
+pub(crate) const CODE_EXTENSIONS: &[&str] = &[
+    "ps1", "psm1", "py", "rs", "go", "ts", "tsx", "js", "jsx", "mjs", "cjs", "java", "cs", "cpp",
+    "c", "h", "hpp", "v",
+];
+
+/// Directory names default-excluded at *any* depth, not just the repository
+/// root. Before #152, `sentrux dsm` checked `tools`/`vendor`/`third_party`/
+/// `external` only against the first path segment, so `legacy/tools/*` was
+/// invisible to that check -- the majority contributor to issue #148 C2's
+/// 277/315 split on this repository's own self-scan. `sentrux scan`'s
+/// `SKIP_DIRECTORIES` already matched at any depth; this list ports that
+/// (superset, including the `vendors` / `third-party` spelling variants)
+/// so both commands share one rule.
+pub(crate) const DEFAULT_EXCLUDE_DIRS: &[&str] = &[
+    ".git",
+    ".repowise",
+    ".understand-anything",
+    ".sentrux",
+    "tools",
+    "vendor",
+    "vendors",
+    "third_party",
+    "third-party",
+    "external",
+    "node_modules",
+    ".pnpm",
+    ".yarn",
+    "target",
+    "dist",
+    "build",
+    "out",
+    "coverage",
+    ".venv",
+    "venv",
+    "env",
+    ".tox",
+    "__pycache__",
+    ".next",
+    ".nuxt",
+    ".turbo",
+    ".cache",
+];
+
+pub(crate) const MAX_FILE_BYTES: u64 = 2 * 1024 * 1024;
+
+/// Bytes read from the front of a candidate file to decide `binary`: enough
+/// to catch a NUL byte in any realistic non-text blob without paying for a
+/// full read of a large file. A text file never legitimately contains a NUL
+/// in its first few KB; this is the same family of heuristic git itself
+/// uses to decide whether to treat a blob as text.
+const BINARY_SNIFF_BYTES: usize = 8000;
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum Decision {
+    Included,
+    Excluded,
+}
+
+impl Decision {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Decision::Included => "included",
+            Decision::Excluded => "excluded",
+        }
+    }
+}
+
+/// One candidate file's judgment: `{path, decision, gate, source}`
+/// (issue #152 requirement 1). `gate` and `source` are always one of the
+/// `GATE_*` / `SOURCE_*` constants above -- never a free-form log string.
+#[derive(Clone, Debug)]
+pub(crate) struct GateDecision {
+    pub(crate) path: String,
+    pub(crate) decision: Decision,
+    pub(crate) gate: &'static str,
+    pub(crate) source: &'static str,
+}
+
+/// Configuration for the gate chain. See the module doc's "Where each
+/// gate's rule comes from" section for why `user_exclude`/`user_include`
+/// are always empty from [`GateConfig::built_in`].
+#[derive(Default, Clone)]
+pub(crate) struct GateConfig {
+    pub(crate) user_exclude: Vec<String>,
+    pub(crate) user_include: Vec<String>,
+}
+
+impl GateConfig {
+    pub(crate) fn built_in() -> Self {
+        Self::default()
+    }
+}
+
+pub(crate) fn matches_pattern(relative: &str, patterns: &[String]) -> bool {
+    patterns.iter().any(|raw| {
+        let pattern = raw.trim().trim_matches('/');
+        !pattern.is_empty() && (relative == pattern || relative.starts_with(&format!("{pattern}/")))
+    })
+}
+
+pub(crate) fn extension_of(relative: &str) -> String {
+    relative
+        .rsplit('/')
+        .next()
+        .and_then(|leaf| leaf.rsplit_once('.'))
+        .map(|(_, extension)| extension.to_ascii_lowercase())
+        .unwrap_or_default()
+}
+
+/// The built-in default path exclusion: any directory component matching
+/// [`DEFAULT_EXCLUDE_DIRS`] at any depth, any hidden directory (`.foo`), a
+/// `.venv-*`/`venv-*`/`env-*` prefixed directory (all ported from
+/// `sentrux scan`'s pre-#152 traversal-time skip), or the bundled/static
+/// asset leaf-name convention below.
+pub(crate) fn default_path_match(relative: &str) -> bool {
+    let lowered = relative.to_ascii_lowercase();
+    let mut parts: Vec<&str> = lowered.split('/').collect();
+    parts.pop(); // the leaf file name itself never gates on this rule
+    for part in parts {
+        if DEFAULT_EXCLUDE_DIRS.contains(&part)
+            || (part.starts_with('.') && part.len() > 1)
+            || part.starts_with(".venv-")
+            || part.starts_with("venv-")
+            || part.starts_with("env-")
+        {
+            return true;
+        }
+    }
+    is_bundled_or_static(&lowered)
+}
+
+/// Bundled/static-asset and minified-output convention, ported unchanged
+/// from `sentrux scan`'s pre-#152 `is_skipped_relative`.
+fn is_bundled_or_static(lowered: &str) -> bool {
+    if lowered.starts_with("static/")
+        || lowered.starts_with("public/")
+        || lowered.starts_with("wwwroot/")
+        || lowered.contains("/static/")
+        || lowered.contains("/public/")
+        || lowered.contains("/wwwroot/")
+    {
+        return true;
+    }
+    let leaf = lowered.rsplit('/').next().unwrap_or(lowered);
+    leaf.ends_with(".min.js") || leaf.ends_with(".bundle.js")
+}
+
+pub(crate) fn is_oversized(repo: &Path, relative: &str) -> bool {
+    fs::metadata(repo.join(relative))
+        .map(|metadata| metadata.len() > MAX_FILE_BYTES)
+        .unwrap_or(false)
+}
+
+pub(crate) fn looks_binary(path: &Path) -> bool {
+    let Ok(mut file) = fs::File::open(path) else {
+        return false;
+    };
+    let mut buffer = [0u8; BINARY_SNIFF_BYTES];
+    let Ok(read) = file.read(&mut buffer) else {
+        return false;
+    };
+    buffer[..read].contains(&0)
+}

--- a/crates/code-intel-cli/src/file_gate/tests.rs
+++ b/crates/code-intel-cli/src/file_gate/tests.rs
@@ -1,0 +1,229 @@
+use super::rules::MAX_FILE_BYTES;
+use super::*;
+use std::fs;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+static FIXTURE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn fixture_root(label: &str) -> std::path::PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock")
+        .as_nanos();
+    let sequence = FIXTURE_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let root = std::env::temp_dir().join(format!(
+        "code-intel-file-gate-{label}-{}-{nonce}-{sequence}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&root).expect("create fixture root");
+    root
+}
+
+fn write(root: &Path, relative: &str, content: &[u8]) {
+    let path = root.join(relative);
+    fs::create_dir_all(path.parent().expect("fixture parent")).expect("create fixture dir");
+    fs::write(path, content).expect("write fixture");
+}
+
+fn decision_for<'a>(report: &'a GateReport, path: &str) -> &'a GateDecision {
+    report
+        .decisions
+        .iter()
+        .find(|decision| decision.path == path)
+        .unwrap_or_else(|| panic!("no decision recorded for {path}"))
+}
+
+#[test]
+fn every_extension_is_only_classified_once() {
+    let mut seen = std::collections::BTreeSet::new();
+    for extension in CODE_EXTENSIONS {
+        assert!(
+            seen.insert(*extension),
+            "{extension} appears twice in CODE_EXTENSIONS"
+        );
+    }
+}
+
+#[test]
+fn identity_holds_and_every_gate_is_represented_over_a_mixed_fixture_tree() {
+    let root = fixture_root("all-gates");
+    write(&root, "src/lib.rs", b"pub fn ordinary() {}\n");
+    write(&root, "README.md", b"not a recognised source extension\n");
+    write(&root, "legacy/tools/nested.ps1", b"function F {}\n");
+    write(&root, "vendor/inner/thing.py", b"x = 1\n");
+    write(&root, ".gitignore", b"ignored/\n");
+    write(&root, "ignored/generated.rs", b"fn generated() {}\n");
+    let big = vec![b'a'; (MAX_FILE_BYTES + 1) as usize];
+    write(&root, "huge.py", &big);
+    write(&root, "binary_blob.rs", b"pub fn f() {\x00garbage}\n");
+
+    let config = GateConfig::built_in();
+    let report = evaluate(&root, &config).expect("evaluate fixture tree");
+    report.verify_identity().expect("identity holds");
+
+    assert_eq!(
+        decision_for(&report, "src/lib.rs").gate,
+        GATE_DEFAULT_INCLUDE
+    );
+    assert_eq!(
+        decision_for(&report, "src/lib.rs").decision,
+        Decision::Included
+    );
+    assert_eq!(
+        decision_for(&report, "README.md").gate,
+        GATE_UNSUPPORTED_EXT
+    );
+    assert_eq!(
+        decision_for(&report, "legacy/tools/nested.ps1").gate,
+        GATE_DEFAULT_PATH,
+        "default_path must match `tools` at any depth, not just the repository root"
+    );
+    assert_eq!(
+        decision_for(&report, "vendor/inner/thing.py").gate,
+        GATE_DEFAULT_PATH
+    );
+    assert_eq!(decision_for(&report, "huge.py").gate, GATE_OVERSIZED);
+    assert_eq!(
+        decision_for(&report, "ignored/generated.rs").gate,
+        GATE_REPOSITORY_IGNORED
+    );
+    assert_eq!(
+        decision_for(&report, "ignored/generated.rs").source,
+        SOURCE_PROJECT
+    );
+    assert_eq!(decision_for(&report, "binary_blob.rs").gate, GATE_BINARY);
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn user_include_overrides_default_path_and_user_exclude_but_not_binary() {
+    let root = fixture_root("user-include");
+    write(&root, "vendor/reviewed/keep.py", b"x = 1\n");
+    write(&root, "vendor/reviewed/binary.py", b"x = \x00\n");
+
+    let config = GateConfig {
+        user_exclude: vec!["vendor/reviewed".to_string()],
+        user_include: vec!["vendor/reviewed".to_string()],
+    };
+    let report = evaluate(&root, &config).expect("evaluate fixture tree");
+    report.verify_identity().expect("identity holds");
+
+    let kept = decision_for(&report, "vendor/reviewed/keep.py");
+    assert_eq!(kept.decision, Decision::Included);
+    assert_eq!(kept.gate, GATE_USER_INCLUDE);
+
+    let binary = decision_for(&report, "vendor/reviewed/binary.py");
+    assert_eq!(
+        binary.decision,
+        Decision::Excluded,
+        "user_include must not override the binary veto"
+    );
+    assert_eq!(binary.gate, GATE_BINARY);
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn user_exclude_removes_a_file_default_path_would_otherwise_include() {
+    let root = fixture_root("user-exclude");
+    write(&root, "src/quarantined.rs", b"pub fn f() {}\n");
+
+    let config = GateConfig {
+        user_exclude: vec!["src/quarantined.rs".to_string()],
+        user_include: Vec::new(),
+    };
+    let report = evaluate(&root, &config).expect("evaluate fixture tree");
+    report.verify_identity().expect("identity holds");
+
+    let decision = decision_for(&report, "src/quarantined.rs");
+    assert_eq!(decision.decision, Decision::Excluded);
+    assert_eq!(decision.gate, GATE_USER_EXCLUDE);
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn verify_identity_fails_closed_on_a_fabricated_mismatch() {
+    // Directly fabricate a broken report: one more candidate than the
+    // number of recorded decisions. This is the shape a real defect
+    // (an early `continue` that forgets to push a decision) would
+    // produce; the check must reject it, not warn and carry on.
+    let broken = GateReport {
+        candidates: 3,
+        included: vec!["a".to_string()],
+        decisions: vec![
+            GateDecision {
+                path: "a".to_string(),
+                decision: Decision::Included,
+                gate: GATE_DEFAULT_INCLUDE,
+                source: SOURCE_BUILT_IN,
+            },
+            GateDecision {
+                path: "b".to_string(),
+                decision: Decision::Excluded,
+                gate: GATE_UNSUPPORTED_EXT,
+                source: SOURCE_BUILT_IN,
+            },
+        ],
+    };
+    assert!(broken.verify_identity().is_err());
+
+    let inconsistent_included = GateReport {
+        candidates: 2,
+        included: vec!["a".to_string(), "b".to_string()],
+        decisions: vec![
+            GateDecision {
+                path: "a".to_string(),
+                decision: Decision::Included,
+                gate: GATE_DEFAULT_INCLUDE,
+                source: SOURCE_BUILT_IN,
+            },
+            GateDecision {
+                path: "b".to_string(),
+                decision: Decision::Excluded,
+                gate: GATE_UNSUPPORTED_EXT,
+                source: SOURCE_BUILT_IN,
+            },
+        ],
+    };
+    assert!(inconsistent_included.verify_identity().is_err());
+}
+
+#[test]
+fn evaluate_fails_closed_when_verify_identity_would_reject_its_own_output() {
+    // Sanity check that `evaluate` really does call `verify_identity`
+    // before returning, over a tree with nothing exotic in it.
+    let root = fixture_root("plain");
+    write(&root, "src/a.rs", b"pub fn a() {}\n");
+    let report = evaluate(&root, &GateConfig::built_in()).expect("evaluate plain tree");
+    assert!(report.verify_identity().is_ok());
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn by_gate_omits_gates_with_zero_matches_and_carries_the_declared_source() {
+    let root = fixture_root("by-gate");
+    write(&root, "src/a.rs", b"pub fn a() {}\n");
+    write(&root, "vendor/b.rs", b"pub fn b() {}\n");
+    let report = evaluate(&root, &GateConfig::built_in()).expect("evaluate");
+    let by_gate = report.by_gate();
+    let gate_names: Vec<&str> = by_gate
+        .iter()
+        .map(|entry| entry["gate"].as_str().unwrap())
+        .collect();
+    assert!(gate_names.contains(&GATE_DEFAULT_INCLUDE));
+    assert!(gate_names.contains(&GATE_DEFAULT_PATH));
+    assert!(
+        !gate_names.contains(&GATE_BINARY),
+        "no binary file in this fixture"
+    );
+
+    let default_path_entry = by_gate
+        .iter()
+        .find(|entry| entry["gate"] == GATE_DEFAULT_PATH)
+        .unwrap();
+    assert_eq!(default_path_entry["source"], SOURCE_BUILT_IN);
+    fs::remove_dir_all(&root).ok();
+}

--- a/crates/code-intel-cli/src/file_gate/walk.rs
+++ b/crates/code-intel-cli/src/file_gate/walk.rs
@@ -1,0 +1,111 @@
+//! Filesystem traversal and the external `rg`/`git` integration that backs
+//! the `repository_ignored` gate. No gate logic lives here -- this module
+//! only answers "what files exist" and "what does version control say about
+//! them", both consumed by `mod.rs::evaluate`.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+#[path = "../hardened_git.rs"]
+mod hardened_git;
+#[path = "../tool_path.rs"]
+mod tool_path;
+
+/// Every non-`.git`, non-symlink path under `repo`, relative and
+/// forward-slash separated. `.git` is the one boundary this walker does not
+/// even enumerate: it is version-control plumbing, not repository content,
+/// and neither `sentrux scan` nor `sentrux dsm` ever treated it as a
+/// candidate.
+pub(crate) fn walk_candidates(
+    root: &Path,
+    directory: &Path,
+    out: &mut Vec<String>,
+) -> Result<(), String> {
+    let entries = fs::read_dir(directory)
+        .map_err(|error| format!("read {}: {error}", directory.display()))?;
+    for entry in entries {
+        let entry = entry.map_err(|error| format!("read {}: {error}", directory.display()))?;
+        let path = entry.path();
+        let file_type = entry
+            .file_type()
+            .map_err(|error| format!("inspect {}: {error}", path.display()))?;
+        if file_type.is_symlink() {
+            continue;
+        }
+        if file_type.is_dir() {
+            if entry.file_name() == ".git" {
+                continue;
+            }
+            walk_candidates(root, &path, out)?;
+            continue;
+        }
+        let relative = path
+            .strip_prefix(root)
+            .map_err(|error| format!("relativize {}: {error}", path.display()))?
+            .to_string_lossy()
+            .replace('\\', "/");
+        out.push(relative);
+    }
+    Ok(())
+}
+
+fn normalize_path(path: &str) -> String {
+    path.replace('\\', "/")
+        .trim()
+        .trim_start_matches("./")
+        .to_string()
+}
+
+/// `rg --files` (hidden files included, this repository's own `.gitignore`
+/// honoured, parent/global/`.git/info/exclude` ignore sources disabled)
+/// unioned with `git ls-files`, so a file is "governed visible" if either
+/// ripgrep would list it or git already tracks it. `--no-require-git` keeps
+/// the result identical whether or not `target` sits inside a git work tree
+/// ("make DSM ignore handling deterministic", e68392d);
+/// `RIPGREP_CONFIG_PATH` is stripped so a config file inside the scanned
+/// tree cannot change what this check sees. Both `rg` and `git` are
+/// launched by absolute path (`tool_path::resolve`, `hardened_git::command`)
+/// rather than bare name, and `git`'s program-executing config keys are
+/// disarmed -- see those modules for why.
+///
+/// `None` means the check could not run (`rg` missing, spawn failure) --
+/// callers must treat that as "cannot evaluate", not "everything ignored":
+/// `repository_ignored` never excludes anything when this returns `None`.
+pub(crate) fn governed_visible_files(target: &Path) -> Option<BTreeSet<String>> {
+    let output = Command::new(tool_path::resolve("rg"))
+        .arg("--files")
+        .args([
+            "--hidden",
+            "--no-require-git",
+            "--no-ignore-parent",
+            "--no-ignore-global",
+            "--no-ignore-exclude",
+        ])
+        .env_remove("RIPGREP_CONFIG_PATH")
+        .current_dir(target)
+        .output()
+        .ok()?;
+    if !output.status.success() && output.status.code() != Some(1) {
+        return None;
+    }
+    let mut visible = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(normalize_path)
+        .collect::<BTreeSet<_>>();
+
+    if let Ok(output) = hardened_git::command(target)
+        .args(["ls-files", "-z"])
+        .output()
+    {
+        if output.status.success() {
+            for relative in String::from_utf8_lossy(&output.stdout).split('\0') {
+                if !relative.is_empty() {
+                    visible.insert(normalize_path(relative));
+                }
+            }
+        }
+    }
+    Some(visible)
+}

--- a/crates/code-intel-cli/src/sentrux_analysis.rs
+++ b/crates/code-intel-cli/src/sentrux_analysis.rs
@@ -2,18 +2,12 @@ use serde_json::{json, Value};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fs;
 use std::path::Path;
-use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+#[path = "file_gate/mod.rs"]
+mod file_gate;
 #[path = "hardened_git.rs"]
 mod hardened_git;
-#[path = "tool_path.rs"]
-mod tool_path;
-
-const SOURCE_EXTENSIONS: [&str; 14] = [
-    ".ps1", ".psm1", ".py", ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".rs", ".go", ".java",
-    ".cs", ".v",
-];
 
 #[derive(Clone, Default)]
 struct GitSignal {
@@ -48,6 +42,10 @@ struct ModuleMetrics {
 struct Inventory {
     files: Vec<String>,
     scope: Value,
+    /// Full per-candidate decision record from `file_gate::evaluate` (issue
+    /// #152), covering every file under the tree -- not just the recognised
+    /// source extensions `scope` accounts for. See `source_inventory`.
+    file_gate: Value,
 }
 
 pub fn analyze(target: &Path) -> Result<Value, String> {
@@ -107,6 +105,7 @@ pub fn analyze(target: &Path) -> Result<Value, String> {
         "tool": "dsm",
         "path": cli_path(&target),
         "scope": inventory.scope,
+        "file_gate": inventory.file_gate,
         "default_color_mode": "Risk",
         "color_modes": color_modes(),
         "modules": module_output(&modules),
@@ -116,203 +115,75 @@ pub fn analyze(target: &Path) -> Result<Value, String> {
     }))
 }
 
+/// Builds the DSM file inventory from the shared [`file_gate::evaluate`]
+/// decision record (issue #152) instead of a separately maintained walk.
+/// Before #152, this function's own `inventory_files` walked the tree and
+/// its own `excluded_reason` matched `tools`/`vendor`/`third_party`/
+/// `external` only against the first path segment, so `legacy/tools/*` was
+/// invisible to it and silently counted as included -- the majority
+/// contributor to issue #148 C2's 277/315 split against `sentrux scan`'s
+/// count on this repository's own tree. `sentrux_gate::measure_project` now
+/// calls the exact same [`file_gate::evaluate`] on the exact same tree, so
+/// the two commands' file counts are one computation, not two.
+///
+/// `scope.*` below keeps its pre-#152 shape and numbers: it stays scoped to
+/// candidates that already carry a supported source extension, exactly the
+/// universe this function always reported over (the old code applied
+/// `SOURCE_EXTENSIONS` filtering first and unconditionally, so a file with
+/// an unrecognised extension -- `README.md`, `.gitignore`, a build-config
+/// file -- was never part of `included_files`/`excluded_files`/
+/// `excluded_by_reason` at all: not included, not excluded, invisible).
+/// `Inventory::file_gate` is the new, additive surface that accounts for
+/// every candidate the walker actually saw, including those -- so nothing
+/// this contract used to report changes shape, while the full accounting
+/// issue #152 asks for exists alongside it rather than replacing it.
 fn source_inventory(target: &Path) -> Result<Inventory, String> {
-    let listed = inventory_files(target)?;
-    let governed_visible = governed_visible_files(target);
+    let config = file_gate::GateConfig::built_in();
+    let report = file_gate::evaluate(target, &config)?;
 
-    let mut included = Vec::new();
-    let mut excluded: BTreeMap<String, (usize, Vec<String>)> = BTreeMap::new();
-    for relative in listed {
-        let extension = extension(&relative);
-        if !SOURCE_EXTENSIONS.contains(&extension.as_str()) {
+    let mut excluded_by_gate: BTreeMap<&'static str, (usize, Vec<String>)> = BTreeMap::new();
+    for decision in &report.decisions {
+        if decision.gate == file_gate::GATE_UNSUPPORTED_EXT
+            || decision.decision == file_gate::Decision::Included
+        {
             continue;
         }
-        let mut reason = excluded_reason(&relative);
-        if reason.is_none()
-            && matches!(extension.as_str(), ".js" | ".jsx" | ".mjs" | ".cjs")
-            && fs::metadata(target.join(&relative))
-                .map(|metadata| metadata.len() > 2_097_152)
-                .unwrap_or(false)
-        {
-            reason = Some("oversized_generated_or_bundle".to_string());
-        }
-        if reason.is_none()
-            && governed_visible
-                .as_ref()
-                .is_some_and(|visible| !visible.contains(&relative))
-        {
-            reason = Some("repository_ignored".to_string());
-        }
-        if let Some(reason) = reason {
-            let entry = excluded.entry(reason).or_default();
-            entry.0 += 1;
-            if entry.1.len() < 8 {
-                entry.1.push(relative);
-            }
-        } else {
-            included.push(relative);
+        let entry = excluded_by_gate.entry(decision.gate).or_default();
+        entry.0 += 1;
+        if entry.1.len() < 8 {
+            entry.1.push(decision.path.clone());
         }
     }
-    included.sort();
-    included.dedup();
-    let excluded_total = excluded.values().map(|entry| entry.0).sum::<usize>();
-    let mut excluded_by_reason = excluded
+    let excluded_total = excluded_by_gate
+        .values()
+        .map(|(count, _)| *count)
+        .sum::<usize>();
+    let mut excluded_by_reason = excluded_by_gate
         .into_iter()
-        .map(|(reason, (files, samples))| json!({"reason": reason, "files": files, "samples": samples}))
+        .map(|(gate, (files, samples))| json!({"reason": gate, "files": files, "samples": samples}))
         .collect::<Vec<_>>();
     excluded_by_reason.sort_by(|left, right| {
         integer(right, "files")
             .cmp(&integer(left, "files"))
             .then_with(|| string(left, "reason").cmp(string(right, "reason")))
     });
-    let included_count = included.len();
+    let included_count = report.included.len();
+
     Ok(Inventory {
-        files: included,
+        files: report.included.clone(),
         scope: json!({
             "mode": "auto_governed_source",
             "included_files": included_count,
             "excluded_files": excluded_total,
             "excluded_by_reason": excluded_by_reason,
-            "source_extensions": SOURCE_EXTENSIONS,
+            "source_extensions": file_gate::CODE_EXTENSIONS
+                .iter()
+                .map(|extension| format!(".{extension}"))
+                .collect::<Vec<_>>(),
             "note": "Root paths are allowed. Dependency, build-output, cache, and bundled static-asset code is excluded from governed source metrics."
         }),
+        file_gate: report.to_json(),
     })
-}
-
-fn governed_visible_files(target: &Path) -> Option<BTreeSet<String>> {
-    let output = Command::new(tool_path::resolve("rg"))
-        .arg("--files")
-        .args([
-            "--hidden",
-            "--no-require-git",
-            "--no-ignore-parent",
-            "--no-ignore-global",
-            "--no-ignore-exclude",
-        ])
-        .env_remove("RIPGREP_CONFIG_PATH")
-        .current_dir(target)
-        .output()
-        .ok()?;
-    if !output.status.success() && output.status.code() != Some(1) {
-        return None;
-    }
-    let mut visible = String::from_utf8_lossy(&output.stdout)
-        .lines()
-        .map(normalize_path)
-        .collect::<BTreeSet<_>>();
-
-    if let Ok(output) = hardened_git::command(target)
-        .args(["ls-files", "-z"])
-        .output()
-    {
-        if output.status.success() {
-            for relative in String::from_utf8_lossy(&output.stdout).split('\0') {
-                if !relative.is_empty() {
-                    visible.insert(normalize_path(relative));
-                }
-            }
-        }
-    }
-    Some(visible)
-}
-
-fn inventory_files(root: &Path) -> Result<Vec<String>, String> {
-    fn visit(root: &Path, current: &Path, out: &mut Vec<String>) -> Result<(), String> {
-        let entries = fs::read_dir(current)
-            .map_err(|error| format!("read inventory directory {}: {error}", current.display()))?;
-        for entry in entries {
-            let entry = entry.map_err(|error| {
-                format!("read inventory entry in {}: {error}", current.display())
-            })?;
-            let file_type = entry
-                .file_type()
-                .map_err(|error| format!("read file type {}: {error}", entry.path().display()))?;
-            if file_type.is_symlink() {
-                continue;
-            }
-            let path = entry.path();
-            if file_type.is_dir() {
-                if entry.file_name() != ".git" {
-                    visit(root, &path, out)?;
-                }
-            } else if file_type.is_file() {
-                let relative = path
-                    .strip_prefix(root)
-                    .map_err(|error| format!("relativize {}: {error}", path.display()))?;
-                out.push(normalize_path(&relative.to_string_lossy()));
-            }
-        }
-        Ok(())
-    }
-
-    let mut files = Vec::new();
-    visit(root, root, &mut files)?;
-    files.sort();
-    files.dedup();
-    Ok(files)
-}
-
-fn excluded_reason(relative: &str) -> Option<String> {
-    let lower = relative.to_ascii_lowercase();
-    let parts = lower
-        .split('/')
-        .filter(|part| !part.is_empty())
-        .collect::<Vec<_>>();
-    if let Some(top) = parts.first() {
-        if ["tools", "vendor", "third_party", "external"].contains(top) {
-            return Some(format!("external_tooling_dir:{top}"));
-        }
-    }
-    let excluded = [
-        ".git",
-        ".repowise",
-        ".understand-anything",
-        ".sentrux",
-        "node_modules",
-        ".pnpm",
-        ".yarn",
-        "target",
-        "dist",
-        "build",
-        "out",
-        "coverage",
-        ".venv",
-        "venv",
-        "env",
-        ".tox",
-        "__pycache__",
-        ".next",
-        ".nuxt",
-        ".turbo",
-        ".cache",
-    ];
-    if let Some(part) = parts.iter().find(|part| excluded.contains(part)) {
-        return Some(format!("excluded_dir:{part}"));
-    }
-    if lower.starts_with("static/assets/")
-        || lower.starts_with("public/assets/")
-        || lower.starts_with("wwwroot/assets/")
-    {
-        return Some("bundled_static_assets".to_string());
-    }
-    let leaf = relative.rsplit('/').next().unwrap_or(relative);
-    let leaf_lower = leaf.to_ascii_lowercase();
-    if [
-        ".min.js",
-        ".bundle.js",
-        ".min.jsx",
-        ".bundle.jsx",
-        ".min.mjs",
-        ".bundle.mjs",
-        ".min.cjs",
-        ".bundle.cjs",
-    ]
-    .iter()
-    .any(|suffix| leaf_lower.ends_with(suffix))
-    {
-        return Some("bundled_or_minified_file".to_string());
-    }
-    None
 }
 
 fn git_signals(target: &Path, files: &[String]) -> BTreeMap<String, GitSignal> {

--- a/crates/code-intel-cli/src/sentrux_gate.rs
+++ b/crates/code-intel-cli/src/sentrux_gate.rs
@@ -28,6 +28,8 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::Path;
 
+#[path = "file_gate/mod.rs"]
+mod file_gate;
 #[path = "hardened_git.rs"]
 mod hardened_git;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -64,11 +66,7 @@ const GATED_METRIC_KEYS: [&str; 4] = [
     "god_file_count",
 ];
 
-const CODE_EXTENSIONS: &[&str] = &[
-    "ps1", "psm1", "py", "rs", "go", "ts", "tsx", "js", "jsx", "mjs", "cjs", "java", "cs", "cpp",
-    "c", "h", "hpp", "v",
-];
-// Subset of CODE_EXTENSIONS whose dependency declarations `is_import_line`
+// Subset of `file_gate::CODE_EXTENSIONS` whose dependency declarations `is_import_line`
 // recognises. Everything measured except coupling (size, functions,
 // complexity, god files) still covers the full CODE_EXTENSIONS set — a
 // PowerShell god file is still a god file.
@@ -83,36 +81,6 @@ const IMPORT_MODELED_EXTENSIONS: &[&str] = &[
 // average. Adding either form to `is_import_line` is the prerequisite for
 // moving these into IMPORT_MODELED_EXTENSIONS.
 const IMPORT_UNMODELED_EXTENSIONS: &[&str] = &["ps1", "psm1"];
-const SKIP_DIRECTORIES: &[&str] = &[
-    ".git",
-    ".repowise",
-    ".understand-anything",
-    ".sentrux",
-    "tools",
-    "vendor",
-    "vendors",
-    "third_party",
-    "third-party",
-    "external",
-    "node_modules",
-    ".pnpm",
-    ".yarn",
-    "target",
-    "dist",
-    "build",
-    "out",
-    "coverage",
-    ".venv",
-    "venv",
-    "env",
-    ".tox",
-    "__pycache__",
-    ".next",
-    ".nuxt",
-    ".turbo",
-    ".cache",
-];
-const MAX_FILE_BYTES: u64 = 2 * 1024 * 1024;
 const MAX_VIOLATION_TARGETS: usize = 8;
 // The god-file rule, single source for both measurement (`measure_file`) and
 // reporting (`god_rule_label`) so the printed rule branch can never drift
@@ -185,7 +153,7 @@ struct ProjectMetrics {
 }
 
 pub(crate) fn run_check(repo: &Path) -> Result<EngineRun, String> {
-    let metrics = measure_project(repo)?;
+    let (metrics, _file_gate) = measure_project(repo)?;
     let mut out = String::new();
     resolve_header(&mut out, &metrics);
     let rules_path = repo.join(".sentrux").join("rules.toml");
@@ -229,7 +197,7 @@ pub(crate) fn run_check(repo: &Path) -> Result<EngineRun, String> {
 }
 
 pub(crate) fn run_gate(repo: &Path, save: bool) -> Result<EngineRun, String> {
-    let metrics = measure_project(repo)?;
+    let (metrics, _file_gate) = measure_project(repo)?;
     let baseline_path = repo.join(".sentrux").join("baseline.json");
     if save {
         let baseline = baseline_document(repo, &metrics)?;
@@ -494,8 +462,12 @@ pub(crate) fn run_check_aligned(repo: &Path, ratchet: bool) -> Result<EngineRun,
 }
 
 pub(crate) fn scan_json(repo: &Path) -> Result<Value, String> {
-    let metrics = measure_project(repo)?;
-    Ok(metrics_json(repo, &metrics))
+    let (metrics, file_gate) = measure_project(repo)?;
+    let mut value = metrics_json(repo, &metrics);
+    if let Value::Object(ref mut map) = value {
+        map.insert("file_gate".to_string(), file_gate.to_json());
+    }
+    Ok(value)
 }
 
 fn baseline_document(repo: &Path, metrics: &ProjectMetrics) -> Result<Value, String> {
@@ -743,13 +715,13 @@ fn cycle_targets(metrics: &ProjectMetrics) -> Vec<String> {
     targets
 }
 
-fn measure_project(repo: &Path) -> Result<ProjectMetrics, String> {
+fn measure_project(repo: &Path) -> Result<(ProjectMetrics, file_gate::GateReport), String> {
     let repo = repo
         .canonicalize()
         .map_err(|error| format!("resolve repository path: {error}"))?;
-    let mut paths = Vec::new();
-    collect_files(&repo, &repo, &mut paths)?;
-    paths.sort();
+    let config = file_gate::GateConfig::built_in();
+    let report = file_gate::evaluate(&repo, &config)?;
+    let paths = report.included.clone();
     let mut files = Vec::new();
     for relative in &paths {
         let content = fs::read(repo.join(relative)).unwrap_or_default();
@@ -784,7 +756,7 @@ fn measure_project(repo: &Path) -> Result<ProjectMetrics, String> {
         - ((max_complexity - 15).max(0) as f64) * 10.0)
         .max(0.0) as i64;
     let cycles = rust_import_cycles(&repo, &paths);
-    Ok(ProjectMetrics {
+    let metrics = ProjectMetrics {
         cycle_count: cycles.len() as i64,
         cycles,
         files,
@@ -798,78 +770,8 @@ fn measure_project(repo: &Path) -> Result<ProjectMetrics, String> {
         max_complexity,
         coupling_score,
         quality_signal,
-    })
-}
-
-fn collect_files(root: &Path, directory: &Path, paths: &mut Vec<String>) -> Result<(), String> {
-    let entries = fs::read_dir(directory)
-        .map_err(|error| format!("read {}: {error}", directory.display()))?;
-    for entry in entries {
-        let entry = entry.map_err(|error| format!("read {}: {error}", directory.display()))?;
-        let path = entry.path();
-        let name = entry.file_name().to_string_lossy().to_string();
-        let file_type = entry
-            .file_type()
-            .map_err(|error| format!("inspect {}: {error}", path.display()))?;
-        if file_type.is_symlink() {
-            continue;
-        }
-        if file_type.is_dir() {
-            if SKIP_DIRECTORIES.contains(&name.as_str())
-                || (name.starts_with('.') && name.len() > 1)
-                || name.starts_with(".venv-")
-                || name.starts_with("venv-")
-                || name.starts_with("env-")
-            {
-                continue;
-            }
-            collect_files(root, &path, paths)?;
-            continue;
-        }
-        let extension = path
-            .extension()
-            .and_then(|value| value.to_str())
-            .map(str::to_ascii_lowercase)
-            .unwrap_or_default();
-        if !CODE_EXTENSIONS.contains(&extension.as_str()) {
-            continue;
-        }
-        if entry
-            .metadata()
-            .map(|metadata| metadata.len() > MAX_FILE_BYTES)
-            .unwrap_or(true)
-        {
-            continue;
-        }
-        let relative = path
-            .strip_prefix(root)
-            .map_err(|error| format!("relativize {}: {error}", path.display()))?
-            .to_string_lossy()
-            .replace('\\', "/");
-        if is_skipped_relative(&relative) {
-            continue;
-        }
-        paths.push(relative);
-    }
-    Ok(())
-}
-
-fn is_skipped_relative(relative: &str) -> bool {
-    let lowered = relative.to_ascii_lowercase();
-    if lowered.starts_with("static/")
-        || lowered.starts_with("public/")
-        || lowered.starts_with("wwwroot/")
-        || lowered.contains("/static/")
-        || lowered.contains("/public/")
-        || lowered.contains("/wwwroot/")
-    {
-        return true;
-    }
-    let leaf = lowered.rsplit('/').next().unwrap_or(&lowered);
-    if leaf.ends_with(".min.js") || leaf.ends_with(".bundle.js") {
-        return true;
-    }
-    false
+    };
+    Ok((metrics, report))
 }
 
 fn measure_file(relative: &str, content: &str) -> FileMetrics {
@@ -1451,10 +1353,11 @@ mod tests {
 
     #[test]
     fn every_code_extension_is_classified_as_import_modeled_or_not() {
-        // A new extension added to CODE_EXTENSIONS without a decision here
-        // would silently land in the coupling denominator with zero imports,
-        // which is the exact defect this split exists to prevent.
-        for extension in CODE_EXTENSIONS {
+        // A new extension added to file_gate::CODE_EXTENSIONS without a
+        // decision here would silently land in the coupling denominator
+        // with zero imports, which is the exact defect this split exists
+        // to prevent.
+        for extension in file_gate::CODE_EXTENSIONS {
             let modeled = IMPORT_MODELED_EXTENSIONS.contains(extension);
             let unmodeled = IMPORT_UNMODELED_EXTENSIONS.contains(extension);
             assert!(
@@ -1467,7 +1370,7 @@ mod tests {
             .chain(IMPORT_UNMODELED_EXTENSIONS)
         {
             assert!(
-                CODE_EXTENSIONS.contains(extension),
+                file_gate::CODE_EXTENSIONS.contains(extension),
                 "{extension} is classified but never collected"
             );
         }
@@ -1481,7 +1384,7 @@ mod tests {
             "use std::fs;\nuse std::io;\npub fn f() {}\n",
         )
         .expect("write rust fixture");
-        let rust_only = measure_project(&root).expect("measure rust-only tree");
+        let (rust_only, _) = measure_project(&root).expect("measure rust-only tree");
         assert_eq!(rust_only.import_modeled_file_count, 1);
         assert_eq!(rust_only.coupling_score, 20.0);
 
@@ -1495,7 +1398,7 @@ mod tests {
             )
             .expect("write powershell fixture");
         }
-        let mixed = measure_project(&root).expect("measure mixed tree");
+        let (mixed, _) = measure_project(&root).expect("measure mixed tree");
         assert_eq!(mixed.file_count, 11);
         assert_eq!(mixed.import_modeled_file_count, 1);
         assert_eq!(mixed.coupling_score, rust_only.coupling_score);
@@ -1503,7 +1406,7 @@ mod tests {
         // Deleting PowerShell — the whole point of the migration — must not
         // register as a coupling regression either.
         fs::remove_file(root.join("helper0.ps1")).expect("remove one powershell fixture");
-        let after_deletion = measure_project(&root).expect("measure tree after deletion");
+        let (after_deletion, _) = measure_project(&root).expect("measure tree after deletion");
         assert_eq!(after_deletion.coupling_score, mixed.coupling_score);
         fs::remove_dir_all(&root).expect("remove fixture");
     }

--- a/orchestration/integrations.json
+++ b/orchestration/integrations.json
@@ -587,7 +587,7 @@
         "toolchainDigests": [
               "300d911f99d9b026606a0d3118f24ed33dad025b0e0212e3ed84705e80760a90",
               "29ad124d984f6ab0756bdc7c0b523a84dfada2a655fe0d282ce681165f6bae4f",
-              "af9ae2fdea5b514a59769259ba9b2f4d3678a59354ca9896edd7729d29c60d09",
+              "e4a641630fe293cf7cbc5cb21a464cc0a16f29e3e8491d4c19eb0813b7b9c2b2",
               "52644a812174988ede91d98ddfec63c6a91f8478277d7bf74c73f106dd0f776b",
               "98ccc64478b2c61bfd7af741ea1f8ee01a88094065c0f025700e8110b525ef26"
             ]

--- a/orchestration/internalization/sentrux.json
+++ b/orchestration/internalization/sentrux.json
@@ -65,7 +65,7 @@
       },
       "source": {
         "path": "crates/code-intel-cli/src/sentrux_analysis.rs",
-        "sha256": "bae17f2206cb15b63e63f5899f227349d5bbb7f27110de6f2f3993c37cfdf148"
+        "sha256": "7b48d4d32702539ec625e547130c889ee7430f9b5267e37c690887903ec1d590"
       },
       "conformance": {
         "path": "crates/code-intel-cli/tests/sentrux_analysis.rs",
@@ -331,7 +331,7 @@
       },
       "source": {
         "path": "crates/code-intel-cli/src/sentrux_gate.rs",
-        "sha256": "af9ae2fdea5b514a59769259ba9b2f4d3678a59354ca9896edd7729d29c60d09"
+        "sha256": "e4a641630fe293cf7cbc5cb21a464cc0a16f29e3e8491d4c19eb0813b7b9c2b2"
       },
       "conformance": {
         "path": "crates/code-intel-cli/tests/dag_run.rs",
@@ -411,7 +411,7 @@
       "path": "crates/code-intel-cli/src/sentrux_analysis.rs",
       "description": "native Rust governed-source, file/function metric, module graph, and DSM risk kernel",
       "evidenceIds": [
-        "local:sentrux:rust-dsm-source-sha256:bae17f2206cb15b63e63f5899f227349d5bbb7f27110de6f2f3993c37cfdf148",
+        "local:sentrux:rust-dsm-source-sha256:7b48d4d32702539ec625e547130c889ee7430f9b5267e37c690887903ec1d590",
         "local:sentrux:rust-dsm-conformance-sha256:9501b59fbe40f7aa76cf82d1bb5f75ed0cc45bd5f2fa9dae1acb735d0b66f266"
       ]
     },
@@ -427,7 +427,7 @@
       "path": "crates/code-intel-cli/src/sentrux_gate.rs",
       "description": "Pipeline-owned built-in structural gate engine (metrics, rules check, no-degradation gate, cycle detection)",
       "evidenceIds": [
-        "local:b03:native-gate-source-sha256:af9ae2fdea5b514a59769259ba9b2f4d3678a59354ca9896edd7729d29c60d09",
+        "local:b03:native-gate-source-sha256:e4a641630fe293cf7cbc5cb21a464cc0a16f29e3e8491d4c19eb0813b7b9c2b2",
         "local:b03:native-gate-conformance:ece31b4fbf1692c582d6bacee7b7beed770d27dc6811fb783e668914984210a0"
       ]
     }


### PR DESCRIPTION
关掉 #148 C2 记录的那个缺陷：同一棵树上 `sentrux scan` 和 `sentrux dsm` 报不同的文件数，38 个文件凭空消失且无法归因。这不是精度问题，是**覆盖面不可审计**——没人能回答「这个文件为什么没被扫」。

## 根因（实测出来的，不是猜的）

两个 bug：

1. **dsm 的排除检查只拿第一段路径匹配** `tools`/`vendor`/`third_party`/`external`，所以 `legacy/tools/*` 对它完全隐形——本仓 39 个文件。
2. **dsm 的扩展名白名单漏了 `cpp`/`c`/`h`/`hpp`**，静默丢文件，且任何计数里都不体现。

## 做法

新增 `crates/code-intel-cli/src/file_gate/`，`scan` 和 `dsm` 都调它，各自原来的私有遍历器（`collect_files`/`SKIP_DIRECTORIES`/`CODE_EXTENSIONS`/`is_skipped_relative`，以及 `inventory_files`/`governed_visible_files`/`excluded_reason`/`SOURCE_EXTENSIONS`）全部删除。

**八道具名闸门，第一个命中的赢**：

```
unsupported_ext → user_include → user_exclude → default_path
→ oversized → repository_ignored → binary → default_include
```

`user_include` 能覆盖 `user_exclude` / `default_path` / `repository_ignored`，但**永远覆盖不了 `binary`**——强行放行真二进制文件会让 dsm 下游 `fs::read_to_string` 崩。顺序理由写在 `mod.rs` 的模块文档里。

**恒等式 fail-closed**：

```
candidates == included + Σ(excluded by gate)
```

在 `GateReport::verify_identity()` 里，由 `evaluate()` 在返回前**无条件**调用。违反是 `Err`，整条命令失败，不是 warning 然后继续。有专门用伪造的不匹配报告驱动的用例守着（`verify_identity_fails_closed_on_a_fabricated_mismatch`）。

## 实测：同一棵树，新旧二进制对照

同一份工作树，用旧二进制（不含本 PR）和新二进制各跑一次：

| 二进制 | `scan.files` | `dsm.scope.included_files` | 差 |
| --- | --- | --- | --- |
| 旧 | 288 | **326** | **38** |
| 新 | 288 | **288** | **0** |

新二进制下两边内嵌的 `file_gate` 块**字节相同**：

```json
{"candidates": 12194, "included": 288, "excluded": 11906}
```

因为它们现在调的是同一个函数。这不是「修好了一次」，是结构上不可能再分叉。

## 巨石回归已修

第一版把整个模块写成单文件 `file_gate.rs`，833 行，命中本仓自己的 `loc > 800`（`god_file_count` 32→33）。**治理诚实度的东西不能自己就是它要治的那个问题。**

按本仓既有约定（`change_risk/`、`change_agenda/` 都是模块目录 + 独立 `tests.rs`）拆开：

| 文件 | 行数 | 职责 |
| --- | --- | --- |
| `mod.rs` | 234 | 闸门顺序模块文档 + `evaluate()` 编排 |
| `rules.rs` | 204 | 闸门命名、扩展名/排除目录常量、纯谓词 |
| `walk.rs` | 111 | 文件系统遍历 + `rg`/`git` 集成 |
| `report.rs` | 107 | `GateReport`、fail-closed 恒等式、JSON 投影 |
| `tests.rs` | 229 | 全部测试 |

外部接口未变——`sentrux_gate.rs` / `sentrux_analysis.rs` 只需改 `#[path]` 一行。`god_file_count` 回到 **32**。

`files` 从 284 变 288 是因为一个文件拆成五个（净 +4 个源文件），与任何语义变化无关；真正要紧的性质（scan/dsm 一致）严格成立。

## 还在自己数数的面（本 PR 不动，已知并公开）

1. `legacy/tools/sentrux-shim/sentrux-lite-core.ps1` —— PATH shim 在找不到外部 `sentrux-core.exe` 时的 fallback，手抄了整条闸门链（同一份排除目录、同样 18 个扩展名、同样的巨石规则），与 `file_gate` 无共享代码也无测试绑定。**是另一条调用路径**（#148 C2 量的是 `code-intel sentrux scan`/`dsm`），所以是相关风险不是同一缺陷——但它是活的，不是遗迹。
2. `crates/code-intel-cli/src/graph.rs` 的 `collect_source_files`（自带 `should_skip_dir` 与扩展名表），报 `summary.files`。
3. `capability_inventory.rs` / `snapshot.rs` 那条 `rg --files` 库存线，自带排除 glob，喂 `survival_scan.rs` / `native_code_evidence.rs`。

未上报的第二个计数器就是这个 bug 本身，所以这三条明写在这里。

## 门禁

| 项 | 结果 |
| --- | --- |
| `cargo fmt --check` | pass |
| `cargo test -p code-intel` | 全绿 |
| `sentrux scan` god_file_count | 32（回到基线） |
| scan / dsm 文件数 | 288 / 288，`file_gate` 块字节相同 |
| `repin --write` → 复跑 | `stalePins: []` |
| `run execute` 权威自扫 | exit 0、`outcome: completed`、`publication.status: committed`、全节点 `verdict: pass` |

Refs #152 #148 #106
