### PR TITLE
fix(gate): 测试不对称信号认得本仓自己的 tests.rs 约定——96 百分位假阻断

### DIFF
--- a/crates/code-intel-cli/src/change_risk/signals.rs
+++ b/crates/code-intel-cli/src/change_risk/signals.rs
@@ -101,16 +101,31 @@ pub(super) fn is_source_file(path: &str) -> bool {
         .is_some_and(|index| index + 1 < parts.len())
 }
 
-/// `tests/**`, `*_test.*`, or `test_*`, matched on path segments and
-/// filename rather than a literal glob engine (no new dependency for three
-/// simple patterns).
+/// `tests/**`, `*_test.*`, `test_*`, or a module's own `tests.<ext>` file,
+/// matched on path segments and filename rather than a literal glob engine
+/// (no new dependency for four simple patterns).
+///
+/// The last pattern is this crate's own convention for inline test modules
+/// — `change_risk/tests.rs`, `change_agenda/tests.rs`, `file_gate/tests.rs`
+/// — and all three of the others miss it: the final path segment is
+/// `tests.rs` rather than a `tests` directory, the name does not start with
+/// `test_`, and the stem `tests` does not end with `_test`. Without it every
+/// PR that follows the convention scored as "source changed, no tests
+/// touched", which carries the largest single weight in this file's formula
+/// (`WEIGHT_TEST_ASYMMETRY`). The monolith rule pushes test modules into
+/// their own file and this signal then refused to see them — two of the
+/// repository's own rules working against each other.
 pub(super) fn is_test_file(path: &str) -> bool {
     let parts: Vec<&str> = path.split('/').collect();
     if parts.contains(&"tests") {
         return true;
     }
     let filename = parts.last().copied().unwrap_or("");
-    filename.starts_with("test_") || file_stem(filename).ends_with("_test")
+    let stem = file_stem(filename);
+    // Whole-stem equality, not a substring or suffix match: `latest.rs` and
+    // `contests.rs` are ordinary source files and must not be credited as
+    // tests.
+    stem == "tests" || filename.starts_with("test_") || stem.ends_with("_test")
 }
 
 fn file_stem(filename: &str) -> &str {

--- a/crates/code-intel-cli/src/change_risk/tests.rs
+++ b/crates/code-intel-cli/src/change_risk/tests.rs
@@ -114,6 +114,32 @@ fn is_test_file_matches_the_documented_heuristics() {
 }
 
 #[test]
+fn is_test_file_credits_this_crates_own_inline_test_module_convention() {
+    // Every multi-part module here keeps its tests in a sibling `tests.rs`.
+    // Before this was recognized, a PR adding one scored as "no tests
+    // touched" — the heaviest single signal in the formula.
+    for path in [
+        "crates/code-intel-cli/src/change_risk/tests.rs",
+        "crates/code-intel-cli/src/change_agenda/tests.rs",
+        "crates/code-intel-cli/src/file_gate/tests.rs",
+    ] {
+        assert!(is_test_file(path), "{path}");
+    }
+}
+
+#[test]
+fn is_test_file_does_not_credit_names_that_merely_contain_tests() {
+    // Whole-stem equality, not substring: these are ordinary source files.
+    for path in [
+        "crates/code-intel-cli/src/latest.rs",
+        "crates/code-intel-cli/src/contests.rs",
+        "crates/code-intel-cli/src/testsuite_helpers.rs",
+    ] {
+        assert!(!is_test_file(path), "{path}");
+    }
+}
+
+#[test]
 fn looks_like_fix_subject_matches_english_and_chinese_markers() {
     assert!(looks_like_fix_subject("fix(gate): correct off-by-one"));
     assert!(looks_like_fix_subject("Fix regression in parser"));

--- a/crates/code-intel-cli/src/change_risk/tests.rs
+++ b/crates/code-intel-cli/src/change_risk/tests.rs
@@ -139,6 +139,59 @@ fn is_test_file_does_not_credit_names_that_merely_contain_tests() {
     }
 }
 
+/// Contract-level guard on the emitted signal, not just the predicate that
+/// feeds it. The defect this fixes lived in what `testAsymmetry` reported,
+/// so a green `is_test_file` alone would not have caught it — and would not
+/// catch a future rewiring that leaves the predicate correct but stops
+/// consulting it.
+#[test]
+fn a_change_touching_an_inline_tests_module_is_not_scored_as_asymmetric() {
+    let files = vec![
+        (
+            40,
+            2,
+            "crates/code-intel-cli/src/change_risk/signals.rs".to_string(),
+        ),
+        (
+            30,
+            0,
+            "crates/code-intel-cli/src/change_risk/tests.rs".to_string(),
+        ),
+    ];
+    let scored = score_subset(&files, &FileHistory::new(), 1_700_000_000);
+
+    let asymmetry = &scored.signals["testAsymmetry"];
+    assert_eq!(asymmetry["testFilesChanged"].as_u64(), Some(1));
+    assert_eq!(asymmetry["asymmetric"], false);
+    assert_eq!(asymmetry["subscore"], 0.0);
+
+    let tests_row = scored
+        .files
+        .iter()
+        .find(|file| file["path"] == "crates/code-intel-cli/src/change_risk/tests.rs")
+        .expect("the tests.rs row must be reported");
+    assert_eq!(tests_row["isTestFile"], true);
+}
+
+/// The complementary half: the signal must still fire when a change really
+/// does touch source without touching any test. A fix that made every change
+/// look symmetric would pass the test above and silently disarm the largest
+/// weight in the formula.
+#[test]
+fn a_source_only_change_is_still_scored_as_asymmetric() {
+    let files = vec![(
+        40,
+        2,
+        "crates/code-intel-cli/src/change_risk/signals.rs".to_string(),
+    )];
+    let scored = score_subset(&files, &FileHistory::new(), 1_700_000_000);
+
+    let asymmetry = &scored.signals["testAsymmetry"];
+    assert_eq!(asymmetry["testFilesChanged"].as_u64(), Some(0));
+    assert_eq!(asymmetry["asymmetric"], true);
+    assert_eq!(asymmetry["subscore"], 1.0);
+}
+
 #[test]
 fn looks_like_fix_subject_matches_english_and_chinese_markers() {
     assert!(looks_like_fix_subject("fix(gate): correct off-by-one"));


### PR DESCRIPTION
PR 门禁在 #166 上报了假信号，并据此以 96 百分位把它挡下。这个 PR 修判据本身。

## 现象

[#166](https://github.com/2233admin/code-intel-pipeline/pull/166) 新增了 `crates/code-intel-cli/src/file_gate/tests.rs`，**229 行测试**。`pr-gate.yml` 的报告：

```
Score 86/100 · Percentile 96th · Level 🔴 high
Test asymmetry: source changed, no tests touched
```

## 原因

`change_risk/signals.rs` 的 `is_test_file` 三条判据，对本 crate 自己的内联测试模块**一条都不命中**：

| 判据 | `crates/code-intel-cli/src/file_gate/tests.rs` |
| --- | --- |
| 路径含 `tests` 目录段 | 最后一段是 `tests.rs`，不是 `tests` |
| 文件名以 `test_` 开头 | 否 |
| 词干以 `_test` 结尾 | 词干是 `tests` |

而 `is_source_file` 命中了（`crates/` 开头 + 含 `src`）。**那 229 行测试既不算测试，还被计入源码改动。**

这不是一次性巧合。本 crate 的多段模块一律「模块目录 + 同级 `tests.rs`」——`change_risk/`、`change_agenda/`，以及本轮新增的 `file_gate/`、`language_pref/`、`graph/`、`anchor_verification/`。**凡遵守约定的 PR 都会被判成「没碰测试」**，而测试不对称是公式里权重最大的单项（`WEIGHT_TEST_ASYMMETRY = 25`）。

更难受的是，这是本仓两条规则互相打架：**巨石规则**（`loc > 800` 或 `functions > 25 && loc > 400`）把测试模块推进独立文件，**这个信号**又拒绝承认它们。本轮三个 agent 按约定拆分之后，全都会踩。

## 同一份 diff，修前修后

```
修前:  score 86   percentile 96   level high   asymmetric=true
修后:  score 61   percentile 53   level low    asymmetric=false   test=1
```

25 分的摆幅，正好是 `WEIGHT_TEST_ASYMMETRY`。96 百分位（阻断）变 53 百分位（放行）。

## 改动

`is_test_file` 增加第四条判据：词干整词等于 `tests`。

**整词干相等，不是子串或后缀匹配**——`latest.rs`、`contests.rs`、`testsuite_helpers.rs` 是普通源文件，不能被算成测试。有专门的负例用例守着。

`is_source_file` 未改：内联测试模块确实在 `src/` 下、确实参与编译，把它算成源文件是对的；`asymmetric` 只要求 `test_files_changed > 0`，所以一个文件同时算两者不影响判定。

## 门禁

| 项 | 结果 |
| --- | --- |
| `cargo fmt --check` | clean |
| `cargo test -p code-intel --bin code-intel` | 433 passed |

## 落地顺序

#166 自己的分支没有这个修复，CI 用的是从 PR 分支构建的二进制，所以它会一直红到本 PR 合入 main 且 #166 rebase 之后。**建议先合本 PR。** 不建议给 #166 贴 `risk-accepted`——那是拿标签盖住一个真实的门禁缺陷，而这个缺陷会继续影响之后每一个 PR。

Refs #152 #95 #165
