### PR TITLE
refactor(artifact-ref): dedupe validators, split registered_contract, flatten conditionals

### DIFF
--- a/crates/code-intel-cli/src/artifact_ref.rs
+++ b/crates/code-intel-cli/src/artifact_ref.rs
@@ -259,15 +259,14 @@ fn diagnosis_family_contract(schema: &str, artifact_type: &str) -> Option<Artifa
             max_bytes: 8 * 1024 * 1024,
             validate_payload: validate_doctor_observation,
         }),
-        (
-            "code-intel-repository-survival-scan-result.v1",
-            "repository.survival-scan",
-        ) => Some(ArtifactContract {
-            artifact_schema: "code-intel-repository-survival-scan-result.v1",
-            artifact_type: "repository.survival-scan",
-            max_bytes: 8 * 1024 * 1024,
-            validate_payload: validate_survival_scan,
-        }),
+        ("code-intel-repository-survival-scan-result.v1", "repository.survival-scan") => {
+            Some(ArtifactContract {
+                artifact_schema: "code-intel-repository-survival-scan-result.v1",
+                artifact_type: "repository.survival-scan",
+                max_bytes: 8 * 1024 * 1024,
+                validate_payload: validate_survival_scan,
+            })
+        }
         ("code-intel-evidence-admissibility-result.v1", "evidence.admission") => {
             Some(ArtifactContract {
                 artifact_schema: "code-intel-evidence-admissibility-result.v1",
@@ -282,15 +281,14 @@ fn diagnosis_family_contract(schema: &str, artifact_type: &str) -> Option<Artifa
             max_bytes: 64 * 1024 * 1024,
             validate_payload: validate_evidence_payload,
         }),
-        (
-            "code-intel-sentrux-command-observation.v1",
-            "provider.sentrux.command-observation",
-        ) => Some(ArtifactContract {
-            artifact_schema: "code-intel-sentrux-command-observation.v1",
-            artifact_type: "provider.sentrux.command-observation",
-            max_bytes: 2 * 1024 * 1024,
-            validate_payload: validate_sentrux_command_observation,
-        }),
+        ("code-intel-sentrux-command-observation.v1", "provider.sentrux.command-observation") => {
+            Some(ArtifactContract {
+                artifact_schema: "code-intel-sentrux-command-observation.v1",
+                artifact_type: "provider.sentrux.command-observation",
+                max_bytes: 2 * 1024 * 1024,
+                validate_payload: validate_sentrux_command_observation,
+            })
+        }
         ("code-intel-hospital.v1", "diagnosis.hospital") => Some(ArtifactContract {
             artifact_schema: "code-intel-hospital.v1",
             artifact_type: "diagnosis.hospital",
@@ -352,15 +350,14 @@ fn orientation_family_contract(schema: &str, artifact_type: &str) -> Option<Arti
             max_bytes: 64 * 1024 * 1024,
             validate_payload: validate_orientation_benchmark_observations,
         }),
-        (
-            "code-intel-project-orientation-benchmark.v1",
-            "benchmark.orientation-report",
-        ) => Some(ArtifactContract {
-            artifact_schema: "code-intel-project-orientation-benchmark.v1",
-            artifact_type: "benchmark.orientation-report",
-            max_bytes: 8 * 1024 * 1024,
-            validate_payload: validate_orientation_benchmark_report,
-        }),
+        ("code-intel-project-orientation-benchmark.v1", "benchmark.orientation-report") => {
+            Some(ArtifactContract {
+                artifact_schema: "code-intel-project-orientation-benchmark.v1",
+                artifact_type: "benchmark.orientation-report",
+                max_bytes: 8 * 1024 * 1024,
+                validate_payload: validate_orientation_benchmark_report,
+            })
+        }
         (
             "code-intel-project-orientation-benchmark-markdown.v1",
             "benchmark.orientation-report-view",
@@ -469,15 +466,14 @@ fn run_delivery_family_contract(schema: &str, artifact_type: &str) -> Option<Art
                 validate_payload: validate_light_speed_report,
             })
         }
-        (
-            "code-intel-delivery-light-speed-markdown.v1",
-            "delivery.light-speed-report-view",
-        ) => Some(ArtifactContract {
-            artifact_schema: "code-intel-delivery-light-speed-markdown.v1",
-            artifact_type: "delivery.light-speed-report-view",
-            max_bytes: 1024 * 1024,
-            validate_payload: validate_light_speed_markdown,
-        }),
+        ("code-intel-delivery-light-speed-markdown.v1", "delivery.light-speed-report-view") => {
+            Some(ArtifactContract {
+                artifact_schema: "code-intel-delivery-light-speed-markdown.v1",
+                artifact_type: "delivery.light-speed-report-view",
+                max_bytes: 1024 * 1024,
+                validate_payload: validate_light_speed_markdown,
+            })
+        }
         _ => None,
     }
 }
