### PR TITLE
test(risk): 给 scoring.rs 补数值单测——26 个存活变异体归零 (#179)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,9 @@ Thumbs.db
 # Local command scratch
 -o
 .gstack/
+
+# cargo-mutants working output (issue #179). Left untracked it also perturbs
+# the repo's own measurements: `sentrux scan` counted 32769 file-gate
+# candidates before a mutation run and 32839 during one.
+mutants.out/
+mutants.out.old/

--- a/crates/code-intel-cli/src/change_risk/scoring.rs
+++ b/crates/code-intel-cli/src/change_risk/scoring.rs
@@ -49,3 +49,152 @@ pub(super) fn level_for_percentile(percentile: u32) -> &'static str {
 pub(super) fn round2(value: f64) -> f64 {
     (value * 100.0).round() / 100.0
 }
+
+/// Every test here asserts a *number*, not a shape.
+///
+/// The arithmetic above decides whether a pull request is blocked, and until
+/// issue #179 it had no direct test at all. Everything reaching it came
+/// through end-to-end paths that assert the report's *shape* -- field
+/// present, schema valid, array non-empty -- so `cargo mutants --file
+/// .../scoring.rs -- --bin code-intel` left 26 of its 31 injected defects
+/// alive against the 544-test unit-test oracle, including `combine`
+/// returning a constant `0.0`, `compute_percentile` returning a constant
+/// `0`, and `level_for_percentile` returning `""`. Every one of those stayed
+/// green.
+///
+/// So the subscores below are chosen deliberately: distinct, non-zero, never
+/// `1.0`, and exactly representable in binary (halves, quarters, eighths).
+/// Distinct and non-`1.0` so that swapping any `*` for `+` or `/`, or any
+/// `+` for `-` or `*`, lands on a different total -- `w * 1.0` and `w / 1.0`
+/// are the same number, which is exactly how an untested formula hides.
+/// Exactly representable so the expected values can be compared with `==`
+/// instead of an epsilon that would re-open the slack this file is closing.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The four subscores used across these tests: distinct, exact, and each
+    /// one multiplied by its own weight gives a distinct product.
+    /// 30*0.5=15, 25*0.25=6.25, 25*0.75=18.75, 20*0.125=2.5 -- total 42.5.
+    const DIFF: f64 = 0.5;
+    const ASYMMETRY: f64 = 0.25;
+    const BUG_MAGNET: f64 = 0.75;
+    const CHURN: f64 = 0.125;
+
+    fn signals(
+        diff: f64,
+        asymmetry: f64,
+        bug_magnet: f64,
+        churn: f64,
+    ) -> (DiffShape, TestAsymmetry, BugMagnet, Churn) {
+        (
+            DiffShape {
+                subscore: diff,
+                ..Default::default()
+            },
+            TestAsymmetry {
+                subscore: asymmetry,
+                ..Default::default()
+            },
+            BugMagnet {
+                subscore: bug_magnet,
+                ..Default::default()
+            },
+            Churn {
+                subscore: churn,
+                ..Default::default()
+            },
+        )
+    }
+
+    fn combined(diff: f64, asymmetry: f64, bug_magnet: f64, churn: f64) -> f64 {
+        let (d, a, b, c) = signals(diff, asymmetry, bug_magnet, churn);
+        combine(&d, &a, &b, &c)
+    }
+
+    /// Pins the whole formula to one number. Every arithmetic operator in
+    /// `combine` -- the four `*` and the three `+` -- moves this total off
+    /// 42.5 when substituted, so this single assertion is what stands
+    /// between the weighting structure and a silent rewrite.
+    #[test]
+    fn combine_is_the_documented_weighted_sum_of_the_four_subscores() {
+        assert_eq!(combined(DIFF, ASYMMETRY, BUG_MAGNET, CHURN), 42.5);
+    }
+
+    /// The 30/25/25/20 split is a documented product decision (see the
+    /// `WEIGHT_*` doc comments), not an implementation detail: test
+    /// asymmetry and bug magnet are deliberately equal, and diff shape
+    /// deliberately outranks both. Isolating one signal at a time pins each
+    /// weight to its own number so a reshuffle cannot pass by keeping the
+    /// total constant.
+    #[test]
+    fn each_signal_contributes_exactly_its_documented_weight() {
+        assert_eq!(combined(DIFF, 0.0, 0.0, 0.0), 15.0, "diff shape @ 30");
+        assert_eq!(combined(0.0, ASYMMETRY, 0.0, 0.0), 6.25, "asymmetry @ 25");
+        assert_eq!(
+            combined(0.0, 0.0, BUG_MAGNET, 0.0),
+            18.75,
+            "bug magnet @ 25"
+        );
+        assert_eq!(combined(0.0, 0.0, 0.0, CHURN), 2.5, "churn @ 20");
+    }
+
+    /// The module doc calls this "a single 0-100 score". Nothing tested that
+    /// claim: the weights summing to 100 is what makes it true, and a single
+    /// weight edit would have broken it silently.
+    #[test]
+    fn saturated_signals_score_exactly_one_hundred_and_idle_signals_score_zero() {
+        assert_eq!(combined(1.0, 1.0, 1.0, 1.0), 100.0);
+        assert_eq!(combined(0.0, 0.0, 0.0, 0.0), 0.0);
+    }
+
+    /// Five samples, three at or below the target: 3/5 -> 60. The asymmetric
+    /// split is deliberate -- with an even split, counting the samples
+    /// *above* the target would return the same percentile and the
+    /// comparison direction would go untested.
+    #[test]
+    fn compute_percentile_is_the_share_of_the_sample_at_or_below_the_target() {
+        let baseline = [10.0, 20.0, 30.0, 40.0, 50.0];
+
+        assert_eq!(compute_percentile(35.0, &baseline), 60);
+    }
+
+    /// `<=`, not `<`: a change that scores exactly as high as every sampled
+    /// commit is at the 100th percentile, not the 0th.
+    #[test]
+    fn a_score_matching_the_sample_counts_as_at_or_below_it() {
+        assert_eq!(compute_percentile(10.0, &[10.0, 10.0]), 100);
+        assert_eq!(compute_percentile(9.0, &[10.0, 10.0]), 0);
+    }
+
+    /// Documented fail-open: a brand-new repository has no history to
+    /// compare against, and a gate with no evidence must not manufacture a
+    /// high percentile out of an empty sample.
+    #[test]
+    fn an_empty_baseline_reports_zero_rather_than_an_undefined_percentile() {
+        assert_eq!(compute_percentile(99.0, &[]), 0);
+    }
+
+    /// Both thresholds pinned from both sides. These three strings are the
+    /// words a reviewer actually reads, and 90/60 are the numbers the PR
+    /// gate acts on -- issue #170 was a false "high" that no test objected
+    /// to.
+    #[test]
+    fn level_thresholds_hold_at_their_documented_boundaries() {
+        assert_eq!(level_for_percentile(0), "low");
+        assert_eq!(level_for_percentile(59), "low");
+        assert_eq!(level_for_percentile(60), "medium");
+        assert_eq!(level_for_percentile(89), "medium");
+        assert_eq!(level_for_percentile(90), "high");
+        assert_eq!(level_for_percentile(100), "high");
+    }
+
+    /// Half-cent rounding is half-away-from-zero (Rust's `f64::round`), and
+    /// an already-short value must not acquire trailing noise.
+    #[test]
+    fn round2_keeps_two_decimals() {
+        assert_eq!(round2(42.4949), 42.49);
+        assert_eq!(round2(42.495), 42.5);
+        assert_eq!(round2(42.5), 42.5);
+    }
+}


