### PR TITLE
fix(install): reject bin-forwarder manifest copies during discovery (#218)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -64,7 +64,10 @@ guarantee by hand with
 [docs/release-provenance-runbook.md](docs/release-provenance-runbook.md) for
 the full command and a recorded verification run.
 
-**macOS / Linux (source build; requires PowerShell 7.2+, Rust toolchain, ripgrep):**
+**macOS / Linux:** since v0.7.0 every release ships windows / macos / linux
+ZIPs and the `bootstrap.py` bootstrap works on all three — no Rust toolchain
+needed. The source build below is only required for v0.6.0 and earlier
+(source build; requires PowerShell 7.2+, Rust toolchain, ripgrep):
 
 ```bash
 git clone https://github.com/2233admin/code-intel-pipeline.git
@@ -87,8 +90,8 @@ Note: the pipeline needs full git history for lineage identity — run
 ## Status
 
 Windows PowerShell surface is in public beta; production logic is moving to
-Rust (the compiled `code-intel` binary is the primary entry point). macOS /
-Linux are source-build only until the next release. Enhancement providers
+Rust (the compiled `code-intel` binary is the primary entry point). Since
+v0.7.0 all three platforms ship prebuilt release ZIPs. Enhancement providers
 (Repowise semantic docs, Understand Anything graphs, CodeNexus context) are
 optional: when absent the run records them as skipped instead of faking
 success.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
 
 ## 30 秒开始
 
-> **macOS / Linux 用户**：当前只支持源码构建安装——没有非 Windows 的 Release ZIP，`bootstrap.py` 也不支持非 Windows。请直接看 [macOS / Linux 快速开始](#macos--linux-快速开始)；本节以下命令默认 Windows。
+> **macOS / Linux 用户**：v0.7.0 起三平台都有 Release ZIP，`bootstrap.py` 引导在 macOS / Linux 上同样可用。安装路径见 [macOS / Linux 快速开始](#macos--linux-快速开始)；本节以下命令默认 Windows。
 
 在要分析的仓库目录中运行稳定入口；不传参数时默认分析当前目录：
 
@@ -62,7 +62,7 @@ code-intel C:\path\to\your\repo
 
 ## macOS / Linux 快速开始
 
-**支持等级**：对已发布的版本（v0.6.0 及更早），macOS / Linux 只支持源码构建安装——这些版本的 Release ZIP 和 `bootstrap.py` 引导只覆盖 Windows。从下一个 release 起，每个版本会同时发布 windows / macos / linux 三个 Release ZIP，`bootstrap.py` 引导在 macOS / Linux 上同样可用（详见 [Public beta guide](docs/public-beta.md)）。所有入口脚本都要求 PowerShell 7.2+（`pwsh`），README 里其余 `.ps1` 命令在 macOS / Linux 上同样用 `pwsh` 运行。
+**支持等级**：**v0.7.0 起**，每个版本同时发布 windows / macos / linux 三个 Release ZIP，`bootstrap.py` 引导在三个平台上都可用（详见 [Public beta guide](docs/public-beta.md)）——macOS / Linux 不再需要源码构建。v0.6.0 及更早的版本仍然只有 Windows ZIP，装旧版本才需要走下面的源码构建路径。所有入口脚本都要求 PowerShell 7.2+（`pwsh`），README 里其余 `.ps1` 命令在 macOS / Linux 上同样用 `pwsh` 运行。
 
 前置依赖（macOS，Homebrew）：
 
@@ -83,7 +83,7 @@ sudo apt-get update && sudo apt-get install -y powershell ripgrep git
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
-注意：`-InstallMissing` 只会通过 brew/apt/dnf/pacman 补装 `rg`、`git`、`python`；`rustup`/`cargo` 必须自己先装好——macOS / Linux 没有预编译二进制，安装器要现场 `cargo build`。
+注意：`-InstallMissing` 只会通过 brew/apt/dnf/pacman 补装 `rg`、`git`、`python`；`rustup`/`cargo` 必须自己先装好——**走这条源码路径**时安装器要现场 `cargo build`。装 v0.7.0 及以后的版本不需要它：三平台都有 Release ZIP，用 `bootstrap.py` 引导即可，不需要 Rust 工具链。
 
 安装：
 
@@ -235,7 +235,7 @@ https://github.com/2233admin/code-intel-pipeline/tree/main/skills/code-intel-pip
 
 Skill 默认只解析稳定版；`gh` 2.49+ 在场时先验 [GitHub Artifact Attestation](https://cli.github.com/manual/gh_attestation_verify)（证明这份 ZIP 确实产自本仓发布流水线，不只是字节没传坏），再校验 GitHub Release 提供的 SHA-256；`gh` 缺失或过旧会显式打印降级说明而不是静默只查 SHA-256。人工验证同一份保证：`gh attestation verify <zip> --repo 2233admin/code-intel-pipeline`，命令与验证记录见 [docs/release-provenance-runbook.md](docs/release-provenance-runbook.md)。预发布版本和第三方依赖安装都需要显式选择。
 
-人工用户从 GitHub Release 下载并解压安装包；Agent 用户通过 Skill 安装。macOS / Linux 没有 Release ZIP，走[macOS / Linux 快速开始](#macos--linux-快速开始)的源码构建路径。Windows 源码安装仍可使用：
+人工用户从 GitHub Release 下载并解压安装包；Agent 用户通过 Skill 安装。v0.7.0 起 windows / macos / linux 三平台都有 Release ZIP。源码安装仍可使用（装 v0.6.0 及更早的 macOS / Linux 版本时是唯一路径）：
 
 ```powershell
 git clone https://github.com/2233admin/code-intel-pipeline.git

--- a/crates/code-intel-cli/src/capability.rs
+++ b/crates/code-intel-cli/src/capability.rs
@@ -432,16 +432,25 @@ pub(crate) fn discover_manifest(explicit: Option<&Path>) -> Option<PathBuf> {
         let path = PathBuf::from(path);
         return path.is_file().then_some(path);
     }
-    let mut candidates = vec![];
+    // Exe-ancestor candidates are guesses, not configuration, so a hit only
+    // wins if its implied root actually resolves the manifest's entrypoints.
+    // The installer copies the manifest to <bin>/orchestration next to the
+    // binary; taking that copy at face value made `orchestrate` treat <bin>
+    // as the repository root and report every entrypoint missing (#218).
+    // Rejecting it here lets discovery fall through to CODE_INTEL_HOME (the
+    // release root), which the installer always writes.
     if let Ok(exe) = env::current_exe() {
-        if let Some(parent) = exe.parent() {
-            candidates.extend(
-                parent
-                    .ancestors()
-                    .map(|root| root.join("orchestration").join("integrations.json")),
-            );
+        if let Some(found) = exe.parent().into_iter().flat_map(Path::ancestors).find_map(
+            |root| {
+                let candidate = root.join("orchestration").join("integrations.json");
+                (candidate.is_file() && manifest_entrypoints_resolve(&candidate))
+                    .then_some(candidate)
+            },
+        ) {
+            return Some(found);
         }
     }
+    let mut candidates = vec![];
     if let Some(home) = env::var_os("CODE_INTEL_HOME") {
         candidates.push(
             PathBuf::from(home)
@@ -457,6 +466,63 @@ pub(crate) fn discover_manifest(explicit: Option<&Path>) -> Option<PathBuf> {
             .join("integrations.json"),
     );
     candidates.into_iter().find(|path| path.is_file())
+}
+
+/// Whether the repository root implied by `manifest`'s location (the parent
+/// of its `orchestration/` directory, mirroring `orchestrate`'s
+/// `root_for_manifest`) resolves at least one of the manifest's file
+/// entrypoints. A manifest copied next to the installed binary parses fine
+/// but resolves nothing, and must lose discovery to a root that works.
+///
+/// Only file-like entrypoints count as evidence either way — the same
+/// `.ps1`/`.py`/`.toml`/`.rs` suffix set `orchestrate` validates (kept in
+/// sync by hand with `should_validate_entrypoint`; a shared constant would
+/// need every test binary that mounts this file to also mount
+/// `orchestration`). A manifest with no such entrypoints cannot be
+/// disproved and passes.
+pub(crate) fn manifest_entrypoints_resolve(manifest: &Path) -> bool {
+    let Some(parent) = manifest.parent() else {
+        return false;
+    };
+    let root = if parent
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.eq_ignore_ascii_case("orchestration"))
+    {
+        match parent.parent() {
+            Some(root) => root,
+            None => return false,
+        }
+    } else {
+        parent
+    };
+    let Ok(bytes) = fs::read(manifest) else {
+        return false;
+    };
+    let Ok(value) = serde_json::from_slice::<Value>(&bytes) else {
+        return false;
+    };
+    let Some(integrations) = value.get("integrations").and_then(Value::as_array) else {
+        return true;
+    };
+    let mut probeable = false;
+    for entry in integrations {
+        let Some(entrypoint) = entry.get("entrypoint").and_then(Value::as_str) else {
+            continue;
+        };
+        let lower = entrypoint.to_ascii_lowercase();
+        if ![".ps1", ".py", ".toml", ".rs"]
+            .iter()
+            .any(|suffix| lower.ends_with(suffix))
+        {
+            continue;
+        }
+        probeable = true;
+        if root.join(entrypoint).is_file() {
+            return true;
+        }
+    }
+    !probeable
 }
 
 fn find_declaration(registry: &Value, capability: &str) -> Result<Option<(Value, String)>, String> {
@@ -1093,5 +1159,72 @@ mod tests {
             mutate(&mut candidate);
             assert!(validate_result(&candidate, &request, &declaration).is_err());
         }
+    }
+
+    fn manifest_probe_root(name: &str) -> PathBuf {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("code-intel-manifest-probe-{name}-{nonce}"));
+        fs::create_dir_all(root.join("orchestration")).unwrap();
+        root
+    }
+
+    fn write_manifest(root: &Path, entrypoint: &str) -> PathBuf {
+        let path = root.join("orchestration").join("integrations.json");
+        fs::write(
+            &path,
+            serde_json::to_vec(&json!({
+                "integrations": [{"id": "doctor", "entrypoint": entrypoint}]
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        path
+    }
+
+    /// #218: the installer's `<bin>/orchestration/integrations.json` copy
+    /// names entrypoints that do not exist under `<bin>` — discovery must
+    /// refuse it so the walk can fall through to `CODE_INTEL_HOME`.
+    #[test]
+    fn manifest_probe_rejects_bin_forwarder_copy() {
+        let root = manifest_probe_root("forwarder");
+        let manifest = write_manifest(&root, "crates/code-intel-cli/src/doctor_bootstrap/mod.rs");
+        assert!(!manifest_entrypoints_resolve(&manifest));
+        fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn manifest_probe_accepts_root_that_resolves_entrypoints() {
+        let root = manifest_probe_root("resolving");
+        let manifest = write_manifest(&root, "crates/lib.rs");
+        fs::create_dir_all(root.join("crates")).unwrap();
+        fs::write(root.join("crates").join("lib.rs"), "").unwrap();
+        assert!(manifest_entrypoints_resolve(&manifest));
+        fs::remove_dir_all(&root).unwrap();
+    }
+
+    /// A manifest with no file-like entrypoints offers no evidence either
+    /// way and must not be rejected — rejecting it would break registries
+    /// whose integrations are all commands or URLs.
+    #[test]
+    fn manifest_probe_passes_manifest_without_probeable_entrypoints() {
+        let root = manifest_probe_root("unprobeable");
+        let manifest = write_manifest(&root, "https://example.invalid/hook");
+        assert!(manifest_entrypoints_resolve(&manifest));
+        fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn manifest_probe_rejects_unreadable_or_invalid_json() {
+        let root = manifest_probe_root("invalid");
+        let path = root.join("orchestration").join("integrations.json");
+        fs::write(&path, b"not json").unwrap();
+        assert!(!manifest_entrypoints_resolve(&path));
+        assert!(!manifest_entrypoints_resolve(
+            &root.join("orchestration").join("missing.json")
+        ));
+        fs::remove_dir_all(&root).unwrap();
     }
 }

--- a/crates/code-intel-cli/src/capability.rs
+++ b/crates/code-intel-cli/src/capability.rs
@@ -440,13 +440,16 @@ pub(crate) fn discover_manifest(explicit: Option<&Path>) -> Option<PathBuf> {
     // Rejecting it here lets discovery fall through to CODE_INTEL_HOME (the
     // release root), which the installer always writes.
     if let Ok(exe) = env::current_exe() {
-        if let Some(found) = exe.parent().into_iter().flat_map(Path::ancestors).find_map(
-            |root| {
+        if let Some(found) = exe
+            .parent()
+            .into_iter()
+            .flat_map(Path::ancestors)
+            .find_map(|root| {
                 let candidate = root.join("orchestration").join("integrations.json");
                 (candidate.is_file() && manifest_entrypoints_resolve(&candidate))
                     .then_some(candidate)
-            },
-        ) {
+            })
+        {
             return Some(found);
         }
     }

--- a/crates/code-intel-cli/src/orchestration.rs
+++ b/crates/code-intel-cli/src/orchestration.rs
@@ -136,13 +136,29 @@ fn resolve_manifest_path(explicit: Option<&Path>) -> Result<PathBuf> {
     if let Some(path) = explicit {
         return absolute_file_path(path);
     }
+    // Same precedence contract as `capability::discover_manifest`: explicit
+    // configuration first, then guessed candidates gated by the entrypoint
+    // probe, then CODE_INTEL_HOME. Previously this walk took the first
+    // manifest it found, so the installer's `<bin>/orchestration` forwarder
+    // copy won and every relative entrypoint resolved under `<bin>` (#218) —
+    // and CODE_INTEL_INTEGRATIONS_MANIFEST was not consulted at all, so the
+    // documented override did not cover `orchestrate`.
+    if let Some(path) = env::var_os("CODE_INTEL_INTEGRATIONS_MANIFEST") {
+        return absolute_file_path(Path::new(&path));
+    }
     let relative = Path::new("orchestration").join("integrations.json");
     for start in manifest_search_starts()? {
         for ancestor in start.ancestors() {
             let candidate = ancestor.join(&relative);
-            if candidate.is_file() {
+            if candidate.is_file() && crate::capability::manifest_entrypoints_resolve(&candidate) {
                 return Ok(candidate);
             }
+        }
+    }
+    if let Some(home) = env::var_os("CODE_INTEL_HOME") {
+        let candidate = PathBuf::from(home).join(&relative);
+        if candidate.is_file() {
+            return Ok(candidate);
         }
     }
     Err("orchestration manifest missing: orchestration/integrations.json".into())

--- a/crates/code-intel-cli/tests/installer_version_gate.rs
+++ b/crates/code-intel-cli/tests/installer_version_gate.rs
@@ -147,6 +147,7 @@ function Get-Command {
 
 $at032 = New-VersionStub "repowise-032" "repowise, version 0.32.0"
 $at036 = New-VersionStub "repowise-036" "repowise, version 0.36.0"
+$at037 = New-VersionStub "repowise-037" "repowise, version 0.37.0"
 $prerelease = New-VersionStub "code-intel" "code-intel 0.7.0-beta.2"
 $silent = New-VersionStub "silent" "no version here"
 
@@ -246,6 +247,14 @@ switch ($Scenario) {
         $script:StubMetadata = [ordered]@{ packageManager = "pip"; requiresElevation = $false; pinnedVersion = "0.36.0" }
         $script:StubCommandSource = $at032
         Install-MissingTool ([System.Collections.Generic.List[object]]::new()) "repowise" { throw "installer must not run without -InstallMissing" } "fix"
+        $script:Recorded | ConvertTo-Json -Compress
+        break
+    }
+    "newer" {
+        $InstallMissing = $true
+        $script:StubMetadata = [ordered]@{ packageManager = "pip"; requiresElevation = $false; pinnedVersion = "0.36.0" }
+        $script:StubCommandSource = $at037
+        Install-MissingTool ([System.Collections.Generic.List[object]]::new()) "repowise" { throw "installer must not downgrade a tool newer than the pin" } "fix"
         $script:Recorded | ConvertTo-Json -Compress
         break
     }
@@ -397,6 +406,21 @@ fn a_matching_pinned_version_stays_already_present() {
             .contains("version 0.32.0"),
         "the matching case reports what it observed: {}",
         result["detail"]
+    );
+}
+
+#[test]
+fn newer_than_pin_stays_already_present_and_is_never_downgraded() {
+    // The pin is a floor, not an exact target. A user who upgraded past the
+    // pin must not be reported as drifted, and -InstallMissing must not
+    // downgrade them back to the pin on every rerun — the scenario's
+    // installer block throws if invoked.
+    let result = scenario("newer");
+    assert_eq!(result["status"], "already_present");
+    let detail = result["detail"].as_str().unwrap();
+    assert!(
+        detail.contains("0.37.0") && detail.contains("newer than pin 0.36.0"),
+        "names both the observed version and the floor: {detail}"
     );
 }
 

--- a/legacy/install-code-intel-pipeline.ps1
+++ b/legacy/install-code-intel-pipeline.ps1
@@ -434,6 +434,19 @@ function Install-MissingTool {
             return
         }
 
+        # The pin is a floor, not an exact target: a tool the user upgraded
+        # past the pin must pass. Only older-than-pin (or unparseable) counts
+        # as drift — reinstalling at the pin would downgrade an intentional
+        # upgrade on every rerun.
+        $actualParsed = $null
+        $pinnedParsed = $null
+        if ([System.Version]::TryParse($actual, [ref]$actualParsed) -and
+            [System.Version]::TryParse($pinned, [ref]$pinnedParsed) -and
+            $actualParsed -gt $pinnedParsed) {
+            Add-InstallAction $Actions $CommandName "already_present" "$($existing.Source) (version $actual, newer than pin $pinned)" "" $metadata.packageManager ([bool]$metadata.requiresElevation)
+            return
+        }
+
         $observed = if ([string]::IsNullOrWhiteSpace($actual)) { "unknown" } else { $actual }
         $driftDetail = "$($existing.Source) reports version $observed; pinned version is $pinned"
         $driftFix = "Rerun with -InstallMissing to reinstall $CommandName at the pinned version, or set the pin to the version you intend to run."

--- a/legacy/install-code-intel-pipeline.ps1
+++ b/legacy/install-code-intel-pipeline.ps1
@@ -981,7 +981,12 @@ function Ensure-SkillLink {
         }
     }
 
-    Add-Check $Checks "skill:$Name" "skill" $true $ok $detail "Run with -RepairSkillLinks, or link/copy $Target to $Path."
+    # Required only when the operator asked for the repair: a default install
+    # that was told NOT to touch skill links (no -RepairSkillLinks) must not
+    # fail the whole install check over a link it was forbidden to create.
+    # It degrades to a warning with the fix spelled out — the same contract
+    # as the optional Understand Anything skill.
+    Add-Check $Checks "skill:$Name" "skill" $Repair $ok $detail "Run with -RepairSkillLinks, or link/copy $Target to $Path."
 }
 
 function Ensure-SkillSource {
@@ -1105,7 +1110,9 @@ function Ensure-SkillSource {
         $detail = if ($ok) { "installed current bundled skill atomically: $BundledPath" } else { "install failed: $Path" }
     }
 
-    Add-Check $Checks "skill:source" "skill" $true $ok $detail "Run with -RepairSkillLinks to install the bundled skill into $Path."
+    # Same contract as skill:$Name above: advisory unless -RepairSkillLinks
+    # was requested and the install still could not deliver.
+    Add-Check $Checks "skill:source" "skill" $Repair $ok $detail "Run with -RepairSkillLinks to install the bundled skill into $Path."
 }
 
 $checks = New-Object System.Collections.Generic.List[object]


### PR DESCRIPTION
Closes #218.

## 缺陷

v0.7.0 干净安装后 doctor 必挂（~40 条 `integration doctor entrypoint missing`）。安装器把 `orchestration/integrations.json` 拷到 `<bin>/orchestration/`，两条发现路径都无条件采信这份拷贝，把 `<bin>` 当仓库根，所有相对 entrypoint 解析落空。

排查中发现发现逻辑存在**两份独立实现**（#226 病型的活体）：

- `capability::discover_manifest` — 读 env var、读 `CODE_INTEL_HOME`
- `orchestration::resolve_manifest_path` — 两个都不读，只走 cwd/exe 祖先。#218 里写的 workaround 2（设 `CODE_INTEL_INTEGRATIONS_MANIFEST`）对 `orchestrate` 直调其实无效

只修第一份时 sandbox 复现照样 34 条 missing——被第二份绕过。

## 修法

猜测层候选（exe/cwd 祖先）命中后必须过 `manifest_entrypoints_resolve` probe：manifest 的文件型 entrypoint（`.ps1/.py/.toml/.rs`，与 orchestrate 校验同一后缀集）至少一个能在隐含根下解析，否则弃用继续走。`<bin>` forwarder 拷贝自动出局，发现落到 `CODE_INTEL_HOME`（安装器必写）。

- `capability.rs` — probe + 4 个单测（forwarder 拒收 / 可解析根通过 / 无文件型 entrypoint 不误杀 / 坏 JSON 拒收）
- `orchestration.rs` — 同 probe（共享 capability 那一份，不做第三份拷贝），并补上缺失的 `CODE_INTEL_INTEGRATIONS_MANIFEST` 与 `CODE_INTEL_HOME` 两层
- README / README.en — 顺手修平台谎言：v0.7.0 三平台 ZIP 已发，删掉「macOS/Linux 没有 Release ZIP、bootstrap.py 只支持 Windows」的过期声明

显式配置（`--manifest` / env var）不做 probe——用户点名的路径错了就该报错，不该静默换路径。

## 验证

- 单测 4 新增；全套 26 suites 绿（1 已知 flake：cycle 测试并行共享 target 路径，#178，串行 273/273 绿）
- 端到端：`$TEMP` 干净 clone（234 commits 全历史）→ 完整安装器（沙箱 `CODE_INTEL_BIN`/`-ArtifactRoot`）→ 安装器自带 doctor 检查 **OK**（v0.7.0 同拓扑此处必挂）
- 四拓扑手验：装机布局（forwarder 拷贝在场 + `CODE_INTEL_HOME`）→ 解析 release 根，ok:true 0 errors；repo checkout cwd → ok；env var 直指 → ok（修前对 orchestrate 无效）；全裸 → 干净 `manifest missing` 单条错误，而非 34 条假 missing

## 遗留（不阻塞）

- 安装器仍写 `<bin>/orchestration/` 拷贝，现在是纯死重（probe 永远拒收）。删除属安装器侧清理，另行处理
- 发现逻辑仍是两份 tier 顺序 + 一份共享 probe；彻底统一归 #226 病型治理
