### PR TITLE
feat(compat): 判定命令防重放 invocation-identity 回显——宿主命令代理下回放可检

### DIFF
--- a/crates/code-intel-cli/src/capability.rs
+++ b/crates/code-intel-cli/src/capability.rs
@@ -981,7 +981,9 @@ fn now_seconds() -> u64 {
         .map(|v| v.as_secs())
         .unwrap_or(0)
 }
-fn rfc3339_now() -> String {
+// `pub(crate)` so `run_identity` reuses the same clock rendering instead of
+// keeping a second civil-calendar implementation in sync with this one.
+pub(crate) fn rfc3339_now() -> String {
     let s = now_seconds() as i64;
     let days = s.div_euclid(86400);
     let ds = s.rem_euclid(86400);

--- a/crates/code-intel-cli/src/cli/command_catalog/mod.rs
+++ b/crates/code-intel-cli/src/cli/command_catalog/mod.rs
@@ -6,8 +6,8 @@ use serde_json::{json, Value};
 use crate::{
     admissibility, artifact_index, audit_report, change_agenda, change_impact, change_risk,
     compatibility_retirement_ticket, decision_port, decision_record, doctor_bootstrap, edit_apply,
-    edit_impact, evidence_query, model_channels, ponytail_gate, providers, repin, run_cli,
-    run_commit, session_evidence, snapshot, survival_scan,
+    edit_impact, evidence_query, invocation_identity, model_channels, ponytail_gate, providers,
+    repin, run_cli, run_commit, session_evidence, snapshot, survival_scan,
 };
 
 use super::legacy::{
@@ -411,6 +411,9 @@ fn render_primary_summary(output: &Value) -> String {
 /// Private, explicit Phase-2 adapters. No controller can call this with argv;
 /// only a typed route ID and its catalog-sliced compatibility arguments arrive.
 fn execute_compatibility(command: CompatibilityCommand) -> i32 {
+    if let Some(label) = invocation_identity_label(command.route, &command.arguments) {
+        invocation_identity::emit(label);
+    }
     let raw = &command.arguments;
     match command.route {
         CompatibilityRoute::DoctorBootstrap => doctor_bootstrap::run_raw(raw),
@@ -448,6 +451,29 @@ fn execute_compatibility(command: CompatibilityCommand) -> i32 {
             run_cli::run_raw(raw)
         }
         CompatibilityRoute::Governance => ponytail_gate::run_raw(raw),
+    }
+}
+
+/// Verdict-producing routes echo an anti-replay identity line (#197) before
+/// their own output. Contract probes are catalog introspection, not verdicts,
+/// and the head-parity fixture byte-compares their stderr, so they stay
+/// silent. Doctor is excluded: its envelope contract asserts an empty stderr.
+fn invocation_identity_label(
+    route: CompatibilityRoute,
+    arguments: &[String],
+) -> Option<&'static str> {
+    if arguments
+        .iter()
+        .any(|argument| argument == "--contract-probe")
+    {
+        return None;
+    }
+    match route {
+        CompatibilityRoute::RunExecute => Some("run-execute"),
+        CompatibilityRoute::RunDagCoordinate => Some("run-dag-coordinate"),
+        CompatibilityRoute::Audit => Some("audit"),
+        CompatibilityRoute::Benchmark => Some("benchmark"),
+        _ => None,
     }
 }
 

--- a/crates/code-intel-cli/src/cli/command_catalog/tests.rs
+++ b/crates/code-intel-cli/src/cli/command_catalog/tests.rs
@@ -470,3 +470,44 @@ fn full_help_alias_discoverability_has_a_v2_output_contract() {
         }
     );
 }
+
+#[test]
+fn verdict_routes_carry_an_invocation_identity_label() {
+    let expectations = [
+        (CompatibilityRoute::RunExecute, "run-execute"),
+        (CompatibilityRoute::RunDagCoordinate, "run-dag-coordinate"),
+        (CompatibilityRoute::Audit, "audit"),
+        (CompatibilityRoute::Benchmark, "benchmark"),
+    ];
+    for (route, label) in expectations {
+        assert_eq!(
+            super::invocation_identity_label(route, &["--repo".into(), ".".into()]),
+            Some(label),
+            "{route:?}"
+        );
+    }
+}
+
+#[test]
+fn contract_probes_and_non_verdict_routes_stay_silent_for_invocation_identity() {
+    // The head-parity fixture byte-compares probe stderr; a per-invocation
+    // identity line there would make the fixture unrecordable.
+    assert_eq!(
+        super::invocation_identity_label(CompatibilityRoute::Audit, &["--contract-probe".into()]),
+        None
+    );
+    // Doctor's envelope contract asserts an empty stderr (doctor_envelope,
+    // doctor_bootstrap_cli); its identity has to ride inside the envelope.
+    for route in [
+        CompatibilityRoute::DoctorBootstrap,
+        CompatibilityRoute::Snapshot,
+        CompatibilityRoute::Repin,
+        CompatibilityRoute::ChangeImpact,
+    ] {
+        assert_eq!(
+            super::invocation_identity_label(route, &[]),
+            None,
+            "{route:?}"
+        );
+    }
+}

--- a/crates/code-intel-cli/src/invocation_identity.rs
+++ b/crates/code-intel-cli/src/invocation_identity.rs
@@ -1,0 +1,76 @@
+//! Anti-replay invocation identity for verdict-producing commands.
+//!
+//! Agent hosts increasingly wrap their shell in token-optimizing command
+//! proxies that may replay a cached capture when the same command line runs
+//! twice (#197). Exit code and stdout are replayed with it, so a verdict
+//! command cannot prove liveness through its verdict alone. The
+//! counter-measure is one stderr line whose bytes necessarily differ on
+//! every invocation: a replayed capture exposes itself by a repeated `id=`
+//! and a stale `at=` clock.
+//!
+//! Named "invocation identity", not "run identity": a manifest `runIdentity`
+//! is digest-derived and deterministically stable for the same content, while
+//! this line is nondeterministic by design — the two must never be conflated.
+//!
+//! stderr carries the line so no stdout JSON contract changes shape, and
+//! the line never enters manifests, reports, or digests, so artifact
+//! determinism contracts are unaffected. Doctor stays silent here: its
+//! envelope contract asserts an empty stderr, so its identity has to ride
+//! inside the envelope itself (tracked in #197).
+
+use std::process;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::capability::rfc3339_now;
+
+static SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+/// Writes the identity line straight to the process stderr stream, matching
+/// the direct-emission family of the compatibility routes that call it.
+pub(crate) fn emit(command_label: &str) {
+    eprintln!("{}", line(command_label));
+}
+
+fn line(command_label: &str) -> String {
+    format!(
+        "invocation-identity: command={command_label} id={} at={}",
+        unique_id(),
+        rfc3339_now()
+    )
+}
+
+/// Wall-clock nanoseconds, process id, and an in-process sequence number.
+/// Uniqueness is the only requirement — replay detection needs two
+/// invocations to differ, not cryptographic unforgeability.
+fn unique_id() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_nanos())
+        .unwrap_or(0);
+    let pid = process::id();
+    let sequence = SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    format!("{nanos:x}-{pid:x}-{sequence:x}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn line_carries_command_id_and_utc_clock() {
+        let line = line("audit");
+        assert!(
+            line.starts_with("invocation-identity: command=audit id="),
+            "{line}"
+        );
+        let at = line.split(" at=").nth(1).expect("at field");
+        assert_eq!(at.len(), "2026-08-06T00:00:00Z".len(), "{line}");
+        assert!(at.ends_with('Z'), "{line}");
+    }
+
+    #[test]
+    fn consecutive_lines_never_repeat() {
+        assert_ne!(line("run-execute"), line("run-execute"));
+    }
+}