### PR DESCRIPTION
`change_risk/scoring.rs` 是 37 行算术，**决定每张 PR 被不被拦**，此前**没有任何直接单测**。

所有经过它的测试都走端到端路径，断言的是产物**形状**——字段在不在、schema 合不合法、数组空不空。没有一条断言**数值**。

## 证据：26 个存活变异体

`cargo mutants --file .../scoring.rs -- --bin code-intel`，判据 544 个单测，31 个可编译变异体，**26 个存活**：

```
replace combine -> f64 with 0.0                        四信号加权和恒返回 0
replace combine -> f64 with 1.0
replace compute_percentile -> u32 with 0               百分位恒为 0
replace level_for_percentile -> &'static str with ""   等级变空串
```

外加 `combine` 里 30/25/25/20 权重结构的**每一个** `+` / `*` 互换，以及 `compute_percentile` 里的 `/`↔`*`、`<=`↔`>`。**门禁对这些全部保持绿灯。**

这解释了 #170：那次 96 百分位假阻断的真因在 `signals.rs`，而下游 `scoring.rs` 把一个荒谬输入照单全收算成 `high`——**整条数值链从未被断言过**，所以没有任何一条测试对那个数字有意见。缺陷不是「漏了一个 case」。

## 8 条测试，每条钉一个具体数字

