### PR TITLE
release: v0.7.0-beta.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,31 @@ All notable changes to **code-intel-pipeline** are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.0-beta.6] — 2026-08-05
+
+这一批的主线是「门禁自己说的话得能被核对」：扫描面、锚点、巨石身份、退出码、schema 五处都从体感口径换成可计算口径——覆盖率不再靠感觉、锚点不再靠猜、巨石不再靠数数、gate finding 不再伪装成崩溃、产物不再违反自家 schema。另一条线是写路径的第一块落地（span 寻址补丁）和文档语言首选项。
 
 ### Added
 
 - **`code-intel edit apply` + `edit.span-apply` 能力：span 寻址补丁，终结"改一个字重写整行"**（#96 item 1、charter gate G4 #139）。`--span <startLine:startColumn-endLine:endColumn> --expect-sha256 <该 span 当前字节的 sha256> --replacement <text>`，行列 1-based、结束列开区间；同一文件可带多个互不重叠的 span，全部对改动前字节定位、写临时同级文件后 rename，整文件原子替换。写之前逐 span 比对 digest：不一致即拒绝（退出码 10、`applied:false`），产物给出 `expectedSha256` / `foundSha256` / 有界原文，且信封 `observedEffects` 不含 `repo_mutation`——"没写"是机器可校验的，不是自报的。写路径全程走既有 capability envelope（`edit.span-apply.compat`，`allowedEffects` 含 `repo_mutation`），能力自身在动手前先检查请求的 effectPolicy，把事后审计变成事前门。不含 ast-grep 接线（下一档）。
