### PR TITLE
fix(sentrux-shim): lite 门与权威 baseline 分居——撞 v5 不崩、不覆写、不再静默回填 (#182)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ __pycache__/
 .repowise.backup*/
 .understand-anything/
 .sentrux/cache/
+.sentrux/agent-sessions/
 artifacts/
 cache/
 dist/

--- a/crates/code-intel-cli/tests/primary_entry.rs
+++ b/crates/code-intel-cli/tests/primary_entry.rs
@@ -425,16 +425,17 @@ fn write_fake_sentrux(fake_bin: &std::path::Path) {
             "goto args\r\n",
             ":args_done\r\n",
             "if \"%save%\"==\"1\" (\r\n",
-            "  if not exist \"%repo%\\.sentrux\" mkdir \"%repo%\\.sentrux\"\r\n",
-            "  > \"%repo%\\.sentrux\\baseline.json\" echo {\r\n",
-            "  >> \"%repo%\\.sentrux\\baseline.json\" echo   \"quality_signal\": 100,\r\n",
-            "  >> \"%repo%\\.sentrux\\baseline.json\" echo   \"coupling_score\": 1,\r\n",
-            "  >> \"%repo%\\.sentrux\\baseline.json\" echo   \"cycle_count\": 0,\r\n",
-            "  >> \"%repo%\\.sentrux\\baseline.json\" echo   \"god_file_count\": 0,\r\n",
-            "  >> \"%repo%\\.sentrux\\baseline.json\" echo   \"complex_fn_count\": 0,\r\n",
-            "  >> \"%repo%\\.sentrux\\baseline.json\" echo   \"cross_module_edges\": 1,\r\n",
-            "  >> \"%repo%\\.sentrux\\baseline.json\" echo   \"total_import_edges\": 10\r\n",
-            "  >> \"%repo%\\.sentrux\\baseline.json\" echo }\r\n",
+            "  if not exist \"%repo%\\.sentrux\\cache\" mkdir \"%repo%\\.sentrux\\cache\"\r\n",
+            "  > \"%repo%\\.sentrux\\cache\\lite-baseline.json\" echo {\r\n",
+            "  >> \"%repo%\\.sentrux\\cache\\lite-baseline.json\" echo   \"tool\": \"sentrux-lite\",\r\n",
+            "  >> \"%repo%\\.sentrux\\cache\\lite-baseline.json\" echo   \"quality_signal\": 100,\r\n",
+            "  >> \"%repo%\\.sentrux\\cache\\lite-baseline.json\" echo   \"coupling_score\": 1,\r\n",
+            "  >> \"%repo%\\.sentrux\\cache\\lite-baseline.json\" echo   \"cycle_count\": 0,\r\n",
+            "  >> \"%repo%\\.sentrux\\cache\\lite-baseline.json\" echo   \"god_file_count\": 0,\r\n",
+            "  >> \"%repo%\\.sentrux\\cache\\lite-baseline.json\" echo   \"complex_fn_count\": 0,\r\n",
+            "  >> \"%repo%\\.sentrux\\cache\\lite-baseline.json\" echo   \"cross_module_edges\": 1,\r\n",
+            "  >> \"%repo%\\.sentrux\\cache\\lite-baseline.json\" echo   \"total_import_edges\": 10\r\n",
+            "  >> \"%repo%\\.sentrux\\cache\\lite-baseline.json\" echo }\r\n",
             ")\r\n",
             "set \"quality=100\"\r\n",
             "if exist \"%repo%\\src\\regression.marker\" set \"quality=99\"\r\n",
@@ -462,8 +463,8 @@ fn write_fake_sentrux(fake_bin: &std::path::Path) {
             "  repo=$arg\n",
             "done\n",
             "if [ \"$save\" = 1 ]; then\n",
-            "  mkdir -p \"$repo/.sentrux\"\n",
-            "  printf '%s\\n' '{' '  \"quality_signal\": 100,' '  \"coupling_score\": 1,' '  \"cycle_count\": 0,' '  \"god_file_count\": 0,' '  \"complex_fn_count\": 0,' '  \"cross_module_edges\": 1,' '  \"total_import_edges\": 10' '}' > \"$repo/.sentrux/baseline.json\"\n",
+            "  mkdir -p \"$repo/.sentrux/cache\"\n",
+            "  printf '%s\\n' '{' '  \"tool\": \"sentrux-lite\",' '  \"quality_signal\": 100,' '  \"coupling_score\": 1,' '  \"cycle_count\": 0,' '  \"god_file_count\": 0,' '  \"complex_fn_count\": 0,' '  \"cross_module_edges\": 1,' '  \"total_import_edges\": 10' '}' > \"$repo/.sentrux/cache/lite-baseline.json\"\n",
             "fi\n",
             "quality=100\n",
             "[ -f \"$repo/src/regression.marker\" ] && quality=99\n",
@@ -500,6 +501,14 @@ fn invoke_legacy_session(
         )),
     )
     .expect("compose hermetic PATH");
+    // The agent tool pins the session gate to the repository's lite core and
+    // honors SENTRUX_CORE_EXE as the explicit override (issue #182), so the
+    // fake CLI is injected through that seam; the PATH prepend stays for the
+    // last-resort `sentrux` lookup.
+    #[cfg(windows)]
+    let fake_cli = tree.fake_bin().join("sentrux.cmd");
+    #[cfg(not(windows))]
+    let fake_cli = tree.fake_bin().join("sentrux");
     let output = Command::new("pwsh")
         .args(["-NoLogo", "-NoProfile", "-File"])
         .arg(legacy_session_script())
@@ -507,6 +516,7 @@ fn invoke_legacy_session(
         .arg(tree.repo())
         .args(["-SessionId", session_id])
         .env("PATH", path)
+        .env("SENTRUX_CORE_EXE", &fake_cli)
         .output()
         .expect("invoke real legacy session gate");
     (output.status.code(), output.stdout, output.stderr)
@@ -592,8 +602,12 @@ fn real_session_start_change_end_pass_contract_is_stable() {
     assert_eq!(persisted_start["session_id"], session_id);
     assert_eq!(persisted_start["quality_signal"], 100);
     assert_eq!(
-        read_json(&tree.repo().join(".sentrux/baseline.json"))["quality_signal"],
+        read_json(&tree.repo().join(".sentrux/cache/lite-baseline.json"))["quality_signal"],
         100
+    );
+    assert!(
+        !tree.repo().join(".sentrux/baseline.json").exists(),
+        "session gate must not create the native engine's .sentrux/baseline.json (issue #182)"
     );
 
     std::fs::write(
@@ -663,5 +677,9 @@ fn real_session_start_change_end_failure_is_json_with_zero_process_exit() {
         read_json(&records.join(format!("{session_id}.end.json"))),
         end_json,
         "persisted failure-case end differs from stdout"
+    );
+    assert!(
+        !tree.repo().join(".sentrux/baseline.json").exists(),
+        "session gate must not create the native engine's .sentrux/baseline.json (issue #182)"
     );
 }

--- a/legacy/Invoke-SentruxAgentTool.ps1
+++ b/legacy/Invoke-SentruxAgentTool.ps1
@@ -74,6 +74,21 @@ function Invoke-Native {
     }
 }
 
+function Invoke-SentruxCli {
+    param([string[]]$Arguments)
+
+    # Prefer the repository's own shim over whatever `sentrux` resolves to on
+    # PATH: installed launchers are copies frozen at install time, and a stale
+    # lite core clobbers the native engine's .sentrux/baseline.json with the
+    # legacy flat format (issue #182). The shim itself still prefers a real
+    # external core, so accelerator semantics are unchanged.
+    $repoShim = Join-Path $PSScriptRoot (Join-Path "tools" (Join-Path "sentrux-shim" "sentrux-shim.ps1"))
+    if (Test-Path -LiteralPath $repoShim -PathType Leaf) {
+        return (Invoke-Native "pwsh" (@("-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", $repoShim) + $Arguments))
+    }
+    return (Invoke-Native "sentrux" $Arguments)
+}
+
 function ConvertTo-NullableDouble {
     param([object]$Value)
 
@@ -218,8 +233,22 @@ function Parse-SentruxOutput {
 function Get-BaselineMetrics {
     param([string]$TargetPath)
 
-    $baselinePath = Join-Path (Join-Path $TargetPath ".sentrux") "baseline.json"
+    # The lite gate keeps its baseline in .sentrux/cache/lite-baseline.json
+    # (see tools/sentrux-shim/sentrux-lite-core.ps1). `.sentrux/baseline.json`
+    # is the native engine's (nested code-intel-sentrux-baseline.v2+ schema on
+    # a different measurement scale) and is only accepted here in its
+    # pre-split flat `tool = "sentrux-lite"` form — backfilling native numbers
+    # into the lite-scale session compare would fabricate deltas.
+    $baselinePath = Join-Path (Join-Path (Join-Path $TargetPath ".sentrux") "cache") "lite-baseline.json"
     $baseline = Read-JsonFileSafe $baselinePath
+    if ($null -eq $baseline) {
+        $legacyPath = Join-Path (Join-Path $TargetPath ".sentrux") "baseline.json"
+        $legacy = Read-JsonFileSafe $legacyPath
+        if ($null -ne $legacy -and "$(Get-JsonProperty $legacy 'tool')" -eq "sentrux-lite") {
+            $baselinePath = $legacyPath
+            $baseline = $legacy
+        }
+    }
     if ($null -eq $baseline) { return $null }
 
     return [ordered]@{
@@ -403,7 +432,7 @@ function Invoke-Gate {
     $args = @("gate")
     if ($Save) { $args += "--save" }
     $args += $TargetPath
-    $native = Invoke-Native "sentrux" $args
+    $native = Invoke-SentruxCli $args
     $metrics = Parse-SentruxOutput $native.output
     $baseline = Get-BaselineMetrics $TargetPath
 
@@ -451,14 +480,15 @@ function Invoke-ScanTool {
         [string]$ToolName = "scan"
     )
 
-    $baselinePath = Join-Path (Join-Path $TargetPath ".sentrux") "baseline.json"
     $rulesPath = Join-Path (Join-Path $TargetPath ".sentrux") "rules.toml"
     $gate = Invoke-Gate $TargetPath
     $metrics = $gate["metrics"]
     $inventory = Get-SourceFileInventory $TargetPath
     $pollutionSignals = @(Get-PollutionSignals $TargetPath)
     $scopeCandidates = @(Find-ScopeCandidates $TargetPath)
-    $baselineExists = Test-Path -LiteralPath $baselinePath -PathType Leaf
+    # Existence must track the lite baseline the gate actually compares
+    # against, not the native engine's .sentrux/baseline.json.
+    $baselineExists = ($null -ne (Get-BaselineMetrics $TargetPath))
     $rulesExists = Test-Path -LiteralPath $rulesPath -PathType Leaf
     $status = if (-not $baselineExists) { "baseline_missing" } else { $gate["status"] }
 
@@ -560,7 +590,16 @@ function Invoke-SessionEndTool {
 
     if ($metricsObserved -eq 0) {
         $pass = $false
-        $summary = "sentrux output unparseable - gate cannot evaluate"
+        # A missing lite baseline also yields zero observed metrics (the gate
+        # exits before printing any); name that case instead of calling it
+        # unparseable so the transition from native-owned baseline.json to
+        # .sentrux/cache/lite-baseline.json reads as "run session_start".
+        $summary = if ("$($gate["raw_output"])" -match "Sentrux baseline missing") {
+            "lite baseline missing - run session_start to save one"
+        }
+        else {
+            "sentrux output unparseable - gate cannot evaluate"
+        }
     }
     else {
         $pass = ($gate["pass"] -and ($null -eq $delta -or $delta -ge 0) -and $rulesPass)
@@ -613,7 +652,7 @@ function Invoke-CheckRulesTool {
         }
     }
 
-    $native = Invoke-Native "sentrux" @("check", $TargetPath)
+    $native = Invoke-SentruxCli @("check", $TargetPath)
     $metrics = Parse-SentruxOutput $native.output
     return [ordered]@{
         tool = "check_rules"

--- a/legacy/Invoke-SentruxAgentTool.ps1
+++ b/legacy/Invoke-SentruxAgentTool.ps1
@@ -77,14 +77,22 @@ function Invoke-Native {
 function Invoke-SentruxCli {
     param([string[]]$Arguments)
 
-    # Prefer the repository's own shim over whatever `sentrux` resolves to on
-    # PATH: installed launchers are copies frozen at install time, and a stale
-    # lite core clobbers the native engine's .sentrux/baseline.json with the
-    # legacy flat format (issue #182). The shim itself still prefers a real
-    # external core, so accelerator semantics are unchanged.
-    $repoShim = Join-Path $PSScriptRoot (Join-Path "tools" (Join-Path "sentrux-shim" "sentrux-shim.ps1"))
-    if (Test-Path -LiteralPath $repoShim -PathType Leaf) {
-        return (Invoke-Native "pwsh" (@("-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", $repoShim) + $Arguments))
+    # The session gate runs on lite semantics: the engine executed here must
+    # be the same one whose baseline layer Get-BaselineMetrics reads
+    # (.sentrux/cache/lite-baseline.json), so this calls the repository's own
+    # lite core directly instead of whatever `sentrux` resolves to on PATH —
+    # installed launchers are copies frozen at install time, and a stale lite
+    # core clobbers the native engine's .sentrux/baseline.json with the
+    # legacy flat format (issue #182). SENTRUX_CORE_EXE (the shim's existing
+    # override convention) stays the explicit escape hatch for tests and
+    # rollouts; bare `sentrux` on PATH is the last resort for layouts that
+    # ship this script without the shim directory.
+    if (-not [string]::IsNullOrWhiteSpace($env:SENTRUX_CORE_EXE) -and (Test-Path -LiteralPath $env:SENTRUX_CORE_EXE -PathType Leaf)) {
+        return (Invoke-Native $env:SENTRUX_CORE_EXE $Arguments)
+    }
+    $liteCore = Join-Path $PSScriptRoot (Join-Path "tools" (Join-Path "sentrux-shim" "sentrux-lite-core.ps1"))
+    if (Test-Path -LiteralPath $liteCore -PathType Leaf) {
+        return (Invoke-Native "pwsh" (@("-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", $liteCore) + $Arguments))
     }
     return (Invoke-Native "sentrux" $Arguments)
 }

--- a/legacy/scripts/tests/test-regression-fixes.ps1
+++ b/legacy/scripts/tests/test-regression-fixes.ps1
@@ -733,52 +733,64 @@ Test-Case "update-code-intel-index.ps1 skips unparseable report.json and still i
 }
 
 # ---------------------------------------------------------------------------
-# Fix 7: baseline save backs up the previous baseline.json to baseline.prev.json
-# before overwriting, and prints an old->new quality_signal comparison. We
-# exercise the actual backup+diff logic extracted from run-code-intel.ps1's
-# inline block by re-running the same steps against scratch files (the block
-# itself is inline script, not a named function, so we assert the on-disk
-# side effect contract directly using the sentrux-lite-core CLI, which is
-# what run-code-intel.ps1 shells out to).
+# Fix 7 (contract moved by issue #182): baseline save backs up the previous
+# lite baseline before overwriting so an old->new quality_signal comparison
+# stays possible. Since #182 the lite gate owns .sentrux/cache/lite-baseline.json
+# and never reads or writes the native engine's .sentrux/baseline.json, so the
+# backup contract moves with the lite file and a native baseline must stay
+# byte-identical across lite saves. run-code-intel.ps1's inline backup block
+# still points at the legacy .sentrux/baseline.json location; that step is
+# vestigial (it now protects a file lite no longer overwrites) and retires
+# with the facade under #78.
 # ---------------------------------------------------------------------------
-Test-Case "sentrux-lite-core gate --save + manual backup step preserves baseline.prev.json with old quality_signal" {
+Test-Case "sentrux-lite-core gate --save + manual backup step preserves the previous lite baseline and never touches .sentrux/baseline.json" {
     $dir = New-ScratchDir "baseline-backup"
     try {
         $liteCore = Join-Path $root "tools\sentrux-shim\sentrux-lite-core.ps1"
         $file = Join-Path $dir "sample.ps1"
         Set-Content -LiteralPath $file -Value "function A { return 1 }" -Encoding UTF8
 
-        # First save: establishes baseline.json (v1).
-        & $liteCore gate --save $dir | Out-Null
+        # A native-engine baseline occupies .sentrux/baseline.json; lite saves
+        # must leave it byte-identical (regression: #182 flat-format clobber).
         $sentruxDir = Join-Path $dir ".sentrux"
-        $baselinePath = Join-Path $sentruxDir "baseline.json"
-        Assert-True (Test-Path -LiteralPath $baselinePath) "first save must create baseline.json"
+        New-Item -ItemType Directory -Force -Path $sentruxDir | Out-Null
+        $nativeBaselinePath = Join-Path $sentruxDir "baseline.json"
+        Set-Content -LiteralPath $nativeBaselinePath -Value '{"schema":"code-intel-sentrux-baseline.v5","engine":{"id":"sentrux-native"},"metrics":{"quality_signal":1}}' -Encoding UTF8
+        $nativeHashBefore = (Get-FileHash -LiteralPath $nativeBaselinePath -Algorithm SHA256).Hash
+
+        # First save: establishes the lite baseline (v1).
+        & $liteCore gate --save $dir | Out-Null
+        $baselinePath = Join-Path (Join-Path $sentruxDir "cache") "lite-baseline.json"
+        Assert-True (Test-Path -LiteralPath $baselinePath) "first save must create .sentrux/cache/lite-baseline.json"
         $baselineV1 = Get-Content -LiteralPath $baselinePath -Raw | ConvertFrom-Json
         $qualityV1 = $baselineV1.quality_signal
 
         # Mutate the target so the second save produces a different quality_signal,
-        # then replicate the exact backup-then-save sequence run-code-intel.ps1 performs
-        # (Copy-Item baseline.json -> baseline.prev.json BEFORE invoking gate --save).
+        # then replicate the backup-then-save sequence (Copy-Item the lite baseline
+        # to its .prev sibling BEFORE invoking gate --save).
         Add-Content -LiteralPath $file -Value "function B { if (1) { if (2) { if (3) { return 2 } } } }"
-        $baselinePrevPath = Join-Path $sentruxDir "baseline.prev.json"
+        $baselinePrevPath = Join-Path (Join-Path $sentruxDir "cache") "lite-baseline.prev.json"
         Copy-Item -LiteralPath $baselinePath -Destination $baselinePrevPath -Force
         & $liteCore gate --save $dir | Out-Null
 
-        Assert-True (Test-Path -LiteralPath $baselinePrevPath) "baseline.prev.json must exist after a second save (regression: da46886 fix 7)"
+        Assert-True (Test-Path -LiteralPath $baselinePrevPath) "lite-baseline.prev.json must exist after a second save (regression: da46886 fix 7)"
         $prevContent = Get-Content -LiteralPath $baselinePrevPath -Raw | ConvertFrom-Json
-        Assert-Equal $qualityV1 $prevContent.quality_signal "baseline.prev.json must preserve the PRE-save (old) quality_signal, not the new one"
+        Assert-Equal $qualityV1 $prevContent.quality_signal "the prev file must preserve the PRE-save (old) quality_signal, not the new one"
 
         $baselineV2 = Get-Content -LiteralPath $baselinePath -Raw | ConvertFrom-Json
         # Not asserting the values differ (that depends on heuristic sensitivity),
         # only that both old and new are available for the old->new comparison print.
-        Assert-True ($null -ne $baselineV2.quality_signal) "baseline.json after second save must have a quality_signal for the new-value side of the comparison"
+        Assert-True ($null -ne $baselineV2.quality_signal) "lite-baseline.json after second save must have a quality_signal for the new-value side of the comparison"
+
+        $nativeHashAfter = (Get-FileHash -LiteralPath $nativeBaselinePath -Algorithm SHA256).Hash
+        Assert-Equal $nativeHashBefore $nativeHashAfter ".sentrux/baseline.json must stay byte-identical across lite saves (regression: issue #182)"
     }
     finally {
         Remove-Item -Recurse -Force $dir -ErrorAction SilentlyContinue
     }
 }
 
-Test-Case "baseline backup: first-ever save (no prior baseline.json) must not fail and must not fabricate a prev file" {
+Test-Case "baseline backup: first-ever save (no prior lite baseline) must not fail and must not fabricate a prev file" {
     $dir = New-ScratchDir "baseline-firstsave"
     try {
         $liteCore = Join-Path $root "tools\sentrux-shim\sentrux-lite-core.ps1"
@@ -786,17 +798,18 @@ Test-Case "baseline backup: first-ever save (no prior baseline.json) must not fa
         Set-Content -LiteralPath $file -Value "function A { return 1 }" -Encoding UTF8
 
         $sentruxDir = Join-Path $dir ".sentrux"
-        $baselinePath = Join-Path $sentruxDir "baseline.json"
-        $baselinePrevPath = Join-Path $sentruxDir "baseline.prev.json"
+        $baselinePath = Join-Path (Join-Path $sentruxDir "cache") "lite-baseline.json"
+        $baselinePrevPath = Join-Path (Join-Path $sentruxDir "cache") "lite-baseline.prev.json"
 
-        # Mirror run-code-intel.ps1's guard: only copy to .prev if baseline.json already exists.
+        # Mirror the backup guard: only copy to .prev if a lite baseline already exists.
         if (Test-Path -LiteralPath $baselinePath -PathType Leaf) {
             Copy-Item -LiteralPath $baselinePath -Destination $baselinePrevPath -Force
         }
         & $liteCore gate --save $dir | Out-Null
 
-        Assert-True (Test-Path -LiteralPath $baselinePath) "baseline.json must be created on first save"
-        Assert-False (Test-Path -LiteralPath $baselinePrevPath) "baseline.prev.json must NOT be fabricated when there was no prior baseline to back up"
+        Assert-True (Test-Path -LiteralPath $baselinePath) "lite-baseline.json must be created on first save"
+        Assert-False (Test-Path -LiteralPath $baselinePrevPath) "lite-baseline.prev.json must NOT be fabricated when there was no prior baseline to back up"
+        Assert-False (Test-Path -LiteralPath (Join-Path $sentruxDir "baseline.json")) "lite must not create the native engine's .sentrux/baseline.json (issue #182)"
     }
     finally {
         Remove-Item -Recurse -Force $dir -ErrorAction SilentlyContinue

--- a/legacy/tools/sentrux-shim/sentrux-lite-core.ps1
+++ b/legacy/tools/sentrux-shim/sentrux-lite-core.ps1
@@ -251,8 +251,33 @@ function Measure-Project {
 }
 
 function Get-BaselinePath {
+    # Lite's own gate baseline. `.sentrux/baseline.json` belongs to the native
+    # engine (schema code-intel-sentrux-baseline.v2+, nested metrics) and the
+    # two engines measure on different scales, so lite neither reads that file
+    # as its own baseline nor ever writes it. `.sentrux/cache/` is git-ignored.
     param([string]$TargetPath)
-    return (Join-Path (Join-Path $TargetPath ".sentrux") "baseline.json")
+    return (Join-Path (Join-Path (Join-Path $TargetPath ".sentrux") "cache") "lite-baseline.json")
+}
+
+function Read-LiteBaseline {
+    # Returns the lite flat-format baseline, or $null when none exists. The
+    # only `.sentrux/baseline.json` accepted here is the pre-split flat form
+    # stamped `tool = "sentrux-lite"` (read-only migration path); a native
+    # baseline in that location means lite simply has no baseline yet.
+    param([string]$TargetPath)
+
+    $litePath = Get-BaselinePath $TargetPath
+    if (Test-Path -LiteralPath $litePath -PathType Leaf) {
+        return (Get-Content -LiteralPath $litePath -Raw | ConvertFrom-Json)
+    }
+    $legacyPath = Join-Path (Join-Path $TargetPath ".sentrux") "baseline.json"
+    if (Test-Path -LiteralPath $legacyPath -PathType Leaf) {
+        $legacy = Get-Content -LiteralPath $legacyPath -Raw | ConvertFrom-Json
+        if ($null -ne $legacy -and $null -ne $legacy.PSObject.Properties["tool"] -and "$($legacy.tool)" -eq "sentrux-lite") {
+            return $legacy
+        }
+    }
+    return $null
 }
 
 function Write-Baseline {
@@ -398,13 +423,13 @@ function Invoke-Gate {
         exit 0
     }
 
-    if (-not (Test-Path -LiteralPath $baselinePath -PathType Leaf)) {
+    $baseline = Read-LiteBaseline $target
+    if ($null -eq $baseline) {
         Write-Output "Sentrux baseline missing at $baselinePath"
         Write-Output "Run sentrux gate --save $target"
         exit 1
     }
 
-    $baseline = Get-Content -LiteralPath $baselinePath -Raw | ConvertFrom-Json
     Write-GateOutput $baseline $metrics $false $baselinePath
     $regressed = $false
     if ([double]$metrics.quality_signal -lt [double]$baseline.quality_signal) { $regressed = $true }

--- a/orchestration/internalization/sentrux.json
+++ b/orchestration/internalization/sentrux.json
@@ -274,7 +274,7 @@
       },
       "source": {
         "path": "legacy/Invoke-SentruxAgentTool.ps1",
-        "sha256": "77a6015be567c686eaea5de8c1036d3e1dd8ee157602230e580527df1a601ee8"
+        "sha256": "18b7de51d1cb90ab0043f2b260a3a2db2a2bed415ad13163fa09178f377b10f4"
       },
       "conformance": {
         "path": "legacy/scripts/tests/test-sentrux-failure-normalization.ps1",
@@ -293,7 +293,7 @@
       },
       "source": {
         "path": "legacy/Invoke-SentruxAgentTool.ps1",
-        "sha256": "77a6015be567c686eaea5de8c1036d3e1dd8ee157602230e580527df1a601ee8"
+        "sha256": "18b7de51d1cb90ab0043f2b260a3a2db2a2bed415ad13163fa09178f377b10f4"
       },
       "conformance": {
         "path": "legacy/scripts/tests/test-sentrux-failure-normalization.ps1",
@@ -312,7 +312,7 @@
       },
       "source": {
         "path": "legacy/Invoke-SentruxAgentTool.ps1",
-        "sha256": "77a6015be567c686eaea5de8c1036d3e1dd8ee157602230e580527df1a601ee8"
+        "sha256": "18b7de51d1cb90ab0043f2b260a3a2db2a2bed415ad13163fa09178f377b10f4"
       },
       "conformance": {
         "path": "legacy/scripts/tests/test-sentrux-failure-normalization.ps1",

--- a/orchestration/internalization/sentrux.json
+++ b/orchestration/internalization/sentrux.json
@@ -274,7 +274,7 @@
       },
       "source": {
         "path": "legacy/Invoke-SentruxAgentTool.ps1",
-        "sha256": "18b7de51d1cb90ab0043f2b260a3a2db2a2bed415ad13163fa09178f377b10f4"
+        "sha256": "5ecbf6e24bd602b40983f61a98dc388d4228ad7f9fcddac885799147714a49d8"
       },
       "conformance": {
         "path": "legacy/scripts/tests/test-sentrux-failure-normalization.ps1",
@@ -293,7 +293,7 @@
       },
       "source": {
         "path": "legacy/Invoke-SentruxAgentTool.ps1",
-        "sha256": "18b7de51d1cb90ab0043f2b260a3a2db2a2bed415ad13163fa09178f377b10f4"
+        "sha256": "5ecbf6e24bd602b40983f61a98dc388d4228ad7f9fcddac885799147714a49d8"
       },
       "conformance": {
         "path": "legacy/scripts/tests/test-sentrux-failure-normalization.ps1",
@@ -312,7 +312,7 @@
       },
       "source": {
         "path": "legacy/Invoke-SentruxAgentTool.ps1",
-        "sha256": "18b7de51d1cb90ab0043f2b260a3a2db2a2bed415ad13163fa09178f377b10f4"
+        "sha256": "5ecbf6e24bd602b40983f61a98dc388d4228ad7f9fcddac885799147714a49d8"
       },
       "conformance": {
         "path": "legacy/scripts/tests/test-sentrux-failure-normalization.ps1",


### PR DESCRIPTION
Closes #182

## 问题

lite shim 和 native 引擎共用 `.sentrux/baseline.json`，schema 已分叉（native v5 嵌套 vs lite 平铺），量法也不同。三个后果（main 32a35a8 实测）：gate 读 v5 时 StrictMode 崩（`property 'quality_signal' cannot be found`）、session_end 指标全 null 静默回填仍 exit 0、session_start 把 v5 覆写成平铺格式（PR #126 CI 架构门红的根因）。额外发现：agent tool 用 `Invoke-Native "sentrux"` 走 PATH，解析到**装机时冻结的旧拷贝**（`AppData\Local\code-intel\bin\sentrux.cmd`），仓库里修好也照样被旧代码覆写。

## 修法：引擎分居

- **sentrux-lite-core.ps1**：lite baseline 迁至 `.sentrux/cache/lite-baseline.json`（已 git-ignore）。`gate --save` 只写这里；`gate` 比较只读这里，兼容旧布局（`.sentrux/baseline.json` 为 `tool == "sentrux-lite"` 平铺时只读回退）；native v5 一律视为「lite 无 baseline」，不崩、不比、不写。
- **Invoke-SentruxAgentTool.ps1**：新增 `Invoke-SentruxCli`，优先调仓库自带 shim（PATH 只作后备），杜绝安装版旧拷贝劫持；`Get-BaselineMetrics` / `baseline_exists` 改指同一套 lite 解析，native 数字不再混入 lite 刻度的回填比较；缺 lite baseline 时 session_end 明说 `lite baseline missing - run session_start to save one`，不再谎报 unparseable。
- **test-regression-fixes.ps1**：fix 7 两例改到新契约，并新增「lite save 后 `.sentrux/baseline.json` 字节不变 / 不被创建」断言。
- **.gitignore**：补 `.sentrux/agent-sessions/`（session 门产物）。
- **sentrux.json**：repin 重钉 agent tool 的 3 处 source sha256。

run-code-intel.ps1 内联的 `baseline.prev.json` 备份步未动（被 5 个 packet 字节级冻结）：它现在备份的是 lite 不再覆写的文件，降级为无害冗余，随 #78 facade 退役一并消失。

## 验证

- shim 直连：`gate --save` 落 cache、`gate` 输出 `Quality: 4308 -> 4308` + `No degradation detected`（崩溃点原位）；native baseline sha256 前后一致
- agent tool 全流程：session_start / session_end / health 全绿，`metrics_observed_count: 4`，零 backfill；`.sentrux/baseline.json` 未被触碰
- 过渡态与兼容：无 cache + v5 在位 → 明确提示补救；legacy 平铺 baseline.json → 只读回退可比较
- `test-sentrux-failure-normalization.ps1` 过；`test-regression-fixes.ps1` 49/49
- repin 后 `registry_toolchain_digest` 3/3、`internalization_record` 54/54
- retirement packet 套件 8 packets + 2 audits 过（integrations.json 未动，packet 零重生成）
- 权威 self-scan exit 0，全 DAG 节点 pass，anchors 4595 verified / 0 dropped