--- a/crates/code-intel-cli/src/main.rs
+++ b/crates/code-intel-cli/src/main.rs
@@ -36,6 +36,7 @@ mod graph;
 mod hardened_git;
 mod hospital_score;
 mod impact_graph;
+mod invocation_identity;
 mod language_pref;
 mod method_catalog;
 mod model_channels;

--- a/docs/host-command-proxy-compat.md
+++ b/docs/host-command-proxy-compat.md
@@ -1,0 +1,62 @@
+# Host Command Proxy Compatibility
+
+Agent hosts increasingly wrap their shell in token-optimizing command proxies
+(e.g. RTK-style PreToolUse rewriters). Three behaviors of that layer threaten
+verdict integrity when `code-intel` runs under it:
+
+1. **Command rewriting.** The proxy substitutes "equivalent" tools with
+   different semantics (`grep` → `rg`, `find` → `fd`); a rewritten judgment
+   command may fail or judge something else.
+2. **Cache replay.** The proxy may answer a byte-identical command line with a
+   cached capture of an earlier run — stdout, stderr, and exit code together.
+   A fixed defect stays red, an unfixed one stays green, and nothing in a
+   replayed verdict says so.
+3. **Output filtering.** The proxy compresses or truncates output; a verdict
+   that exists only as stdout text can be dropped.
+
+## Standing defenses
+
+- **Verdicts ride exit codes.** `run execute` reports through exit codes
+  (`0`, `10` architecture/domain gate failure, `70` process failure, `73`
+  publication collision), as do the other gate commands. Output filtering
+  cannot change a verdict.
+- **Judgment invocations never repeat a command line.** `run execute`
+  requires a fresh `--out` directory and a unique `--final-name`; the
+  benchmark requires a fresh `--out`. Two honest invocations therefore never
+  share command-line bytes, so a byte-keyed cache cannot serve one for the
+  other. This uniqueness is part of the anti-replay contract, not an
+  accident of the publication design.
+- **Invocation-identity echo.** Verdict-producing commands (`run execute`,
+  `run dag-coordinate`, `audit`, `benchmark`) print one line to stderr before
+  any other output:
+
+  ```
+  invocation-identity: command=run-execute id=<nanos-pid-seq hex> at=<UTC RFC3339>
+  ```
+
+  This is deliberately not the manifest `runIdentity`: that identity is
+  digest-derived and stays stable for identical content, while this line is
+  nondeterministic by design — one names the artifact, the other proves the
+  invocation happened.
+
+  The bytes differ on every invocation. A replayed capture exposes itself by
+  a repeated `id=` or a stale `at=` clock. The line is stderr-only — no
+  stdout JSON contract changes shape — and it never enters manifests,
+  reports, or digests, so artifact determinism contracts are unaffected.
+  Contract probes (`--contract-probe`) stay silent: they are catalog
+  introspection, and the head-parity fixture byte-compares their streams.
+  `doctor` also stays silent for now — its envelope contract asserts an empty
+  stderr — so its identity has to ride inside the envelope itself (#197).
+
+## Guidance for proxy hosts
+
+- Trust exit codes, not prose, for pass/fail.
+- Run judgment commands through a pass-through channel (e.g. `rtk proxy`, or
+  a shell surface the proxy does not intercept) when the proxy caches or
+  rewrites.
+- When the same judgment command must run twice (test reruns, flake checks),
+  compare the `invocation-identity` lines: identical lines mean the second
+  run never happened.
+- Prefer recoverable compression (`repowise distill` / `expand`) over lossy
+  filtering for noisy command output; distilled output preserves exit codes
+  and every omitted line stays retrievable.


### PR DESCRIPTION
## 内容

#197 缺口 1 + 3 落地:判定子命令的防重放"invocation identity"回显 + 宿主命令代理兼容文档。

## 实现

- 新模块 `crates/code-intel-cli/src/invocation_identity.rs`:每次调用产出必然不同的一行
  `invocation-identity: command=<label> id=<nanos-pid-seq> at=<UTC RFC3339>`,
  复用 `capability.rs` 现有 `rfc3339_now()`(改为 `pub(crate)`),零新依赖。
- 发射点在 `command_catalog::execute_compatibility` 分发前,**只写 stderr**:
  不碰任何 stdout JSON 契约,不进 manifest/report/digest,artifact 确定性契约不受影响。
- 覆盖路由:`run execute` / `run dag-coordinate` / `audit` / `benchmark`。

## 关键取舍(与 #197 提案的偏差,已在 issue 留言)

- **命名 `invocation-identity` 而非 `run-identity`**:manifest 的 `runIdentity`
  是 digest 派生、同内容恒定;本行故意每次不同。两个概念方向相反,不能共用名字。
- **doctor 暂不发射**:`doctor_envelope` / `doctor_bootstrap_cli` 断言 stderr 为空是
  既有契约;doctor 的身份得走 envelope 字段,留在 #197。
- **`--contract-probe` 静默**:探针是目录自省不是判定,且 head-parity fixture 逐字节
  比对探针 stderr,发射会让 fixture 不可录制。
- **不含 snapshot identity 字段**:run execute 的 manifest 已携带权威 snapshot
  identity;在 doctor/benchmark 上现算一遍树快照对一行回显来说代价错配。

## 验证

- 新增 4 个单测(格式、唯一性、路由标签映射、probe/非判定路由静默)全绿。
- 实机 smoke:同命令两次运行 id 不同;`--contract-probe` 无发射;exit code 不变。
- `cargo fmt --check` / `cargo check --locked` / 全量 `cargo test -p code-intel --locked` 全绿。
- 权威 self-scan(release-gate parity)绿。
- 新文档 `docs/host-command-proxy-compat.md`:威胁模型(重写/缓存重放/输出过滤)、
  三条既有防线(exit-code 裁决、判定命令行唯一性、distill 可恢复压缩)、代理宿主指引。

Refs #197(缺口 2 的 `--nonce` 与 doctor envelope 身份仍留在 issue)