+- **锚点验证闸：三态 `verified` / `approximate` / `dropped` + 计数出账（#151）**。`run execute` 发布前新增一道锚点验证：文件锚点（路径是否还在）、行区间锚点、符号锚点（声称的名字能否在声称的 `file:startLine` 重新解析出来）——只在声称的那一个文件内找，不做全仓搜，解不出就是解不出。三态而非两态：`approximate` 表示同名符号还在同一文件、只是行漂了，带纠正后的行号；`dropped` 表示文件不在了或文件里再也找不到这个名字，带原因。状态类型仿 G1 的 `EvidenceOutcome`（#141）：`Approximate` 造不出来除非真带纠正行号，`Dropped` 造不出来除非真带 reason，`from_json` 对每个状态做穷尽 key 校验，把「只改 state 字段、留下另一状态残留字段」挡在反序列化边界上。
+- **扫描面具名排除闸门：覆盖率从体感变计算，38 个失踪文件归位（#152）**。`included_files: 315` 只列 2 条排除、38 个文件消失且无法归因，根因不是精度问题，是 `scan` 与 `dsm` 各自维护一套排除规则会悄悄漂移。用 `file_gate::evaluate` 实测定位到两个真实 bug：`dsm` 的 `excluded_reason` 只把 `tools`/`vendor`/`third_party`/`external` 当 `parts.first()` 检查，`legacy/tools/*` 这类嵌套路径对它不可见（本仓自扫一次贡献 39 个文件的分叉）；`dsm` 的 `SOURCE_EXTENSIONS` 漏了 `cpp`/`c`/`h`/`hpp`，命中文件在 dsm 里连「被排除」都算不上。排除判据统一到单一模块并从磁盘发现，每条排除具名出账。
+- **文档语言首选项：优先级链 + locale 默认 + 只在交互式才问（#155）**。新增 `crates/code-intel-cli/src/language_pref.rs`：`--language` 标志 > 项目配置 > 用户配置 > 系统 locale > `en`，链条声明为纯函数（`resolve_from`）并逐档单测，不读用户对话历史或其它文件去猜语言。项目级配置落在 `<repo>/.code-intel/config.json`（和 `.sentrux/`、`.understand-anything/` 同级的仓根点目录，不塞进 `.sentrux/` 内部——语言是管线级设置，不是质量闸门子系统私有的）；用户级落在平台 data root 下的 `config.json`，复用 `doctor_bootstrap::paths` 的三平台 OS switch。
 
 ### Fixed
 
 - **execution-result schema declared `additionalProperties: false` yet omitted the `failures` field it always emits (#168)**: every `code-intel run execute` output was invalid by its own schema; nothing caught it because the existing schema validation step does not enforce the closed-world bit. The schema now declares `failures` (`{process: [{node, diagnostic}], domain: [{node, verdict}]}`, shapes taken from `to_execution_json()` / `execution_kernel::failures()`, not invented) and lists it as required. A strict in-process key check now runs against a real `code-intel run execute` output in `dag_run.rs`, with a negative control proving an undeclared extra field turns it red. The 88-schema emitter sweep from #168 remains open.
 - **Exit-code semantics conflated gate findings with process failure (#130)**: `legacy/run-code-intel.ps1` exited `1` whenever `sentrux gate` reported architecture/quality debt (e.g. `god_files 23 -> 25`) in the target repo — identical to a genuine tool crash, even though every artifact was produced intact. Exit codes are now layered: `0` clean, `2` pipeline completed with Sentrux gate findings (see new `report.summary.gateFindings`), `1` the pipeline genuinely did not complete. Scoped to `sentrux gate` only; `sentrux check` keeps its prior behavior. See `docs/artifact-data-contract.md#exit-code-contract-issue-130`.
 - **God-file ratchet compared counts against a stale baseline — three real branches each shipped a new god file with every self-scan green (#165)**: the ratchet now compares file *identities*. `.sentrux/baseline.json` moves to schema v5 and records every tolerated god file by path with its measured loc/functions and the rule branch it trips; any god file the baseline does not list fails `god_files_increased`, and the violation names the file, the branch (`loc>800` or `functions>25&&loc>400`), and the measured values — files, not counts (#148 C1). Count slack and fix+regress swaps can no longer hide a new monolith. Baselines without the identity list fail closed as `baseline_engine_mismatch`. A green gate now also reports reclaimable slack ("N god file(s) no longer over threshold") since the gate itself never rewrites repository state. Decision recorded in `.sentrux/rules.toml`: test functions count toward the functions limit (option B) — the convention that tests live in a module directory's own `tests.rs` is what keeps production files under the limit; the cfg-aware alternative is explicitly rebutted there. The repository's 33 standing god files are grandfathered by identity, not amnestied.
+- **测试不对称信号不认本仓自己的 `tests.rs` 约定——96 百分位假阻断（#170）**：`is_test_file` 的三条判据全都漏掉内联测试模块约定（`change_risk/tests.rs`、`change_agenda/tests.rs`、`file_gate/tests.rs`：最后一段是 `tests.rs` 不是 `tests` 目录，文件名不以 `test_` 开头，词干 `tests` 不以 `_test` 结尾）。后果不是理论上的：PR #166 加了 229 行 `file_gate/tests.rs`，门禁却报「source changed, no tests touched」并以 96 百分位挡下它——而测试不对称是公式里权重最大的单项（`WEIGHT_TEST_ASYMMETRY = 25`）。
+- **sentrux shim 的 lite 门与权威 baseline 分居（#182）**：lite 门的缓存迁入 `.sentrux/cache`，撞上 baseline schema v5 不再崩、不再覆写权威 baseline、不再静默回填。session 门锁的 lite 语义直调 lite-core，`SENTRUX_CORE_EXE` 作为显式注入缝。
+- **测试临时目录按进程归属，不再只按时钟命名（#175）**：`switching_documentation_language_changes_only_the_language_field` 在 windows-latest 上偶发红——一条断言确定性的测试自己不确定，训练出「重跑一下就好」的假绿灯文化。机制是 `graph` 模块被 `#[path]` 编进 12 个集成测试二进制、由 cargo 当独立进程并行跑，而 `unique_temp_dir()` 的目录名只由 `SystemTime::now()` 决定（无 pid、无计数器）：两个进程观测到同一瞬间就拿到同一路径，先跑完的 `remove_dir_all` 掉另一个正在读的树。修法是结构性的——目录名带进程 id，跨进程碰撞从「不太可能」变成「不可能」。
+
+### Notes
+
+- `scoring.rs` 补数值单测，26 个存活变异体归零（#179）：8 条测试钉住离散取值，变异测试 caught 35 / missed 0。
+- agent 分支的 PR 须带 `agent-approved` label 才放行（#189）：draft 阶段的口头约定升级为 pr-gate 机制。
+- OpenSpec 内化记录核实入账（#156）：MIT + v1.7.0 证据落到文档。
 
 ## [0.7.0-beta.5] — 2026-08-04
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "code-intel"
-version = "0.7.0-beta.5"
+version = "0.7.0-beta.6"
 dependencies = [
  "serde_json",
 ]

--- a/crates/code-intel-cli/Cargo.toml
+++ b/crates/code-intel-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "code-intel"
-version = "0.7.0-beta.5"
+version = "0.7.0-beta.6"
 edition = "2021"
 description = "Local Code Intel Pipeline CLI for artifact resume and contract checks"
 license = "MIT"

--- a/crates/code-intel-cli/tests/fixtures/cli-head-parity.v2.json
+++ b/crates/code-intel-cli/tests/fixtures/cli-head-parity.v2.json
@@ -32,7 +32,7 @@
         "--json"
       ],
       "exitCode": 0,
-      "stdoutUtf8": "{\"name\":\"code-intel\",\"schema\":\"code-intel-version.v1\",\"version\":\"0.7.0-beta.5\"}\n",
+      "stdoutUtf8": "{\"name\":\"code-intel\",\"schema\":\"code-intel-version.v1\",\"version\":\"0.7.0-beta.6\"}\n",
       "stderrUtf8": ""
     },
     {
@@ -42,7 +42,7 @@
         "--json"
       ],
       "exitCode": 0,
-      "stdoutUtf8": "{\"name\":\"code-intel\",\"schema\":\"code-intel-version.v1\",\"version\":\"0.7.0-beta.5\"}\n",
+      "stdoutUtf8": "{\"name\":\"code-intel\",\"schema\":\"code-intel-version.v1\",\"version\":\"0.7.0-beta.6\"}\n",
       "stderrUtf8": ""
     },
     {

--- a/orchestration/toolchain-versions.v1.json
+++ b/orchestration/toolchain-versions.v1.json
@@ -93,7 +93,7 @@
     },
     {
       "name": "code-intel",
-      "version": "0.7.0-beta.5",
+      "version": "0.7.0-beta.6",
       "scope": "runtime",
       "required": true,
       "rationale": "The pipeline's own binary. An installed copy that lags the tree is invisible without a version surface: a v0.6.0 build answered `snapshot identity` in 10.9s where the current tree answers in 0.28s.",


### PR DESCRIPTION
剪 v0.7.0-beta.6：版本位同步 + CHANGELOG 补漏账。无行为变更，diff 只有版本字符串与 CHANGELOG。

## 改了什么

版本位五处，和 v0.7.0-beta.5 (#164) 完全同一组文件：

| 文件 | 改动 |
|---|---|
| `crates/code-intel-cli/Cargo.toml` | `0.7.0-beta.5` → `0.7.0-beta.6` |
| `Cargo.lock` | 随之刷新 |
| `crates/code-intel-cli/tests/fixtures/cli-head-parity.v2.json` | old + new 两份 `--version` stdout 同步（契约 id 不升版） |
| `orchestration/toolchain-versions.v1.json` | `code-intel` 条目，其 `declaredIn` 绑定 Cargo.toml |
| `CHANGELOG.md` | `[Unreleased]` → `[0.7.0-beta.6] — 2026-08-05` |

## CHANGELOG 的漏账

beta.5 之后 13 个 commit，只有 4 个进过 `[Unreleased]`。本次补写：

- **Added**：锚点验证闸三态 + 计数出账 (#151)、扫描面具名排除闸门 (#152)、文档语言首选项 (#155)
- **Fixed**：测试不对称信号认本仓 `tests.rs` 约定 (#170)、sentrux shim lite 门与权威 baseline 分居 (#182)、测试临时目录按进程归属 (#175)
- **Notes**：`scoring.rs` 变异测试补测 (#179)、agent 分支 `agent-approved` label 门 (#189)、OpenSpec 记录核实 (#156)

条目内容取自各 commit 正文，不是重新概括的。漏账本身是 #174 要解的 `[Unreleased]` 单行道税的现症，不是本次引入的。

## 发布前证据（本机，非 CI）

- `cargo test -p code-intel --locked`：**3432 passed / 0 failed**，55 个测试二进制
- `cli_head_parity` 3/3、`toolchain_versions` 5/5 —— 版本绑定判据
- `tests/test_repository_layout.py` 5/5、`tests/test_skill_package.py` 18/18 —— release job 的前两道
- 权威 self-scan（release 构建，`run execute --doctor-require-repowise false`）：`exitCode 0`，9 个节点全 `pass`，anchors **4596 verified / 0 approximate / 0 dropped**，`failures.process` 与 `failures.domain` 皆空

一个诚实标注：首轮全量 `cargo test` 以默认并行度跑，撞上宿主 `rustc-LLVM ERROR: out of memory`（本机 commit charge 贴顶，与 #123 bug 1 同因）。`-j 2` 复跑全绿——是环境限制，不是代码红灯。首轮我把输出管进了 `tail`，退出码取的是 `tail` 的 0，差点把这次 OOM 读成绿灯；重跑时改成先落盘再取退出码。

## 合并之后

合进 main 后打 `v0.7.0-beta.6` tag 推送，触发 `.github/workflows/release.yml`：三平台各自跑一遍权威 self-scan（release blocking）+ 打包后二进制的 `sentrux check` / `gate`，全过才由 publish job 发 Release 并出 provenance attestation。

这一版仍是 pre-release。GA 的卡点另算：#192（引用环判据把「引擎没跑起来」和「仓库有环」报成同一个红灯）、#148（149 条警告直通发布）、以及 #190 那三道闸补齐不变量。