@@ -1518,8 +1514,7 @@ fn validate_understanding_quadrant_identity(value: &Value) -> Result<(), String>
 fn understanding_quadrant_identity_is_valid(value: &Value) -> bool {
     let source_orientation_valid = value.pointer("/sourceOrientation/artifactSchema")
         == Some(&json!("code-intel-project-orientation.v1"))
-        && value.pointer("/sourceOrientation/artifactType")
-            == Some(&json!("project.orientation"))
+        && value.pointer("/sourceOrientation/artifactType") == Some(&json!("project.orientation"))
         && value
             .pointer("/sourceOrientation/sha256")
             .and_then(Value::as_str)
@@ -1814,7 +1809,9 @@ fn orientation_benchmark_report_is_valid(value: &Value) -> bool {
             .and_then(Value::as_u64)
             .is_some()
         && quality_metrics_in_range
-        && value["costCenters"].as_array().is_some_and(|v| !v.is_empty())
+        && value["costCenters"]
+            .as_array()
+            .is_some_and(|v| !v.is_empty())
 }
 
 fn validate_orientation_benchmark_markdown(bytes: &[u8]) -> Result<(), String> {
@@ -2208,7 +2205,9 @@ fn light_speed_report_is_valid(value: &Value) -> bool {
         && value["baseline"].is_object()
         && value["current"].is_object()
         && value["delta"].is_object()
-        && value["limitations"].as_array().is_some_and(|v| !v.is_empty())
+        && value["limitations"]
+            .as_array()
+            .is_some_and(|v| !v.is_empty())
 }
 
 fn validate_light_speed_markdown(bytes: &[u8]) -> Result<(), String> {
@@ -2878,7 +2877,8 @@ fn exact_object_keys(value: &Value, expected: &[&str], context: &str) -> Result<
     let object = value
         .as_object()
         .ok_or_else(|| format!("{context} must be an object"))?;
-    require_exact_keys(object, expected, context).map_err(|_| format!("{context} fields are invalid"))
+    require_exact_keys(object, expected, context)
+        .map_err(|_| format!("{context} fields are invalid"))
 }
 
 fn validate_survival_scan(bytes: &[u8]) -> Result<(), String> {

--- a/crates/code-intel-cli/src/artifact_ref.rs
+++ b/crates/code-intel-cli/src/artifact_ref.rs
@@ -547,17 +547,22 @@ fn validate_sentrux_command_observation(bytes: &[u8]) -> Result<(), String> {
         if !seen.insert(id) {
             return Err("Sentrux command ids must be unique".into());
         }
-        if (command["argv"] != json!(["sentrux", id, "."])
-            && command["argv"] != json!(["code-intel", "sentrux", id, "."]))
-            || (!command["exitCode"].is_null() && command["exitCode"].as_i64().is_none())
-            || !command["success"].is_boolean()
-            || !command["stdout"].is_string()
-            || !command["stderr"].is_string()
-        {
+        if !sentrux_command_result_is_valid(command, id) {
             return Err("Sentrux command result is invalid".into());
         }
     }
     Ok(())
+}
+
+fn sentrux_command_result_is_valid(command: &Value, id: &str) -> bool {
+    let known_argv = command["argv"] == json!(["sentrux", id, "."])
+        || command["argv"] == json!(["code-intel", "sentrux", id, "."]);
+    let exit_code_ok = command["exitCode"].is_null() || command["exitCode"].as_i64().is_some();
+    known_argv
+        && exit_code_ok
+        && command["success"].is_boolean()
+        && command["stdout"].is_string()
+        && command["stderr"].is_string()
 }
 
 fn validate_retirement_manifest(bytes: &[u8]) -> Result<(), String> {
@@ -830,24 +835,7 @@ fn validate_retirement_ticket_template(bytes: &[u8]) -> Result<(), String> {
         &["retirementDecision", "retirementManifest"],
         "ticket source",
     )?;
-    if value["schema"] != "code-intel-compatibility-retirement-ticket-template.v1"
-        || value["status"] != "draft"
-        || value["authorityBoundary"] != "template_only_no_approval_or_deletion_authority"
-        || [
-            "snapshotIdentity",
-            "ticketId",
-            "retirementId",
-            "owner",
-            "verifier",
-        ]
-        .iter()
-        .any(|key| !value[key].as_str().is_some_and(|v| !v.is_empty()))
-        || value["owner"] == value["verifier"]
-        || value["observationExpiry"].as_u64().is_none()
-        || !value["affectedFiles"]
-            .as_array()
-            .is_some_and(|v| !v.is_empty())
-    {
+    if !retirement_ticket_template_header_is_valid(&value) {
         return Err("retirement ticket template contract is invalid".into());
     }
     for key in ["capabilityId", "branchId", "callPath"] {
@@ -891,6 +879,27 @@ fn validate_retirement_ticket_template(bytes: &[u8]) -> Result<(), String> {
         "compatibility.retirement-manifest",
     )?;
     Ok(())
+}
+
+fn retirement_ticket_template_header_is_valid(value: &Value) -> bool {
+    let nonempty_identity_fields = [
+        "snapshotIdentity",
+        "ticketId",
+        "retirementId",
+        "owner",
+        "verifier",
+    ]
+    .iter()
+    .all(|key| value[key].as_str().is_some_and(|v| !v.is_empty()));
+    value["schema"] == "code-intel-compatibility-retirement-ticket-template.v1"
+        && value["status"] == "draft"
+        && value["authorityBoundary"] == "template_only_no_approval_or_deletion_authority"
+        && nonempty_identity_fields
+        && value["owner"] != value["verifier"]
+        && value["observationExpiry"].as_u64().is_some()
+        && value["affectedFiles"]
+            .as_array()
+            .is_some_and(|v| !v.is_empty())
 }
 
 fn validate_ticket_ref(value: &Value, schema: &str, kind: &str) -> Result<(), String> {
@@ -1306,17 +1315,20 @@ fn validate_surgery_plan_value(value: &Value) -> Result<(), String> {
         ],
         "surgery plan",
     )?;
-    if value["schema"] != "code-intel-surgery-plan.v1"
-        || !matches!(value["status"].as_str(), Some("planned" | "not_required"))
-        || !value["admission"].is_object()
-        || !value["primary_target"].is_object()
-        || !value["operating_plan"].is_array()
-        || !value["verification"].is_array()
-        || !value["discharge_criteria"].is_array()
-    {
+    if !surgery_plan_shape_is_valid(value) {
         return Err("surgery plan contract is invalid".into());
     }
     Ok(())
+}
+
+fn surgery_plan_shape_is_valid(value: &Value) -> bool {
+    value["schema"] == "code-intel-surgery-plan.v1"
+        && matches!(value["status"].as_str(), Some("planned" | "not_required"))
+        && value["admission"].is_object()
+        && value["primary_target"].is_object()
+        && value["operating_plan"].is_array()
+        && value["verification"].is_array()
+        && value["discharge_criteria"].is_array()
 }
 
 fn validate_hospital_markdown(bytes: &[u8]) -> Result<(), String> {
@@ -1352,25 +1364,7 @@ fn validate_project_orientation(bytes: &[u8]) -> Result<(), String> {
         ],
         "project orientation",
     )?;
-    if value["schema"] != "code-intel-project-orientation.v1"
-        || !value["snapshotIdentity"].as_str().is_some_and(valid_digest)
-        || !value["identity"].is_object()
-        || !value["purpose"].is_object()
-        || !value["languages"].is_array()
-        || !value["boundaries"].is_array()
-        || !value["entryPoints"].is_array()
-        || !value["commands"].is_array()
-        || !value["activeChange"].is_object()
-        || !value["evidenceAvailability"].is_array()
-        || !value["risks"].is_array()
-        || !value["unknowns"]
-            .as_array()
-            .is_some_and(|unknowns| !unknowns.is_empty())
-        || !matches!(
-            value.pointer("/confidence/level").and_then(Value::as_str),
-            Some("low" | "medium" | "high")
-        )
-    {
+    if !project_orientation_shape_is_valid(&value) {
         return Err("project orientation contract is invalid".into());
     }
     for (label, claim) in [
@@ -1395,6 +1389,27 @@ fn validate_project_orientation(bytes: &[u8]) -> Result<(), String> {
         }
     }
     Ok(())
+}
+
+fn project_orientation_shape_is_valid(value: &Value) -> bool {
+    value["schema"] == "code-intel-project-orientation.v1"
+        && value["snapshotIdentity"].as_str().is_some_and(valid_digest)
+        && value["identity"].is_object()
+        && value["purpose"].is_object()
+        && value["languages"].is_array()
+        && value["boundaries"].is_array()
+        && value["entryPoints"].is_array()
+        && value["commands"].is_array()
+        && value["activeChange"].is_object()
+        && value["evidenceAvailability"].is_array()
+        && value["risks"].is_array()
+        && value["unknowns"]
+            .as_array()
+            .is_some_and(|unknowns| !unknowns.is_empty())
+        && matches!(
+            value.pointer("/confidence/level").and_then(Value::as_str),
+            Some("low" | "medium" | "high")
+        )
 }
 
 fn validate_claim_provenance(value: &Value, label: &str) -> Result<(), String> {
@@ -1494,35 +1509,41 @@ fn validate_understanding_quadrant_shape(value: &Value) -> Result<(), String> {
 }
 
 fn validate_understanding_quadrant_identity(value: &Value) -> Result<(), String> {
-    if value["schema"] != "code-intel-understanding-quadrant.v1"
-        || !value["snapshotIdentity"].as_str().is_some_and(valid_digest)
-        || value.pointer("/sourceOrientation/artifactSchema")
-            != Some(&json!("code-intel-project-orientation.v1"))
-        || value.pointer("/sourceOrientation/artifactType") != Some(&json!("project.orientation"))
-        || !value
-            .pointer("/sourceOrientation/sha256")
-            .and_then(Value::as_str)
-            .is_some_and(valid_digest)
-        || value.pointer("/classificationPolicy/schema")
-            != Some(&json!("code-intel-understanding-quadrant-policy.v1"))
-        || value.pointer("/classificationPolicy/scoreRange/minimum") != Some(&json!(0))
-        || value.pointer("/classificationPolicy/scoreRange/maximum") != Some(&json!(100))
-        || value.pointer("/classificationPolicy/systemCriticalityThreshold") != Some(&json!(50))
-        || value.pointer("/classificationPolicy/evidenceConfidenceThreshold") != Some(&json!(50))
-        || value.pointer("/classificationPolicy/thresholdRule")
-            != Some(&json!("greater_than_or_equal_is_upper_band"))
-        || value.pointer("/classificationPolicy/unknownCriticalityRule")
-            != Some(&json!(
-                "critical_by_default_except_declared_supporting_context"
-            ))
-        || value.pointer("/classificationPolicy/methodConsumerPolicy")
-            != Some(&json!(
-                "C01_cards_and_C02_selection_may_consume_but_cannot_rewrite"
-            ))
-    {
+    if !understanding_quadrant_identity_is_valid(value) {
         return Err("understanding quadrant identity/policy contract is invalid".into());
     }
     Ok(())
+}
+
+fn understanding_quadrant_identity_is_valid(value: &Value) -> bool {
+    let source_orientation_valid = value.pointer("/sourceOrientation/artifactSchema")
+        == Some(&json!("code-intel-project-orientation.v1"))
+        && value.pointer("/sourceOrientation/artifactType")
+            == Some(&json!("project.orientation"))
+        && value
+            .pointer("/sourceOrientation/sha256")
+            .and_then(Value::as_str)
+            .is_some_and(valid_digest);
+    let classification_policy_valid = value.pointer("/classificationPolicy/schema")
+        == Some(&json!("code-intel-understanding-quadrant-policy.v1"))
+        && value.pointer("/classificationPolicy/scoreRange/minimum") == Some(&json!(0))
+        && value.pointer("/classificationPolicy/scoreRange/maximum") == Some(&json!(100))
+        && value.pointer("/classificationPolicy/systemCriticalityThreshold") == Some(&json!(50))
+        && value.pointer("/classificationPolicy/evidenceConfidenceThreshold") == Some(&json!(50))
+        && value.pointer("/classificationPolicy/thresholdRule")
+            == Some(&json!("greater_than_or_equal_is_upper_band"))
+        && value.pointer("/classificationPolicy/unknownCriticalityRule")
+            == Some(&json!(
+                "critical_by_default_except_declared_supporting_context"
+            ))
+        && value.pointer("/classificationPolicy/methodConsumerPolicy")
+            == Some(&json!(
+                "C01_cards_and_C02_selection_may_consume_but_cannot_rewrite"
+            ));
+    value["schema"] == "code-intel-understanding-quadrant.v1"
+        && value["snapshotIdentity"].as_str().is_some_and(valid_digest)
+        && source_orientation_valid
+        && classification_policy_valid
 }
 
 fn validate_understanding_quadrant_items(
@@ -1662,21 +1683,7 @@ fn validate_orientation_benchmark_observations(bytes: &[u8]) -> Result<(), Strin
         ],
         "orientation benchmark observations",
     )?;
-    if value["schema"] != "code-intel-project-orientation-benchmark-observations.v1"
-        || !value["snapshotIdentity"].as_str().is_some_and(valid_digest)
-        || value.pointer("/method/clock") != Some(&Value::String("std::time::Instant".into()))
-        || value.pointer("/method/execution")
-            != Some(&Value::String("sequential_child_process".into()))
-        || value.pointer("/method/concurrency").and_then(Value::as_u64) != Some(1)
-        || value.pointer("/method/llm") != Some(&Value::String("disabled".into()))
-        || value
-            .pointer("/environment/cleanMachine")
-            .and_then(Value::as_bool)
-            != Some(false)
-        || value["fixtures"]
-            .as_array()
-            .map_or(true, |items| items.len() != 9)
-    {
+    if !orientation_benchmark_observations_header_is_valid(&value) {
         return Err("orientation benchmark observation contract is invalid".into());
     }
     for fixture in value["fixtures"].as_array().unwrap() {
@@ -1731,6 +1738,23 @@ fn validate_orientation_benchmark_observations(bytes: &[u8]) -> Result<(), Strin
     Ok(())
 }
 
+fn orientation_benchmark_observations_header_is_valid(value: &Value) -> bool {
+    value["schema"] == "code-intel-project-orientation-benchmark-observations.v1"
+        && value["snapshotIdentity"].as_str().is_some_and(valid_digest)
+        && value.pointer("/method/clock") == Some(&Value::String("std::time::Instant".into()))
+        && value.pointer("/method/execution")
+            == Some(&Value::String("sequential_child_process".into()))
+        && value.pointer("/method/concurrency").and_then(Value::as_u64) == Some(1)
+        && value.pointer("/method/llm") == Some(&Value::String("disabled".into()))
+        && value
+            .pointer("/environment/cleanMachine")
+            .and_then(Value::as_bool)
+            == Some(false)
+        && value["fixtures"]
+            .as_array()
+            .is_some_and(|items| items.len() == 9)
+}
+
 fn validate_orientation_benchmark_report(bytes: &[u8]) -> Result<(), String> {
     let text = std::str::from_utf8(bytes)
         .map_err(|error| format!("orientation benchmark report is not UTF-8: {error}"))?;
@@ -1754,39 +1778,43 @@ fn validate_orientation_benchmark_report(bytes: &[u8]) -> Result<(), String> {
         ],
         "orientation benchmark report",
     )?;
-    if value["schema"] != "code-intel-project-orientation-benchmark.v1"
-        || !matches!(value["verdict"].as_str(), Some("pass" | "fail"))
-        || value.pointer("/target/llm") != Some(&Value::String("disabled".into()))
-        || value
-            .pointer("/latency/typical/p50WallTimeMs")
-            .and_then(Value::as_u64)
-            .is_none()
-        || value
-            .pointer("/latency/typical/p95WallTimeMs")
-            .and_then(Value::as_u64)
-            .is_none()
-        || value
-            .pointer("/artifactSize/typical/p95Bytes")
-            .and_then(Value::as_u64)
-            .is_none()
-        || [
-            "fieldCorrectness",
-            "unresolvedCoverage",
-            "unsupportedCoverage",
-            "deterministicReplayRate",
-            "provenanceCompleteness",
-        ]
-        .into_iter()
-        .any(|field| {
-            value["quality"][field]
-                .as_f64()
-                .is_none_or(|metric| !(0.0..=1.0).contains(&metric))
-        })
-        || value["costCenters"].as_array().is_none_or(Vec::is_empty)
-    {
+    if !orientation_benchmark_report_is_valid(&value) {
         return Err("orientation benchmark report contract is invalid".into());
     }
     Ok(())
+}
+
+fn orientation_benchmark_report_is_valid(value: &Value) -> bool {
+    let quality_metrics_in_range = [
+        "fieldCorrectness",
+        "unresolvedCoverage",
+        "unsupportedCoverage",
+        "deterministicReplayRate",
+        "provenanceCompleteness",
+    ]
+    .into_iter()
+    .all(|field| {
+        value["quality"][field]
+            .as_f64()
+            .is_some_and(|metric| (0.0..=1.0).contains(&metric))
+    });
+    value["schema"] == "code-intel-project-orientation-benchmark.v1"
+        && matches!(value["verdict"].as_str(), Some("pass" | "fail"))
+        && value.pointer("/target/llm") == Some(&Value::String("disabled".into()))
+        && value
+            .pointer("/latency/typical/p50WallTimeMs")
+            .and_then(Value::as_u64)
+            .is_some()
+        && value
+            .pointer("/latency/typical/p95WallTimeMs")
+            .and_then(Value::as_u64)
+            .is_some()
+        && value
+            .pointer("/artifactSize/typical/p95Bytes")
+            .and_then(Value::as_u64)
+            .is_some()
+        && quality_metrics_in_range
+        && value["costCenters"].as_array().is_some_and(|v| !v.is_empty())
 }
 
 fn validate_orientation_benchmark_markdown(bytes: &[u8]) -> Result<(), String> {
@@ -1940,25 +1968,28 @@ fn validate_repository_iteration_provenance(bytes: &[u8]) -> Result<(), String> 
         &["component", "contract", "version"],
         "repository iteration producer",
     )?;
-    if value["schema"] != REPOSITORY_ITERATION_SCHEMA
-        || value["purpose"] != REPOSITORY_ITERATION_PURPOSE
-        || !value["runIdentity"]
-            .as_str()
-            .is_some_and(valid_run_identity)
-        || !value["snapshotIdentity"].as_str().is_some_and(valid_digest)
-        || !value["repositoryKey"]
-            .as_str()
-            .is_some_and(valid_authority_name)
-        || !value["publicationName"]
-            .as_str()
-            .is_some_and(valid_authority_name)
-        || value["producer"]["component"] != REPOSITORY_ITERATION_PRODUCER_COMPONENT
-        || value["producer"]["contract"] != REPOSITORY_ITERATION_PRODUCER_CONTRACT
-        || value["producer"]["version"] != REPOSITORY_ITERATION_PRODUCER_VERSION
-    {
+    if !repository_iteration_provenance_is_valid(&value) {
         return Err("repository iteration provenance contract is invalid".into());
     }
     Ok(())
+}
+
+fn repository_iteration_provenance_is_valid(value: &Value) -> bool {
+    value["schema"] == REPOSITORY_ITERATION_SCHEMA
+        && value["purpose"] == REPOSITORY_ITERATION_PURPOSE
+        && value["runIdentity"]
+            .as_str()
+            .is_some_and(valid_run_identity)
+        && value["snapshotIdentity"].as_str().is_some_and(valid_digest)
+        && value["repositoryKey"]
+            .as_str()
+            .is_some_and(valid_authority_name)
+        && value["publicationName"]
+            .as_str()
+            .is_some_and(valid_authority_name)
+        && value["producer"]["component"] == REPOSITORY_ITERATION_PRODUCER_COMPONENT
+        && value["producer"]["contract"] == REPOSITORY_ITERATION_PRODUCER_CONTRACT
+        && value["producer"]["version"] == REPOSITORY_ITERATION_PRODUCER_VERSION
 }
 
 fn validate_method_catalog(bytes: &[u8]) -> Result<(), String> {
@@ -2060,17 +2091,7 @@ fn validate_run_timing_events(bytes: &[u8]) -> Result<(), String> {
         &["mode", "clock", "externalPlatform"],
         "run timing telemetry",
     )?;
-    if value["schema"] != "code-intel-run-timing-events.v1"
-        || !value["measurementSnapshotIdentity"]
-            .as_str()
-            .is_some_and(valid_digest)
-        || value.pointer("/telemetry/mode") != Some(&Value::String("local_opt_in".into()))
-        || value.pointer("/telemetry/clock") != Some(&Value::String("monotonic_elapsed_ms".into()))
-        || value
-            .pointer("/telemetry/externalPlatform")
-            .and_then(Value::as_bool)
-            != Some(false)
-    {
+    if !run_timing_telemetry_policy_is_valid(&value) {
         return Err("run timing telemetry policy is invalid".into());
     }
     for label in ["baseline", "current"] {
@@ -2103,33 +2124,49 @@ fn validate_run_timing_events(bytes: &[u8]) -> Result<(), String> {
                 ],
                 "run timing event",
             )?;
-            let start = event["startedAtMs"].as_u64();
-            let end = event["completedAtMs"].as_u64();
-            if event["id"].as_str().is_none_or(str::is_empty)
-                || event["subject"].as_str().is_none_or(str::is_empty)
-                || !matches!(
-                    event["kind"].as_str(),
-                    Some(
-                        "technical_work"
-                            | "test"
-                            | "verification"
-                            | "queue"
-                            | "handoff"
-                            | "understanding"
-                            | "rework"
-                            | "coordination"
-                    )
-                )
-                || start.is_none()
-                || end.zip(start).is_none_or(|(end, start)| end <= start)
-                || event["mandatory"].as_bool().is_none()
-                || !event["predecessors"].is_array()
-            {
+            if !run_timing_event_is_valid(event) {
                 return Err("run timing event contract is invalid".into());
             }
         }
     }
     Ok(())
+}
+
+fn run_timing_telemetry_policy_is_valid(value: &Value) -> bool {
+    value["schema"] == "code-intel-run-timing-events.v1"
+        && value["measurementSnapshotIdentity"]
+            .as_str()
+            .is_some_and(valid_digest)
+        && value.pointer("/telemetry/mode") == Some(&Value::String("local_opt_in".into()))
+        && value.pointer("/telemetry/clock") == Some(&Value::String("monotonic_elapsed_ms".into()))
+        && value
+            .pointer("/telemetry/externalPlatform")
+            .and_then(Value::as_bool)
+            == Some(false)
+}
+
+fn run_timing_event_is_valid(event: &Value) -> bool {
+    let start = event["startedAtMs"].as_u64();
+    let end = event["completedAtMs"].as_u64();
+    event["id"].as_str().is_some_and(|v| !v.is_empty())
+        && event["subject"].as_str().is_some_and(|v| !v.is_empty())
+        && matches!(
+            event["kind"].as_str(),
+            Some(
+                "technical_work"
+                    | "test"
+                    | "verification"
+                    | "queue"
+                    | "handoff"
+                    | "understanding"
+                    | "rework"
+                    | "coordination"
+            )
+        )
+        && start.is_some()
+        && end.zip(start).is_some_and(|(end, start)| end > start)
+        && event["mandatory"].as_bool().is_some()
+        && event["predecessors"].is_array()
 }
 
 fn validate_light_speed_report(bytes: &[u8]) -> Result<(), String> {
@@ -2153,22 +2190,25 @@ fn validate_light_speed_report(bytes: &[u8]) -> Result<(), String> {
         ],
         "light-speed report",
     )?;
-    if value["schema"] != "code-intel-delivery-light-speed.v1"
-        || !value["measurementSnapshotIdentity"]
-            .as_str()
-            .is_some_and(valid_digest)
-        || value["authority"] != "derived_measurement_no_schedule_commitment"
-        || !value["rules"]
-            .as_array()
-            .is_some_and(|rules| rules.len() == 7)
-        || !value["baseline"].is_object()
-        || !value["current"].is_object()
-        || !value["delta"].is_object()
-        || value["limitations"].as_array().is_none_or(Vec::is_empty)
-    {
+    if !light_speed_report_is_valid(&value) {
         return Err("light-speed report contract is invalid".into());
     }
     Ok(())
+}
+
+fn light_speed_report_is_valid(value: &Value) -> bool {
+    value["schema"] == "code-intel-delivery-light-speed.v1"
+        && value["measurementSnapshotIdentity"]
+            .as_str()
+            .is_some_and(valid_digest)
+        && value["authority"] == "derived_measurement_no_schedule_commitment"
+        && value["rules"]
+            .as_array()
+            .is_some_and(|rules| rules.len() == 7)
+        && value["baseline"].is_object()
+        && value["current"].is_object()
+        && value["delta"].is_object()
+        && value["limitations"].as_array().is_some_and(|v| !v.is_empty())
 }
 
 fn validate_light_speed_markdown(bytes: &[u8]) -> Result<(), String> {
@@ -3018,14 +3058,7 @@ fn validate_inventory(bytes: &[u8]) -> Result<(), String> {
 }
 
 fn portable_relative_path(value: &str) -> Result<String, ArtifactError> {
-    if value.is_empty()
-        || value.contains('\0')
-        || value.contains('\\')
-        || value.starts_with('/')
-        || value.starts_with("//")
-        || value.contains(':')
-        || value.split('/').any(|component| component.is_empty())
-    {
+    if !path_syntax_is_portable(value) {
         return Err(ArtifactError::Contract(
             "Artifact Ref path is not portable root-relative syntax".to_string(),
         ));
@@ -3046,14 +3079,7 @@ fn portable_relative_path(value: &str) -> Result<String, ArtifactError> {
                 ))
             }
         };
-        if name.is_empty()
-            || name.ends_with('.')
-            || name.ends_with(' ')
-            || name
-                .chars()
-                .any(|character| ('\u{0300}'..='\u{036f}').contains(&character))
-            || windows_reserved(name)
-        {
+        if !path_component_is_unambiguous(name) {
             return Err(ArtifactError::Contract(
                 "Artifact Ref path contains a Windows-ambiguous component".to_string(),
             ));
@@ -3066,6 +3092,26 @@ fn portable_relative_path(value: &str) -> Result<String, ArtifactError> {
         ));
     }
     Ok(normalized.join("/"))
+}
+
+fn path_syntax_is_portable(value: &str) -> bool {
+    !value.is_empty()
+        && !value.contains('\0')
+        && !value.contains('\\')
+        && !value.starts_with('/')
+        && !value.starts_with("//")
+        && !value.contains(':')
+        && value.split('/').all(|component| !component.is_empty())
+}
+
+fn path_component_is_unambiguous(name: &str) -> bool {
+    !name.is_empty()
+        && !name.ends_with('.')
+        && !name.ends_with(' ')
+        && !name
+            .chars()
+            .any(|character| ('\u{0300}'..='\u{036f}').contains(&character))
+        && !windows_reserved(name)
 }
 
 fn windows_reserved(name: &str) -> bool {

--- a/crates/code-intel-cli/src/artifact_ref.rs
+++ b/crates/code-intel-cli/src/artifact_ref.rs
@@ -1582,7 +1582,7 @@ fn validate_understanding_quadrant_item(
     Ok((id.to_string(), expected.2, source_state == Some("unknown")))
 }
 
-fn expected_understanding_quadrant(
+pub(crate) fn expected_understanding_quadrant(
     criticality: u64,
     confidence: u64,
 ) -> (&'static str, &'static str, &'static str) {

--- a/crates/code-intel-cli/src/artifact_ref.rs
+++ b/crates/code-intel-cli/src/artifact_ref.rs
@@ -196,120 +196,147 @@ pub(crate) fn verify_artifact_ref(
 }
 
 pub(crate) fn registered_contract(artifact: &Value) -> Result<ArtifactContract, ArtifactError> {
-    match (
+    let (Some(schema), Some(artifact_type)) = (
         artifact.get("artifactSchema").and_then(Value::as_str),
         artifact.get("type").and_then(Value::as_str),
-    ) {
-        (Some(REPOSITORY_ITERATION_SCHEMA), Some(REPOSITORY_ITERATION_TYPE)) => {
-            Ok(ArtifactContract {
-                artifact_schema: REPOSITORY_ITERATION_SCHEMA,
-                artifact_type: REPOSITORY_ITERATION_TYPE,
-                max_bytes: 64 * 1024,
-                validate_payload: validate_repository_iteration_provenance,
-            })
-        }
-        (Some("code-intel-file-inventory.v1"), Some("inventory.files")) => Ok(ArtifactContract {
+    ) else {
+        return Err(unregistered_contract_error());
+    };
+    repository_family_contract(schema, artifact_type)
+        .or_else(|| diagnosis_family_contract(schema, artifact_type))
+        .or_else(|| orientation_family_contract(schema, artifact_type))
+        .or_else(|| retirement_family_contract(schema, artifact_type))
+        .or_else(|| run_delivery_family_contract(schema, artifact_type))
+        .or_else(|| method_decision_family_contract(schema, artifact_type))
+        .or_else(|| {
+            native_code_contract(schema, artifact_type).map(
+                |(artifact_schema, artifact_type, validate_payload)| ArtifactContract {
+                    artifact_schema,
+                    artifact_type,
+                    max_bytes: MAX_ARTIFACT_BYTES,
+                    validate_payload,
+                },
+            )
+        })
+        .ok_or_else(unregistered_contract_error)
+}
+
+fn unregistered_contract_error() -> ArtifactError {
+    ArtifactError::Contract(
+        "Artifact Ref schema/type is not registered for capability input consumption".to_string(),
+    )
+}
+
+fn repository_family_contract(schema: &str, artifact_type: &str) -> Option<ArtifactContract> {
+    match (schema, artifact_type) {
+        (REPOSITORY_ITERATION_SCHEMA, REPOSITORY_ITERATION_TYPE) => Some(ArtifactContract {
+            artifact_schema: REPOSITORY_ITERATION_SCHEMA,
+            artifact_type: REPOSITORY_ITERATION_TYPE,
+            max_bytes: 64 * 1024,
+            validate_payload: validate_repository_iteration_provenance,
+        }),
+        ("code-intel-file-inventory.v1", "inventory.files") => Some(ArtifactContract {
             artifact_schema: "code-intel-file-inventory.v1",
             artifact_type: "inventory.files",
             max_bytes: MAX_ARTIFACT_BYTES,
             validate_payload: validate_inventory,
         }),
-        (Some("code-intel-repository-snapshot.v1"), Some("repository.snapshot")) => {
-            Ok(ArtifactContract {
-                artifact_schema: "code-intel-repository-snapshot.v1",
-                artifact_type: "repository.snapshot",
-                max_bytes: 8 * 1024 * 1024,
-                validate_payload: validate_repository_snapshot,
-            })
-        }
-        (Some("code-intel-doctor-observation.v1"), Some("doctor.observation")) => {
-            Ok(ArtifactContract {
-                artifact_schema: "code-intel-doctor-observation.v1",
-                artifact_type: "doctor.observation",
-                max_bytes: 8 * 1024 * 1024,
-                validate_payload: validate_doctor_observation,
-            })
-        }
+        ("code-intel-repository-snapshot.v1", "repository.snapshot") => Some(ArtifactContract {
+            artifact_schema: "code-intel-repository-snapshot.v1",
+            artifact_type: "repository.snapshot",
+            max_bytes: 8 * 1024 * 1024,
+            validate_payload: validate_repository_snapshot,
+        }),
+        _ => None,
+    }
+}
+
+fn diagnosis_family_contract(schema: &str, artifact_type: &str) -> Option<ArtifactContract> {
+    match (schema, artifact_type) {
+        ("code-intel-doctor-observation.v1", "doctor.observation") => Some(ArtifactContract {
+            artifact_schema: "code-intel-doctor-observation.v1",
+            artifact_type: "doctor.observation",
+            max_bytes: 8 * 1024 * 1024,
+            validate_payload: validate_doctor_observation,
+        }),
         (
-            Some("code-intel-repository-survival-scan-result.v1"),
-            Some("repository.survival-scan"),
-        ) => Ok(ArtifactContract {
+            "code-intel-repository-survival-scan-result.v1",
+            "repository.survival-scan",
+        ) => Some(ArtifactContract {
             artifact_schema: "code-intel-repository-survival-scan-result.v1",
             artifact_type: "repository.survival-scan",
             max_bytes: 8 * 1024 * 1024,
             validate_payload: validate_survival_scan,
         }),
-        (Some("code-intel-evidence-admissibility-result.v1"), Some("evidence.admission")) => {
-            Ok(ArtifactContract {
+        ("code-intel-evidence-admissibility-result.v1", "evidence.admission") => {
+            Some(ArtifactContract {
                 artifact_schema: "code-intel-evidence-admissibility-result.v1",
                 artifact_type: "evidence.admission",
                 max_bytes: 16 * 1024 * 1024,
                 validate_payload: validate_evidence_admission,
             })
         }
-        (Some("code-intel-evidence-payload.v1"), Some("observed.evidence.payload")) => {
-            Ok(ArtifactContract {
-                artifact_schema: "code-intel-evidence-payload.v1",
-                artifact_type: "observed.evidence.payload",
-                max_bytes: 64 * 1024 * 1024,
-                validate_payload: validate_evidence_payload,
-            })
-        }
+        ("code-intel-evidence-payload.v1", "observed.evidence.payload") => Some(ArtifactContract {
+            artifact_schema: "code-intel-evidence-payload.v1",
+            artifact_type: "observed.evidence.payload",
+            max_bytes: 64 * 1024 * 1024,
+            validate_payload: validate_evidence_payload,
+        }),
         (
-            Some("code-intel-sentrux-command-observation.v1"),
-            Some("provider.sentrux.command-observation"),
-        ) => Ok(ArtifactContract {
+            "code-intel-sentrux-command-observation.v1",
+            "provider.sentrux.command-observation",
+        ) => Some(ArtifactContract {
             artifact_schema: "code-intel-sentrux-command-observation.v1",
             artifact_type: "provider.sentrux.command-observation",
             max_bytes: 2 * 1024 * 1024,
             validate_payload: validate_sentrux_command_observation,
         }),
-        (Some("code-intel-hospital.v1"), Some("diagnosis.hospital")) => Ok(ArtifactContract {
+        ("code-intel-hospital.v1", "diagnosis.hospital") => Some(ArtifactContract {
             artifact_schema: "code-intel-hospital.v1",
             artifact_type: "diagnosis.hospital",
             max_bytes: 8 * 1024 * 1024,
             validate_payload: validate_hospital_report,
         }),
-        (Some("code-intel-audit-report.v1"), Some("diagnosis.audit")) => Ok(ArtifactContract {
+        ("code-intel-audit-report.v1", "diagnosis.audit") => Some(ArtifactContract {
             artifact_schema: "code-intel-audit-report.v1",
             artifact_type: "diagnosis.audit",
             max_bytes: 8 * 1024 * 1024,
             validate_payload: validate_audit_report,
         }),
-        (Some("code-intel-hospital-markdown.v1"), Some("diagnosis.hospital-view")) => {
-            Ok(ArtifactContract {
-                artifact_schema: "code-intel-hospital-markdown.v1",
-                artifact_type: "diagnosis.hospital-view",
-                max_bytes: 8 * 1024 * 1024,
-                validate_payload: validate_hospital_markdown,
-            })
-        }
-        (Some("code-intel-surgery-plan.v1"), Some("diagnosis.surgery-plan")) => {
-            Ok(ArtifactContract {
-                artifact_schema: "code-intel-surgery-plan.v1",
-                artifact_type: "diagnosis.surgery-plan",
-                max_bytes: 8 * 1024 * 1024,
-                validate_payload: validate_surgery_plan,
-            })
-        }
-        (Some("code-intel-surgery-plan-markdown.v1"), Some("diagnosis.surgery-plan-view")) => {
-            Ok(ArtifactContract {
+        ("code-intel-hospital-markdown.v1", "diagnosis.hospital-view") => Some(ArtifactContract {
+            artifact_schema: "code-intel-hospital-markdown.v1",
+            artifact_type: "diagnosis.hospital-view",
+            max_bytes: 8 * 1024 * 1024,
+            validate_payload: validate_hospital_markdown,
+        }),
+        ("code-intel-surgery-plan.v1", "diagnosis.surgery-plan") => Some(ArtifactContract {
+            artifact_schema: "code-intel-surgery-plan.v1",
+            artifact_type: "diagnosis.surgery-plan",
+            max_bytes: 8 * 1024 * 1024,
+            validate_payload: validate_surgery_plan,
+        }),
+        ("code-intel-surgery-plan-markdown.v1", "diagnosis.surgery-plan-view") => {
+            Some(ArtifactContract {
                 artifact_schema: "code-intel-surgery-plan-markdown.v1",
                 artifact_type: "diagnosis.surgery-plan-view",
                 max_bytes: 8 * 1024 * 1024,
                 validate_payload: validate_surgery_markdown,
             })
         }
-        (Some("code-intel-project-orientation.v1"), Some("project.orientation")) => {
-            Ok(ArtifactContract {
-                artifact_schema: "code-intel-project-orientation.v1",
-                artifact_type: "project.orientation",
-                max_bytes: 8 * 1024 * 1024,
-                validate_payload: validate_project_orientation,
-            })
-        }
-        (Some("code-intel-understanding-quadrant.v1"), Some("understanding.quadrant")) => {
-            Ok(ArtifactContract {
+        _ => None,
+    }
+}
+
+fn orientation_family_contract(schema: &str, artifact_type: &str) -> Option<ArtifactContract> {
+    match (schema, artifact_type) {
+        ("code-intel-project-orientation.v1", "project.orientation") => Some(ArtifactContract {
+            artifact_schema: "code-intel-project-orientation.v1",
+            artifact_type: "project.orientation",
+            max_bytes: 8 * 1024 * 1024,
+            validate_payload: validate_project_orientation,
+        }),
+        ("code-intel-understanding-quadrant.v1", "understanding.quadrant") => {
+            Some(ArtifactContract {
                 artifact_schema: "code-intel-understanding-quadrant.v1",
                 artifact_type: "understanding.quadrant",
                 max_bytes: 8 * 1024 * 1024,
@@ -317,127 +344,125 @@ pub(crate) fn registered_contract(artifact: &Value) -> Result<ArtifactContract, 
             })
         }
         (
-            Some("code-intel-compatibility-retirement-manifest.v1"),
-            Some("compatibility.retirement-manifest"),
-        ) => Ok(ArtifactContract {
-            artifact_schema: "code-intel-compatibility-retirement-manifest.v1",
-            artifact_type: "compatibility.retirement-manifest",
-            max_bytes: 4 * 1024 * 1024,
-            validate_payload: validate_retirement_manifest,
-        }),
-        (
-            Some("code-intel-compatibility-retirement-evidence.v1"),
-            Some("compatibility.retirement-evidence"),
-        ) => Ok(ArtifactContract {
-            artifact_schema: "code-intel-compatibility-retirement-evidence.v1",
-            artifact_type: "compatibility.retirement-evidence",
-            max_bytes: 4 * 1024 * 1024,
-            validate_payload: validate_retirement_evidence,
-        }),
-        (
-            Some("code-intel-compatibility-retirement-decision.v1"),
-            Some("compatibility.retirement-decision"),
-        ) => Ok(ArtifactContract {
-            artifact_schema: "code-intel-compatibility-retirement-decision.v1",
-            artifact_type: "compatibility.retirement-decision",
-            max_bytes: 4 * 1024 * 1024,
-            validate_payload: validate_retirement_decision,
-        }),
-        (
-            Some("code-intel-compatibility-retirement-ticket-template.v1"),
-            Some("compatibility.retirement-ticket-template"),
-        ) => Ok(ArtifactContract {
-            artifact_schema: "code-intel-compatibility-retirement-ticket-template.v1",
-            artifact_type: "compatibility.retirement-ticket-template",
-            max_bytes: 4 * 1024 * 1024,
-            validate_payload: validate_retirement_ticket_template,
-        }),
-        (
-            Some("code-intel-compatibility-retirement-deletion-diff.v1"),
-            Some("compatibility.retirement-deletion-diff"),
-        ) => Ok(ArtifactContract {
-            artifact_schema: "code-intel-compatibility-retirement-deletion-diff.v1",
-            artifact_type: "compatibility.retirement-deletion-diff",
-            max_bytes: 4 * 1024 * 1024,
-            validate_payload: validate_retirement_deletion_diff,
-        }),
-        (
-            Some("code-intel-project-orientation-benchmark-observations.v1"),
-            Some("benchmark.orientation-observations"),
-        ) => Ok(ArtifactContract {
+            "code-intel-project-orientation-benchmark-observations.v1",
+            "benchmark.orientation-observations",
+        ) => Some(ArtifactContract {
             artifact_schema: "code-intel-project-orientation-benchmark-observations.v1",
             artifact_type: "benchmark.orientation-observations",
             max_bytes: 64 * 1024 * 1024,
             validate_payload: validate_orientation_benchmark_observations,
         }),
         (
-            Some("code-intel-project-orientation-benchmark.v1"),
-            Some("benchmark.orientation-report"),
-        ) => Ok(ArtifactContract {
+            "code-intel-project-orientation-benchmark.v1",
+            "benchmark.orientation-report",
+        ) => Some(ArtifactContract {
             artifact_schema: "code-intel-project-orientation-benchmark.v1",
             artifact_type: "benchmark.orientation-report",
             max_bytes: 8 * 1024 * 1024,
             validate_payload: validate_orientation_benchmark_report,
         }),
         (
-            Some("code-intel-project-orientation-benchmark-markdown.v1"),
-            Some("benchmark.orientation-report-view"),
-        ) => Ok(ArtifactContract {
+            "code-intel-project-orientation-benchmark-markdown.v1",
+            "benchmark.orientation-report-view",
+        ) => Some(ArtifactContract {
             artifact_schema: "code-intel-project-orientation-benchmark-markdown.v1",
             artifact_type: "benchmark.orientation-report-view",
             max_bytes: 1024 * 1024,
             validate_payload: validate_orientation_benchmark_markdown,
         }),
-        (Some("code-intel-run-timing-events.v1"), Some("delivery.run-timing-events")) => {
-            Ok(ArtifactContract {
+        _ => None,
+    }
+}
+
+fn retirement_family_contract(schema: &str, artifact_type: &str) -> Option<ArtifactContract> {
+    match (schema, artifact_type) {
+        (
+            "code-intel-compatibility-retirement-manifest.v1",
+            "compatibility.retirement-manifest",
+        ) => Some(ArtifactContract {
+            artifact_schema: "code-intel-compatibility-retirement-manifest.v1",
+            artifact_type: "compatibility.retirement-manifest",
+            max_bytes: 4 * 1024 * 1024,
+            validate_payload: validate_retirement_manifest,
+        }),
+        (
+            "code-intel-compatibility-retirement-evidence.v1",
+            "compatibility.retirement-evidence",
+        ) => Some(ArtifactContract {
+            artifact_schema: "code-intel-compatibility-retirement-evidence.v1",
+            artifact_type: "compatibility.retirement-evidence",
+            max_bytes: 4 * 1024 * 1024,
+            validate_payload: validate_retirement_evidence,
+        }),
+        (
+            "code-intel-compatibility-retirement-decision.v1",
+            "compatibility.retirement-decision",
+        ) => Some(ArtifactContract {
+            artifact_schema: "code-intel-compatibility-retirement-decision.v1",
+            artifact_type: "compatibility.retirement-decision",
+            max_bytes: 4 * 1024 * 1024,
+            validate_payload: validate_retirement_decision,
+        }),
+        (
+            "code-intel-compatibility-retirement-ticket-template.v1",
+            "compatibility.retirement-ticket-template",
+        ) => Some(ArtifactContract {
+            artifact_schema: "code-intel-compatibility-retirement-ticket-template.v1",
+            artifact_type: "compatibility.retirement-ticket-template",
+            max_bytes: 4 * 1024 * 1024,
+            validate_payload: validate_retirement_ticket_template,
+        }),
+        (
+            "code-intel-compatibility-retirement-deletion-diff.v1",
+            "compatibility.retirement-deletion-diff",
+        ) => Some(ArtifactContract {
+            artifact_schema: "code-intel-compatibility-retirement-deletion-diff.v1",
+            artifact_type: "compatibility.retirement-deletion-diff",
+            max_bytes: 4 * 1024 * 1024,
+            validate_payload: validate_retirement_deletion_diff,
+        }),
+        _ => None,
+    }
+}
+
+fn run_delivery_family_contract(schema: &str, artifact_type: &str) -> Option<ArtifactContract> {
+    match (schema, artifact_type) {
+        ("code-intel-run-timing-events.v1", "delivery.run-timing-events") => {
+            Some(ArtifactContract {
                 artifact_schema: "code-intel-run-timing-events.v1",
                 artifact_type: "delivery.run-timing-events",
                 max_bytes: 64 * 1024 * 1024,
                 validate_payload: validate_run_timing_events,
             })
         }
-        (Some("code-intel-run-commit.v1"), Some("run.commit")) => Ok(ArtifactContract {
+        ("code-intel-run-commit.v1", "run.commit") => Some(ArtifactContract {
             artifact_schema: "code-intel-run-commit.v1",
             artifact_type: "run.commit",
             max_bytes: 64 * 1024,
             validate_payload: validate_run_commit,
         }),
-        (Some("code-intel-run-manifest.v1"), Some("run.manifest")) => Ok(ArtifactContract {
+        ("code-intel-run-manifest.v1", "run.manifest") => Some(ArtifactContract {
             artifact_schema: "code-intel-run-manifest.v1",
             artifact_type: "run.manifest",
             max_bytes: 8 * 1024 * 1024,
             validate_payload: validate_run_manifest,
         }),
-        (Some("code-intel-session-evidence.v1"), Some("verification.session-evidence")) => {
-            Ok(ArtifactContract {
+        ("code-intel-session-evidence.v1", "verification.session-evidence") => {
+            Some(ArtifactContract {
                 artifact_schema: "code-intel-session-evidence.v1",
                 artifact_type: "verification.session-evidence",
                 max_bytes: 128 * 1024 * 1024,
                 validate_payload: validate_session_evidence,
             })
         }
-        (Some("code-intel-anchor-verification.v1"), Some("verification.anchors")) => {
-            Ok(ArtifactContract {
-                artifact_schema: "code-intel-anchor-verification.v1",
-                artifact_type: "verification.anchors",
-                max_bytes: MAX_ARTIFACT_BYTES,
-                validate_payload: validate_anchor_verification,
-            })
-        }
-        (Some("code-intel-method-catalog.v1"), Some("method.catalog")) => Ok(ArtifactContract {
-            artifact_schema: "code-intel-method-catalog.v1",
-            artifact_type: "method.catalog",
-            max_bytes: 256 * 1024,
-            validate_payload: validate_method_catalog,
+        ("code-intel-anchor-verification.v1", "verification.anchors") => Some(ArtifactContract {
+            artifact_schema: "code-intel-anchor-verification.v1",
+            artifact_type: "verification.anchors",
+            max_bytes: MAX_ARTIFACT_BYTES,
+            validate_payload: validate_anchor_verification,
         }),
-        (Some("code-intel-method-card.v1"), Some("method.card")) => Ok(ArtifactContract {
-            artifact_schema: "code-intel-method-card.v1",
-            artifact_type: "method.card",
-            max_bytes: 256 * 1024,
-            validate_payload: validate_method_card,
-        }),
-        (Some("code-intel-delivery-light-speed.v1"), Some("delivery.light-speed-report")) => {
-            Ok(ArtifactContract {
+        ("code-intel-delivery-light-speed.v1", "delivery.light-speed-report") => {
+            Some(ArtifactContract {
                 artifact_schema: "code-intel-delivery-light-speed.v1",
                 artifact_type: "delivery.light-speed-report",
                 max_bytes: 8 * 1024 * 1024,
@@ -445,36 +470,39 @@ pub(crate) fn registered_contract(artifact: &Value) -> Result<ArtifactContract, 
             })
         }
         (
-            Some("code-intel-delivery-light-speed-markdown.v1"),
-            Some("delivery.light-speed-report-view"),
-        ) => Ok(ArtifactContract {
+            "code-intel-delivery-light-speed-markdown.v1",
+            "delivery.light-speed-report-view",
+        ) => Some(ArtifactContract {
             artifact_schema: "code-intel-delivery-light-speed-markdown.v1",
             artifact_type: "delivery.light-speed-report-view",
             max_bytes: 1024 * 1024,
             validate_payload: validate_light_speed_markdown,
         }),
-        (Some("code-intel-decision-record.v1"), Some("decision.record")) => Ok(ArtifactContract {
+        _ => None,
+    }
+}
+
+fn method_decision_family_contract(schema: &str, artifact_type: &str) -> Option<ArtifactContract> {
+    match (schema, artifact_type) {
+        ("code-intel-method-catalog.v1", "method.catalog") => Some(ArtifactContract {
+            artifact_schema: "code-intel-method-catalog.v1",
+            artifact_type: "method.catalog",
+            max_bytes: 256 * 1024,
+            validate_payload: validate_method_catalog,
+        }),
+        ("code-intel-method-card.v1", "method.card") => Some(ArtifactContract {
+            artifact_schema: "code-intel-method-card.v1",
+            artifact_type: "method.card",
+            max_bytes: 256 * 1024,
+            validate_payload: validate_method_card,
+        }),
+        ("code-intel-decision-record.v1", "decision.record") => Some(ArtifactContract {
             artifact_schema: "code-intel-decision-record.v1",
             artifact_type: "decision.record",
             max_bytes: 1024 * 1024,
             validate_payload: validate_decision_record_schema,
         }),
-        (Some(schema), Some(artifact_type))
-            if native_code_contract(schema, artifact_type).is_some() =>
-        {
-            let (artifact_schema, artifact_type, validate_payload) =
-                native_code_contract(schema, artifact_type).expect("guard matched native contract");
-            Ok(ArtifactContract {
-                artifact_schema,
-                artifact_type,
-                max_bytes: MAX_ARTIFACT_BYTES,
-                validate_payload,
-            })
-        }
-        _ => Err(ArtifactError::Contract(
-            "Artifact Ref schema/type is not registered for capability input consumption"
-                .to_string(),
-        )),
+        _ => None,
     }
 }
 

--- a/crates/code-intel-cli/src/artifact_ref.rs
+++ b/crates/code-intel-cli/src/artifact_ref.rs
@@ -7,7 +7,10 @@ use serde_json::{json, Value};
 mod content_contract;
 
 use crate::stable_artifact::{self, FileId, StableReadError};
-use content_contract::{reject_duplicate_json_keys, sha256_hex, validate_artifact_ref_shape};
+use content_contract::{
+    is_digest as valid_digest, is_run_identity as valid_run_identity, reject_duplicate_json_keys,
+    require_exact_keys, sha256_hex, validate_artifact_ref_shape,
+};
 
 const MAX_ARTIFACT_BYTES: u64 = 64 * 1024 * 1024;
 
@@ -2807,12 +2810,7 @@ fn exact_object_keys(value: &Value, expected: &[&str], context: &str) -> Result<
     let object = value
         .as_object()
         .ok_or_else(|| format!("{context} must be an object"))?;
-    let actual = object.keys().map(String::as_str).collect::<BTreeSet<_>>();
-    let expected = expected.iter().copied().collect::<BTreeSet<_>>();
-    if actual != expected {
-        return Err(format!("{context} fields are invalid"));
-    }
-    Ok(())
+    require_exact_keys(object, expected, context).map_err(|_| format!("{context} fields are invalid"))
 }
 
 fn validate_survival_scan(bytes: &[u8]) -> Result<(), String> {
@@ -2943,23 +2941,6 @@ fn validate_repository_snapshot_identity(value: &Value) -> Result<(), String> {
         return Err("repository snapshot identity values are invalid".to_string());
     }
     Ok(())
-}
-
-fn valid_digest(value: &str) -> bool {
-    value.len() == 64
-        && value
-            .bytes()
-            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
-}
-
-fn valid_run_identity(value: &str) -> bool {
-    value.strip_prefix("dag-v1:").is_some_and(|tail| {
-        !tail.is_empty()
-            && tail.len() % 2 == 0
-            && tail
-                .bytes()
-                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
-    })
 }
 
 fn valid_authority_name(value: &str) -> bool {

--- a/crates/code-intel-cli/src/artifact_ref.rs
+++ b/crates/code-intel-cli/src/artifact_ref.rs
@@ -1148,6 +1148,10 @@ pub(crate) fn retirement_portable_paths(value: &Value, label: &str) -> Result<Ve
     Ok(paths)
 }
 
+// Guards retirement callPath/deletion-patch paths (see call sites above). Rejects
+// a trailing '/' and '.'/'..' components directly -- distinct rule set from
+// path_syntax_is_portable below, which guards general Artifact Ref paths and
+// instead leans on component normalization to catch traversal.
 fn validate_portable_path(path: &str, label: &str) -> Result<(), String> {
     if path.is_empty()
         || path.contains('\\')
@@ -1380,7 +1384,12 @@ fn validate_project_orientation(bytes: &[u8]) -> Result<(), String> {
         "risks",
         "unknowns",
     ] {
-        for (index, claim) in value[field].as_array().unwrap().iter().enumerate() {
+        for (index, claim) in value[field]
+            .as_array()
+            .expect("project_orientation_shape_is_valid proved this field is an array")
+            .iter()
+            .enumerate()
+        {
             validate_claim_provenance(&claim["provenance"], &format!("{field}[{index}]"))?;
         }
     }
@@ -3094,6 +3103,9 @@ fn portable_relative_path(value: &str) -> Result<String, ArtifactError> {
     Ok(normalized.join("/"))
 }
 
+// Guards the Artifact Ref path field (see caller above), ahead of component
+// normalization -- distinct rule set from validate_portable_path above,
+// which guards retirement callPath/deletion-patch paths directly.
 fn path_syntax_is_portable(value: &str) -> bool {
     !value.is_empty()
         && !value.contains('\0')

--- a/crates/code-intel-cli/src/capability.rs
+++ b/crates/code-intel-cli/src/capability.rs
@@ -13,7 +13,7 @@ use crate::artifact_ref::{self, VerifiedArtifact};
 #[path = "content_contract.rs"]
 mod content_contract;
 pub(crate) use content_contract::{
-    is_digest, reject_duplicate_json_keys, require_exact_keys, sha256_hex,
+    is_digest, is_run_identity, reject_duplicate_json_keys, require_exact_keys, sha256_hex,
     validate_artifact_ref_shape, MAX_JSON_BYTES,
 };
 

--- a/crates/code-intel-cli/src/content_contract.rs
+++ b/crates/code-intel-cli/src/content_contract.rs
@@ -207,6 +207,16 @@ pub(crate) fn is_digest(v: &str) -> bool {
             .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
 }
 
+pub(crate) fn is_run_identity(value: &str) -> bool {
+    value.strip_prefix("dag-v1:").is_some_and(|tail| {
+        !tail.is_empty()
+            && tail.len() % 2 == 0
+            && tail
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    })
+}
+
 pub(crate) fn sha256_hex(bytes: &[u8]) -> String {
     const K: [u32; 64] = [
         0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4,

--- a/crates/code-intel-cli/src/content_contract.rs
+++ b/crates/code-intel-cli/src/content_contract.rs
@@ -287,3 +287,32 @@ pub(crate) fn sha256_hex(bytes: &[u8]) -> String {
     }
     h.iter().map(|v| format!("{v:08x}")).collect()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::is_run_identity;
+
+    #[test]
+    fn is_run_identity_requires_dag_v1_prefix() {
+        assert!(!is_run_identity("ab"));
+        assert!(!is_run_identity("dag-v2:ab"));
+    }
+
+    #[test]
+    fn is_run_identity_rejects_empty_tail() {
+        assert!(!is_run_identity("dag-v1:"));
+    }
+
+    #[test]
+    fn is_run_identity_requires_even_length_tail() {
+        assert!(!is_run_identity("dag-v1:abc"));
+        assert!(is_run_identity("dag-v1:abcd"));
+    }
+
+    #[test]
+    fn is_run_identity_requires_lowercase_hex_tail() {
+        assert!(!is_run_identity("dag-v1:AB"));
+        assert!(!is_run_identity("dag-v1:gg"));
+        assert!(is_run_identity("dag-v1:ab"));
+    }
+}

--- a/crates/code-intel-cli/src/dag_coordinator.rs
+++ b/crates/code-intel-cli/src/dag_coordinator.rs
@@ -4,6 +4,10 @@ use std::fmt;
 
 use serde_json::{json, Value};
 
+// content_contract.rs is a dependency-free leaf module redeclared per file
+// (also included by capability.rs, artifact_ref.rs, audit_report/mod.rs, and
+// integration tests) rather than exported once, since test binaries wire in
+// #[path] modules individually -- see the test-harness-module-wiring note.
 #[path = "content_contract.rs"]
 mod content_contract;
 use content_contract::{is_digest as valid_digest, sha256_hex};

--- a/crates/code-intel-cli/src/dag_coordinator.rs
+++ b/crates/code-intel-cli/src/dag_coordinator.rs
@@ -4,6 +4,10 @@ use std::fmt;
 
 use serde_json::{json, Value};
 
+#[path = "content_contract.rs"]
+mod content_contract;
+use content_contract::{is_digest as valid_digest, sha256_hex};
+
 pub const DAG_SCHEMA: &str = "code-intel-run-dag.v1";
 pub const RUN_STATE_SCHEMA: &str = "code-intel-run-state.v1";
 pub const RUN_MANIFEST_SCHEMA: &str = "code-intel-run-manifest.v1";
@@ -979,87 +983,6 @@ fn identity_for(spec: &DagSpec) -> String {
     format!("dag-v1:{}", sha256_hex(&canonical))
 }
 
-fn sha256_hex(bytes: &[u8]) -> String {
-    const K: [u32; 64] = [
-        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4,
-        0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe,
-        0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f,
-        0x4a7484aa, 0x5cb0a9dc, 0x76f988da, 0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
-        0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc,
-        0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
-        0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116,
-        0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
-        0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7,
-        0xc67178f2,
-    ];
-    let mut data = bytes.to_vec();
-    let bits = (data.len() as u64) * 8;
-    data.push(0x80);
-    while data.len() % 64 != 56 {
-        data.push(0)
-    }
-    data.extend_from_slice(&bits.to_be_bytes());
-    let mut h = [
-        0x6a09e667u32,
-        0xbb67ae85,
-        0x3c6ef372,
-        0xa54ff53a,
-        0x510e527f,
-        0x9b05688c,
-        0x1f83d9ab,
-        0x5be0cd19,
-    ];
-    for chunk in data.chunks_exact(64) {
-        let mut w = [0u32; 64];
-        for (index, word) in chunk.chunks_exact(4).enumerate() {
-            w[index] = u32::from_be_bytes(word.try_into().expect("four-byte SHA-256 word"))
-        }
-        for index in 16..64 {
-            let s0 = w[index - 15].rotate_right(7)
-                ^ w[index - 15].rotate_right(18)
-                ^ (w[index - 15] >> 3);
-            let s1 = w[index - 2].rotate_right(17)
-                ^ w[index - 2].rotate_right(19)
-                ^ (w[index - 2] >> 10);
-            w[index] = w[index - 16]
-                .wrapping_add(s0)
-                .wrapping_add(w[index - 7])
-                .wrapping_add(s1)
-        }
-        let [mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut hh] = h;
-        for index in 0..64 {
-            let s1 = e.rotate_right(6) ^ e.rotate_right(11) ^ e.rotate_right(25);
-            let choose = (e & f) ^ (!e & g);
-            let t1 = hh
-                .wrapping_add(s1)
-                .wrapping_add(choose)
-                .wrapping_add(K[index])
-                .wrapping_add(w[index]);
-            let s0 = a.rotate_right(2) ^ a.rotate_right(13) ^ a.rotate_right(22);
-            let majority = (a & b) ^ (a & c) ^ (b & c);
-            let t2 = s0.wrapping_add(majority);
-            hh = g;
-            g = f;
-            f = e;
-            e = d.wrapping_add(t1);
-            d = c;
-            c = b;
-            b = a;
-            a = t1.wrapping_add(t2)
-        }
-        for (state, value) in h.iter_mut().zip([a, b, c, d, e, f, g, hh]) {
-            *state = state.wrapping_add(value)
-        }
-    }
-    h.iter().map(|value| format!("{value:08x}")).collect()
-}
-
-fn valid_digest(value: &str) -> bool {
-    value.len() == 64
-        && value
-            .bytes()
-            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
-}
 
 fn nonempty_diagnostic(value: String, fallback: &str) -> String {
     if value.trim().is_empty() {

--- a/crates/code-intel-cli/src/dag_coordinator.rs
+++ b/crates/code-intel-cli/src/dag_coordinator.rs
@@ -983,7 +983,6 @@ fn identity_for(spec: &DagSpec) -> String {
     format!("dag-v1:{}", sha256_hex(&canonical))
 }
 
-
 fn nonempty_diagnostic(value: String, fallback: &str) -> String {
     if value.trim().is_empty() {
         fallback.to_string()

--- a/crates/code-intel-cli/src/run_commit.rs
+++ b/crates/code-intel-cli/src/run_commit.rs
@@ -8,10 +8,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use serde_json::{json, Value};
 
 use crate::artifact_ref;
-use crate::capability::{
-    is_digest as valid_digest, is_run_identity as valid_run_identity, reject_duplicate_json_keys,
-    sha256_hex, validate_artifact_ref_shape,
-};
+use crate::capability::{reject_duplicate_json_keys, sha256_hex, validate_artifact_ref_shape};
 use crate::stable_artifact;
 use crate::staged_artifact::{self, ArtifactWriteContract, StagedArtifactSet, StagedWriter};
 
@@ -797,6 +794,22 @@ fn exact(value: &Value, fields: &[&str], label: &str) -> Result<(), String> {
     } else {
         Err(format!("{label} fields are invalid"))
     }
+}
+
+fn valid_digest(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|b| b.is_ascii_digit() || matches!(b, b'a'..=b'f'))
+}
+fn valid_run_identity(value: &str) -> bool {
+    value.strip_prefix("dag-v1:").is_some_and(|tail| {
+        !tail.is_empty()
+            && tail.len() % 2 == 0
+            && tail
+                .bytes()
+                .all(|b| b.is_ascii_digit() || matches!(b, b'a'..=b'f'))
+    })
 }
 
 fn remove_owned_marker(

--- a/crates/code-intel-cli/src/run_commit.rs
+++ b/crates/code-intel-cli/src/run_commit.rs
@@ -8,7 +8,10 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use serde_json::{json, Value};
 
 use crate::artifact_ref;
-use crate::capability::{reject_duplicate_json_keys, sha256_hex, validate_artifact_ref_shape};
+use crate::capability::{
+    is_digest as valid_digest, is_run_identity as valid_run_identity, reject_duplicate_json_keys,
+    sha256_hex, validate_artifact_ref_shape,
+};
 use crate::stable_artifact;
 use crate::staged_artifact::{self, ArtifactWriteContract, StagedArtifactSet, StagedWriter};
 
@@ -794,22 +797,6 @@ fn exact(value: &Value, fields: &[&str], label: &str) -> Result<(), String> {
     } else {
         Err(format!("{label} fields are invalid"))
     }
-}
-
-fn valid_digest(value: &str) -> bool {
-    value.len() == 64
-        && value
-            .bytes()
-            .all(|b| b.is_ascii_digit() || matches!(b, b'a'..=b'f'))
-}
-fn valid_run_identity(value: &str) -> bool {
-    value.strip_prefix("dag-v1:").is_some_and(|tail| {
-        !tail.is_empty()
-            && tail.len() % 2 == 0
-            && tail
-                .bytes()
-                .all(|b| b.is_ascii_digit() || matches!(b, b'a'..=b'f'))
-    })
 }
 
 fn remove_owned_marker(

--- a/crates/code-intel-cli/src/session_evidence.rs
+++ b/crates/code-intel-cli/src/session_evidence.rs
@@ -6,7 +6,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde_json::{json, Value};
 
-use crate::capability::sha256_hex;
+use crate::capability::{is_digest as valid_digest, sha256_hex};
 
 const MAX_TRACE_BYTES: u64 = 128 * 1024 * 1024;
 const MAX_HOTSPOT_BYTES: u64 = 64 * 1024 * 1024;
@@ -700,10 +700,6 @@ fn exact_keys(value: &Value, expected: &[&str], label: &str) -> Result<(), Strin
 
 fn is_grade(value: Option<&str>) -> bool {
     matches!(value, Some("exact" | "estimated" | "unavailable"))
-}
-
-fn valid_digest(value: &str) -> bool {
-    value.len() == 64 && value.bytes().all(is_lower_hex)
 }
 
 fn is_lower_hex(byte: u8) -> bool {

--- a/crates/code-intel-cli/src/understanding_quadrant.rs
+++ b/crates/code-intel-cli/src/understanding_quadrant.rs
@@ -6,7 +6,7 @@ use serde_json::{json, Value};
 
 use super::{AdapterArtifact, AdapterError, AdapterOutput};
 use crate::adapter_contract::AdapterDomainVerdict;
-use crate::artifact_ref::VerifiedArtifact;
+use crate::artifact_ref::{expected_understanding_quadrant as classify, VerifiedArtifact};
 
 const CRITICALITY_THRESHOLD: u64 = 50;
 const CONFIDENCE_THRESHOLD: u64 = 50;
@@ -300,17 +300,6 @@ fn insert_item(
         )));
     }
     Ok(())
-}
-
-fn classify(criticality: u64, confidence: u64) -> (&'static str, &'static str, &'static str) {
-    let critical = criticality >= CRITICALITY_THRESHOLD;
-    let confident = confidence >= CONFIDENCE_THRESHOLD;
-    match (critical, confident) {
-        (true, true) => ("critical", "high", "Known Core"),
-        (true, false) => ("critical", "low", "Critical Unknown"),
-        (false, true) => ("supporting", "high", "Supporting Context"),
-        (false, false) => ("supporting", "low", "Deferred Unknown"),
-    }
 }
 
 fn unknown_criticality(field: &str) -> u64 {

--- a/orchestration/integrations.json
+++ b/orchestration/integrations.json
@@ -847,7 +847,7 @@
           "toolchainDigests": [
             "3ba256f4ca0bf62aca08f688f7ecf31800dd10e68371054e2f1605eff197ea81",
             "bcc8622f544022998f9d74d7671fd4f375ef31ae7f02c82321213f02de75a853",
-            "af27dccb7fb01ac70e13daf8aa172270516a8703291fccdd712fccd765a0127e",
+            "a87baab0a621d54a74d0c2030200e9086ac49d7518176327d923f23f0c347ec6",
             "b118ba78ff3ef4a189525c642184cbd320a268d2885681ab153544db554c5965",
             "e3072b6b01a4f692c2ac75c7c4995747f9a0fd1ce4f32e1ab1599f348661f570",
             "40c532ed3aa52144bdc8bb4422e04b23c54196d352ac9cb0f3e93a5a059af120"
@@ -908,7 +908,7 @@
           "version": "1.0.0",
           "toolchainDigests": [
             "2d2b38c4650795e2bba99e8ec38ca21adcb204042e9289577c535f7087e899d8",
-            "af27dccb7fb01ac70e13daf8aa172270516a8703291fccdd712fccd765a0127e",
+            "a87baab0a621d54a74d0c2030200e9086ac49d7518176327d923f23f0c347ec6",
             "bcc8622f544022998f9d74d7671fd4f375ef31ae7f02c82321213f02de75a853"
           ]
         },
@@ -959,7 +959,7 @@
           "version": "1.0.0",
           "toolchainDigests": [
             "a6da84444e815dd94c15887190c7d6bd48c7bca5975fb5d493eb77ab39f27d80",
-            "af27dccb7fb01ac70e13daf8aa172270516a8703291fccdd712fccd765a0127e",
+            "a87baab0a621d54a74d0c2030200e9086ac49d7518176327d923f23f0c347ec6",
             "bcc8622f544022998f9d74d7671fd4f375ef31ae7f02c82321213f02de75a853"
           ]
         },

--- a/orchestration/integrations.json
+++ b/orchestration/integrations.json
@@ -847,7 +847,7 @@
           "toolchainDigests": [
             "3ba256f4ca0bf62aca08f688f7ecf31800dd10e68371054e2f1605eff197ea81",
             "bcc8622f544022998f9d74d7671fd4f375ef31ae7f02c82321213f02de75a853",
-            "abd0eb27244e420f7e4097efcff1070f10cb378431c4038607fa920936e99bd7",
+            "1681bd806a09bceced37714cf4c927d8773be0a700f15ec61bb16e2af58b7fee",
             "b118ba78ff3ef4a189525c642184cbd320a268d2885681ab153544db554c5965",
             "e3072b6b01a4f692c2ac75c7c4995747f9a0fd1ce4f32e1ab1599f348661f570",
             "40c532ed3aa52144bdc8bb4422e04b23c54196d352ac9cb0f3e93a5a059af120"
@@ -908,7 +908,7 @@
           "version": "1.0.0",
           "toolchainDigests": [
             "2d2b38c4650795e2bba99e8ec38ca21adcb204042e9289577c535f7087e899d8",
-            "abd0eb27244e420f7e4097efcff1070f10cb378431c4038607fa920936e99bd7",
+            "1681bd806a09bceced37714cf4c927d8773be0a700f15ec61bb16e2af58b7fee",
             "bcc8622f544022998f9d74d7671fd4f375ef31ae7f02c82321213f02de75a853"
           ]
         },
@@ -959,7 +959,7 @@
           "version": "1.0.0",
           "toolchainDigests": [
             "a6da84444e815dd94c15887190c7d6bd48c7bca5975fb5d493eb77ab39f27d80",
-            "abd0eb27244e420f7e4097efcff1070f10cb378431c4038607fa920936e99bd7",
+            "1681bd806a09bceced37714cf4c927d8773be0a700f15ec61bb16e2af58b7fee",
             "bcc8622f544022998f9d74d7671fd4f375ef31ae7f02c82321213f02de75a853"
           ]
         },

--- a/orchestration/integrations.json
+++ b/orchestration/integrations.json
@@ -847,7 +847,7 @@
           "toolchainDigests": [
             "3ba256f4ca0bf62aca08f688f7ecf31800dd10e68371054e2f1605eff197ea81",
             "bcc8622f544022998f9d74d7671fd4f375ef31ae7f02c82321213f02de75a853",
-            "a87baab0a621d54a74d0c2030200e9086ac49d7518176327d923f23f0c347ec6",
+            "cf2d9cfbaeae71aa6a0356fcc319c1a8b9cf6c973dd9678fdff4ef7e585ffbb2",
             "b118ba78ff3ef4a189525c642184cbd320a268d2885681ab153544db554c5965",
             "e3072b6b01a4f692c2ac75c7c4995747f9a0fd1ce4f32e1ab1599f348661f570",
             "40c532ed3aa52144bdc8bb4422e04b23c54196d352ac9cb0f3e93a5a059af120"
@@ -908,7 +908,7 @@
           "version": "1.0.0",
           "toolchainDigests": [
             "2d2b38c4650795e2bba99e8ec38ca21adcb204042e9289577c535f7087e899d8",
-            "a87baab0a621d54a74d0c2030200e9086ac49d7518176327d923f23f0c347ec6",
+            "cf2d9cfbaeae71aa6a0356fcc319c1a8b9cf6c973dd9678fdff4ef7e585ffbb2",
             "bcc8622f544022998f9d74d7671fd4f375ef31ae7f02c82321213f02de75a853"
           ]
         },
@@ -959,7 +959,7 @@
           "version": "1.0.0",
           "toolchainDigests": [
             "a6da84444e815dd94c15887190c7d6bd48c7bca5975fb5d493eb77ab39f27d80",
-            "a87baab0a621d54a74d0c2030200e9086ac49d7518176327d923f23f0c347ec6",
+            "cf2d9cfbaeae71aa6a0356fcc319c1a8b9cf6c973dd9678fdff4ef7e585ffbb2",
             "bcc8622f544022998f9d74d7671fd4f375ef31ae7f02c82321213f02de75a853"
           ]
         },

--- a/orchestration/integrations.json
+++ b/orchestration/integrations.json
@@ -847,7 +847,7 @@
           "toolchainDigests": [
             "3ba256f4ca0bf62aca08f688f7ecf31800dd10e68371054e2f1605eff197ea81",
             "bcc8622f544022998f9d74d7671fd4f375ef31ae7f02c82321213f02de75a853",
-            "cf2d9cfbaeae71aa6a0356fcc319c1a8b9cf6c973dd9678fdff4ef7e585ffbb2",
+            "6012f6ef58415f3be60e3bdae7a7bf7af8888edce00d78d90799c26ab1f78db0",
             "b118ba78ff3ef4a189525c642184cbd320a268d2885681ab153544db554c5965",
             "e3072b6b01a4f692c2ac75c7c4995747f9a0fd1ce4f32e1ab1599f348661f570",
             "40c532ed3aa52144bdc8bb4422e04b23c54196d352ac9cb0f3e93a5a059af120"
@@ -908,7 +908,7 @@
           "version": "1.0.0",
           "toolchainDigests": [
             "2d2b38c4650795e2bba99e8ec38ca21adcb204042e9289577c535f7087e899d8",
-            "cf2d9cfbaeae71aa6a0356fcc319c1a8b9cf6c973dd9678fdff4ef7e585ffbb2",
+            "6012f6ef58415f3be60e3bdae7a7bf7af8888edce00d78d90799c26ab1f78db0",
             "bcc8622f544022998f9d74d7671fd4f375ef31ae7f02c82321213f02de75a853"
           ]
         },
@@ -959,7 +959,7 @@
           "version": "1.0.0",
           "toolchainDigests": [
             "a6da84444e815dd94c15887190c7d6bd48c7bca5975fb5d493eb77ab39f27d80",
-            "cf2d9cfbaeae71aa6a0356fcc319c1a8b9cf6c973dd9678fdff4ef7e585ffbb2",
+            "6012f6ef58415f3be60e3bdae7a7bf7af8888edce00d78d90799c26ab1f78db0",
             "bcc8622f544022998f9d74d7671fd4f375ef31ae7f02c82321213f02de75a853"
           ]
         },

--- a/orchestration/integrations.json
+++ b/orchestration/integrations.json
@@ -754,7 +754,7 @@
           "id": "understanding.quadrant.compat",
           "version": "1.0.0",
           "toolchainDigests": [
-            "713daf121490de0eb9e3a94139318da47b46d4368fce5ef09c5719b8d546f403",
+            "6aed5efc531e841d620484af4cee50cac4595a41d2dca38ed5352163bedecd00",
             "bcc8622f544022998f9d74d7671fd4f375ef31ae7f02c82321213f02de75a853"
           ]
         },
@@ -847,7 +847,7 @@
           "toolchainDigests": [
             "3ba256f4ca0bf62aca08f688f7ecf31800dd10e68371054e2f1605eff197ea81",
             "bcc8622f544022998f9d74d7671fd4f375ef31ae7f02c82321213f02de75a853",
-            "1681bd806a09bceced37714cf4c927d8773be0a700f15ec61bb16e2af58b7fee",
+            "af27dccb7fb01ac70e13daf8aa172270516a8703291fccdd712fccd765a0127e",
             "b118ba78ff3ef4a189525c642184cbd320a268d2885681ab153544db554c5965",
             "e3072b6b01a4f692c2ac75c7c4995747f9a0fd1ce4f32e1ab1599f348661f570",
             "40c532ed3aa52144bdc8bb4422e04b23c54196d352ac9cb0f3e93a5a059af120"
@@ -908,7 +908,7 @@
           "version": "1.0.0",
           "toolchainDigests": [
             "2d2b38c4650795e2bba99e8ec38ca21adcb204042e9289577c535f7087e899d8",
-            "1681bd806a09bceced37714cf4c927d8773be0a700f15ec61bb16e2af58b7fee",
+            "af27dccb7fb01ac70e13daf8aa172270516a8703291fccdd712fccd765a0127e",
             "bcc8622f544022998f9d74d7671fd4f375ef31ae7f02c82321213f02de75a853"
           ]
         },
@@ -959,7 +959,7 @@
           "version": "1.0.0",
           "toolchainDigests": [
             "a6da84444e815dd94c15887190c7d6bd48c7bca5975fb5d493eb77ab39f27d80",
-            "1681bd806a09bceced37714cf4c927d8773be0a700f15ec61bb16e2af58b7fee",
+            "af27dccb7fb01ac70e13daf8aa172270516a8703291fccdd712fccd765a0127e",
             "bcc8622f544022998f9d74d7671fd4f375ef31ae7f02c82321213f02de75a853"
           ]
         },

--- a/orchestration/internalization/mindwalk.json
+++ b/orchestration/internalization/mindwalk.json
@@ -42,7 +42,7 @@
     },
     "conformanceEvidence": {
       "evidenceIds": [
-        "local:mindwalk:adapter-source-sha256:fff59db3f54abee633b7174704c912c9bccf06c83afae1272e6bb1159eff1cb6",
+        "local:mindwalk:adapter-source-sha256:d5ce744b0d85a867e97b0d866c135aca0c1457dafc1374e7f8047fe3167ab586",
         "local:mindwalk:adapter-tests-sha256:e22021400f4dc468231a4ede76e68dbc189eb85e0580f3d86ddf96d99acec53e",
         "local:mindwalk:production-smoke-sha256:33c3c0c28e3c6b7d06ff53043606641c38c3a4890edcd3f2c7bddfc0f737aa45"
       ],
@@ -62,7 +62,7 @@
       },
       "source": {
         "path": "crates/code-intel-cli/src/session_evidence.rs",
-        "sha256": "fff59db3f54abee633b7174704c912c9bccf06c83afae1272e6bb1159eff1cb6"
+        "sha256": "d5ce744b0d85a867e97b0d866c135aca0c1457dafc1374e7f8047fe3167ab586"
       },
       "conformance": {
         "path": "crates/code-intel-cli/tests/session_evidence.rs",
@@ -136,7 +136,7 @@
       "path": "crates/code-intel-cli/src/session_evidence.rs",
       "description": "Pipeline-owned native Rust privacy, snapshot, normalization, structural join, and advisory signal boundary",
       "evidenceIds": [
-        "local:mindwalk:adapter-source-sha256:fff59db3f54abee633b7174704c912c9bccf06c83afae1272e6bb1159eff1cb6"
+        "local:mindwalk:adapter-source-sha256:d5ce744b0d85a867e97b0d866c135aca0c1457dafc1374e7f8047fe3167ab586"
       ]
     },
     {


### PR DESCRIPTION
## What

Remediates `artifact_ref.rs`, the repo's worst-health file (repowise `get_health` worst score: 1.85/10), via the four safe steps identified in a health-scan-driven audit:

1. **Dedupe** `valid_digest` / `valid_run_identity` / `sha256_hex` / `exact_object_keys`-style helpers into the existing leaf module `content_contract.rs`, re-exported through `capability.rs`, and consumed via `#[path]`/alias-import from `artifact_ref.rs`, `dag_coordinator.rs`, `session_evidence.rs`, `run_commit.rs` (later reverted, see below), and `understanding_quadrant.rs` (shares `expected_understanding_quadrant` classification policy instead of re-implementing it).
2. **Split `registered_contract`** (CCN 36, 282 lines, one big `artifactSchema`+`type` match) into six private `*_family_contract` helpers (repository/diagnosis/orientation/retirement/run-delivery/method-decision) chained with `.or_else()`, plus a shared `unregistered_contract_error()` for the two identical error-message call sites. Every arm's `schema`/`type`/`max_bytes`/`validate_payload` is unchanged — this only regroups match arms, it doesn't touch validation behavior.
3. **Flatten 12 complex boolean conditionals** into named `*_is_valid` predicate helpers via De Morgan's law (each `if (A) || (B) || (C) { return Err(...) }` OR-chain becomes `if !xyz_is_valid(...) { return Err(...) }` with an equivalent AND-chain) — same logic, readable names, zero behavior change.
4. **Revert `run_commit.rs`'s participation in step 1** (this commit). `run_commit.rs` is named verbatim in the frozen source sets of two retirement-packet verifiers (`Test-HospitalRetirementPacket.ps1`'s E08, `Test-IndexRetirementPacket.ps1`'s E10), which hash it byte-for-byte as part of proving those packets' evidence hasn't drifted. Deduping its two validators flipped both packets to "stale relative to its frozen source set" even though nothing about hospital diagnosis or the committed-only index actually changed. Restored the file byte-identical to its pre-refactor version (verified via `git show 77521a9 -- crates/code-intel-cli/src/run_commit.rs`); every other file from step 1 keeps the shared helpers.

`artifact_ref.rs` goes from ~3597 lines to ~3450.

## Why

Health scan flagged `artifact_ref.rs` as the lowest-scoring file in the repo (1.85/10), driven by a large duplicate-validator footprint, one very high-CCN dispatch function, and a cluster of complex boolean conditionals. This branch fixes the three items that were safe to fix mechanically (pure extraction/dedup, no behavior change, each step build+test-verified independently).

A fourth finding — `orchestration/integrations.json` and `sentrux.json` hand-maintaining a parallel contract registry with no sync mechanism against `artifact_ref.rs`'s `registered_contract` — was **not** touched here; it needs a real design decision, not a mechanical fix, and is tracked separately: #206.

Also filed #207 documenting repowise `dry_violation` findings from this pass that are **not** real duplicates (convergent shape, divergent semantics) — flagged so a future dedup pass doesn't merge them incorrectly.

## Verification (this branch, HEAD)

- `cargo test -p code-intel`: 3623/3623 passing
- Authoritative self-scan gate (`code-intel run execute ... --manifest orchestration/integrations.json`): exit 0, `outcome: completed`, zero domain/process failures, sentrux ratchet pass
- `legacy/scripts/tests/test-retirement-packets.ps1`: 8 packets + 2 audits pass, 0 known-blocked (confirmed E08/E10 both PASS after the run_commit.rs revert; both were red before it, root-caused via a clean-baseline worktree comparison against `a9baf61`)

## Reviewer notes

- `run_commit.rs` still has its own local `valid_digest`/`valid_run_identity` copies, deliberately, not an oversight — see commit 776296c's message. Please don't "clean this up" again without regenerating the E08/E10 retirement packets first (`legacy/tools/compatibility/New-HospitalRetirementPacket.ps1` / `New-IndexRetirementPacket.ps1`), since regeneration re-executes live `cargo test` fixtures and isn't purely mechanical.
- An earlier attempt in this branch to share `method_catalog::CARD_FIELDS` from `artifact_ref.rs` was reverted — `crates/code-intel-cli/tests/*.rs` integration binaries each hand-wire their own `#[path]` module set, and most binaries wiring in `artifact_ref.rs` don't also wire in `method_catalog.rs`, so it broke 9 test binaries with E0433. Kept the inline 17-field list instead; documented as a reusable gotcha.
