### PR TITLE
feat(gate): agent 分支 PR 须 agent-approved label 才放行——draft 口头约定升级为机制

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -166,3 +166,33 @@ jobs:
         run: |
           echo "::error::change risk percentile ${{ steps.gate.outputs.percentile }} is at or above the ${RISK_PERCENTILE_BLOCK} threshold, and this PR does not carry the 'risk-accepted' label."
           exit 1
+
+  agent-gate:
+    # 编排 agent 推的分支(grok/**、agent/**、codex/**)必须由人点上
+    # `agent-approved` label 这个检查才绿。此前「agent PR 一律开 draft」只是
+    # 口头约定,合并权全靠记性;这里把它变成机制——label 是显式的人审动作,
+    # 配合 branch protection 的 required check 生效。labeled/unlabeled 已在
+    # 本 workflow 的触发类型里,点 label 即重跑。
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate agent label gate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          case "$HEAD_REF" in
+            grok/*|agent/*|codex/*) ;;
+            *)
+              echo "non-agent branch ($HEAD_REF) — gate not applicable"
+              exit 0
+              ;;
+          esac
+          APPROVED=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels \
+            --jq '[.labels[].name] | any(. == "agent-approved")')
+          if [ "$APPROVED" != "true" ]; then
+            echo "::error::agent branch '$HEAD_REF' needs the 'agent-approved' label (human review) before merge."
+            exit 1
+          fi
+          echo "agent-approved label present — gate green"


### PR DESCRIPTION
## 干什么

`pr-gate.yml` 新增 `agent-gate` job:head 分支匹配 `grok/**` / `agent/**` / `codex/**` 的 PR,必须带 `agent-approved` label(人点的)检查才绿;非 agent 分支直接通过。label 已建(`agent-approved`,绿色)。

## 为什么

#174 试点(PR #187)确认:本仓合并惯例是「绿灯即合」,而 agent PR 不误合的唯一防线是「记得开 draft」——口头约定,零机制。编排放量后这是必然事故点。本 job 把人审动作物化成 label,配合 branch protection required check(本 PR 合并后由维护者启用)形成真闸。

## 配套(合并后一步)

branch protection on `main`:required checks = `change-risk` + `agent-gate` + ci.yml 四个 job,`enforce_admins` 开。ci.yml `pull_request` 无 path 过滤,所有 PR 都会产生这些 check,不会有 docs-only PR 卡死问题。

## 验证

- 语法:actionlint 风格与现有 `change-risk` job 一致,复用同一触发集(`labeled`/`unlabeled` 已在,点 label 即重跑)。
- 行为验证在本 PR 无法自证(本分支非 agent 前缀,gate 走 not-applicable 分支);#187(`grok/**` 分支)将是第一个真实用例:未打 label 应红,打上应绿。

Refs #184