| 测试 | 钉住 |
| --- | --- |
| `combine_is_the_documented_weighted_sum_of_the_four_subscores` | 42.5 |
| `each_signal_contributes_exactly_its_documented_weight` | 15 / 6.25 / 18.75 / 2.5，锁住 30/25/25/20 |
| `saturated_signals_score_exactly_one_hundred_and_idle_signals_score_zero` | 模块文档「0-100 分」的声明 |
| `compute_percentile_is_the_share_of_the_sample_at_or_below_the_target` | 3/5 非对称样本 → 60 |
| `a_score_matching_the_sample_counts_as_at_or_below_it` | `<=` 而非 `<` |
| `an_empty_baseline_reports_zero_rather_than_an_undefined_percentile` | 文档化的 fail-open |
| `level_thresholds_hold_at_their_documented_boundaries` | 90 / 60 两侧各一次 |
| `round2_keeps_two_decimals` | 半分位舍入 |

### 输入取值是设计出来的，不是随手挑的

subscore 取 **互异、非零、非 1.0、二进制可精确表示**（1/2、1/4、3/4、1/8）：

- **非 1.0**——`w * 1.0` 与 `w / 1.0` 是同一个数，取 1.0 会让一整类算符替换测不出来。这正是一个没测过的公式藏身的方式。
- **互异**——任一 `*`→`+`/`/` 或 `+`→`-`/`*` 的替换都落在不同总和上。
- **精确可表示**——可以用 `==` 比较而不是 epsilon。epsilon 会重新放出这批测试正要收紧的余量。

30\*0.5=15，25\*0.25=6.25，25\*0.75=18.75，20\*0.125=2.5，合计 42.5，全部精确。

## 反证：重跑同一条命令

同一工具、同一 `--bin code-intel` 判据：

```
caught     35
missed      0
```

**`missed.txt` 为空。26 个存活体一个不剩。**

（本次报 35 个变异体、上次报 31 个可编译体，差额是 unviable 的归属统计口径；决定性的是 missed 从 26 条变成 0 条，两次同工具同判据，逐条可比。）

## 为什么放在 `scoring.rs` 内联而不是 `change_risk/tests.rs`

`change_risk/tests.rs` 当前 **25 函数 / 385 loc**。god file 判据是 `functions > 25 && loc > 400`——追加 8 条测试会同时越过两条阈值，**造出一个新的 god file**。这正是 #165 的坑。

`scoring.rs` 现为 **114 loc / 14 函数**，两条阈值都远未触及。内联 `mod tests` 也是本仓叶子文件的既有惯例（`admissibility.rs`、`capability.rs`、`artifact_ref.rs` 等）。

## 顺带

`mutants.out/` 加进 `.gitignore`。不忽略它会**扰动本仓自己的度量**：实测 `sentrux scan` 的 file-gate 候选数在跑变异测试期间从 32769 变成 32839。

## 门禁

| 项 | 结果 |
| --- | --- |
| `cargo fmt --check` | clean |
| `cargo test -p code-intel` | **3432 passed / 0 failed** |
| `repin`（提交后重跑） | clean，`filesChanged: 0`，无孤儿 pin |
| 反证 | 旧实现 26 存活 → 新实现 0 存活 |

PowerShell 侧本 PR 未本地跑：改动只有一个 Rust 文件的 `#[cfg(test)]` 代码，不碰 `.ps1`、不碰 schema、不碰 help 文本。交给 CI 判。

## 范围

只补 `scoring.rs`。同一次变异测试里 `change_risk/signals.rs` 是 40%、`change_risk/mod.rs` 53%，仍然没补——那些留在 #179 里。全仓变异基线要单独排期。

Refs #179 #170 #165 #55
