### PR TITLE
fix(test): 测试临时目录按进程归属，不再只按时钟命名 (#175)

### DIFF
--- a/crates/code-intel-cli/src/graph/tests.rs
+++ b/crates/code-intel-cli/src/graph/tests.rs
@@ -77,16 +77,79 @@ fn truncates_unicode_on_a_character_boundary() {
     assert_eq!(truncated, "交易账...");
 }
 
+/// A scratch directory unique per (process, call), not merely per instant.
+///
+/// This module is `#[path]`-included into 12 separate integration-test
+/// binaries and `cargo test` runs those binaries as parallel *processes*,
+/// so up to 12 independent callers share this naming scheme at once. Naming
+/// the directory from `SystemTime::now()` alone made the name a function of
+/// nothing but the clock: any two processes observing the same instant get
+/// the *identical* path, and whichever finishes first deletes the tree the
+/// other is still reading. That is the mechanism behind
+/// `switching_documentation_language_changes_only_the_language_field`
+/// failing intermittently on `windows-latest` (issue #175) — a shared
+/// mutable path with no owner.
+///
+/// The race itself was not reproduced locally: on this machine the clock
+/// does advance between consecutive calls, so a same-instant collision is
+/// rare rather than routine. The fix is therefore structural — the process
+/// id makes cross-process collision impossible instead of improbable —
+/// rather than a repair of an observed local failure. `NEXT_ID` does the
+/// same for repeated calls inside one process. The timestamp is kept only
+/// so leftover directories from a killed run stay sortable by age.
 fn unique_temp_dir() -> std::path::PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    static NEXT_ID: AtomicU64 = AtomicU64::new(0);
 
     let mut dir = std::env::temp_dir();
     dir.push(format!(
-        "code-intel-graph-test-{}",
+        "code-intel-graph-test-{}-{}-{}",
+        std::process::id(),
+        NEXT_ID.fetch_add(1, Ordering::Relaxed),
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_nanos()
     ));
     dir
+}
+
+/// Guards `NEXT_ID`: a burst tighter than the clock could plausibly resolve
+/// must still produce distinct names.
+///
+/// Honest limitation — this test does **not** reproduce #175. Run against
+/// the old clock-only implementation on this machine it still passes,
+/// because the clock does advance between consecutive calls here. It guards
+/// the in-process half of the property and would catch a regression on a
+/// platform with a coarser clock; the cross-process half, which is what
+/// #175 actually was, is pinned by the test below.
+#[test]
+fn scratch_directories_stay_unique_within_a_single_clock_tick() {
+    let mut seen = std::collections::BTreeSet::new();
+    for _ in 0..1000 {
+        let dir = unique_temp_dir();
+        assert!(
+            seen.insert(dir.clone()),
+            "unique_temp_dir returned a duplicate inside one burst: {}",
+            dir.display()
+        );
+    }
+}
+
+/// The counter above only separates calls *within* one process. Cross-process
+/// separation rests entirely on the pid being part of the name, so pin that
+/// rather than leave it to be refactored away.
+#[test]
+fn scratch_directory_names_carry_the_process_id() {
+    let dir = unique_temp_dir();
+    let name = dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .expect("scratch directory name");
+    assert!(
+        name.contains(&std::process::id().to_string()),
+        "the name must carry the process id or parallel test binaries can collide: {name}"
+    );
 }


### PR DESCRIPTION
关掉 #175：一条断言确定性的测试，自己不确定。

`switching_documentation_language_changes_only_the_language_field` 断言的正是「zh 与 en 两次运行除 `language` 字段外字节相同」（#155/#169 的核心验收），却在 `windows-latest` 上偶发失败。**一条周期性无故变红的测试，训练所有人养成「重跑一下就好」的习惯**——那是假绿灯文化的入口。它这次先骗了我三轮排查，下一个人多半会直接重跑。

## 机制

实测（`rtk proxy cargo test -p code-intel switching_documentation_language`）：

```
switching_documentation_language ... ok   × 12
Running tests                            × 28
```

`graph` 模块被 `#[path]` 编进 **12 个**集成测试二进制，而 `cargo test` 把这些二进制当**独立进程并行**跑。目录名生成：

```rust
dir.push(format!("code-intel-graph-test-{}", SystemTime::now()…as_nanos()));
```

**只有时钟，没有 pid、没有计数器。** 任意两个进程观测到同一瞬间就拿到完全相同的路径，先跑完的那个 `remove_dir_all` 掉另一个正在读的树。共享可变路径，无归属。

## 修法

结构性消除，不是概率改善：

- **进程 id** —— 跨进程碰撞从「不太可能」变成「不可能」
- **原子计数器** —— 覆盖同进程内的重复调用（3 个调用点）
- **时间戳保留** —— 只为让被杀死的运行留下的目录仍可按时间排序

## 诚实边界：竞态本身没在本地复现

本机时钟在连续调用之间确实推进，所以「同一瞬间碰撞」是罕见而非常态。**这是消除可能性，不是修复一次已观测到的本地失败。**

两条回归测试，只有一条真的能抓住旧实现，注释里都写明了：

| 测试 | 对旧实现 | 守什么 |
| --- | --- | --- |
| `scratch_directory_names_carry_the_process_id` | **FAILED** | 跨进程属性——#175 实际就是这一半 |
| `scratch_directories_stay_unique_within_a_single_clock_tick` | 仍然 ok | 同进程计数器；时钟更粗的平台才发挥作用 |

第二条我原本在注释里写成「直接复现 #175」，实测不成立，已改写成它真实的作用范围。**不谎称它复现了 #175。**

#175 要求「不含 retry、不含 sleep、不含放宽断言」——三条都没用。

## 顺带发现：同一类还有第二处

全量跑的时候撞到另一条偶发红，重跑即过：

```
capability_inventory::builtin_provider_evidence::sentrux_gate::tests::this_repository_has_no_resolved_import_cycles
  → sentrux check should run against this repository:
    "read \\?\D:\…\target\tool-path-r…"
```

同样是**并行测试进程共享 `target/` 下一条可变路径且无按进程归属**。与本 PR 无关（本 PR 只改 `graph/tests.rs`），但值得单独一票——本 PR 不顺手扩进去。

## 门禁

| 项 | 结果 |
| --- | --- |
| `cargo fmt --check` | clean |
| `cargo test -p code-intel` | 55 suites 全 ok，0 FAILED |
| 反证：对旧实现跑新测试 | `scratch_directory_names_carry_the_process_id` FAILED，确认能抓 |

Refs #175 #106 #148 #155
