### PR TITLE
chore(release): cut v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] — 2026-08-08
+
+### Fixed
+
+- **安装后 discovery 误把 bin-forwarder manifest 当仓库根（#218）**：安装器会把 `orchestration/integrations.json` 复制到二进制旁边以便脱离 checkout 解析能力清单，但两条 discovery 路径都对这份副本照单全收、把 `<bin>` 当仓库根，导致干净的 v0.7.0 安装报出约 40 条相对入口缺失的假错误。现在 exe 祖先目录候选只是猜测而非配置：命中必须至少解析出一个 manifest 文件入口才算数，否则回落到安装器必写的 `CODE_INTEL_HOME`；`orchestration::resolve_manifest_path` 同享这套探测，并补上它一直缺的两层——`CODE_INTEL_INTEGRATIONS_MANIFEST` 显式覆盖与 `CODE_INTEL_HOME` 回落。README 同步删掉「macOS/Linux 无发布 ZIP、bootstrap.py 仅限 Windows」的过时说法（v0.7.0 起三平台齐发）。
+
 ## [0.7.0] — 2026-08-07
 
 首个正式版切割。#14 的发布闸验收条款本身早已做完（自扫门禁、`dag_run`/`execution_kernel` 循环依赖修复，issue 自己的 checklist 勾过）；剩下未勾的 session-intelligence/2D viewer 是另一条独立多版本 roadmap，跟能不能发 GA 无关，留 backlog。#158 复核后没有整条延后：Skill 安装路径升级为先验 GitHub Artifact Attestation 再退回 SHA-256（`gh` 缺失时显式降级，不静默）；跑了一次真实的 supply-chain 自审（`orchestration/audit/reports/audit-report.json`，8.0/10，一条确认发现——发布 tag 未签名也没有 ruleset 保护）；对已发布的 v0.7.0-beta.6 三平台 ZIP 实测 `gh attestation verify` 全过，记录在 `docs/release-provenance-runbook.md`；OpenSSF Best Practices 逐条自评进 `docs/openssf-best-practices-gap.md`。只有「签名 tag + tag 保护 ruleset」明确留给维护者（改仓库设置不该由 agent 单方面做），继续在 #158 追踪。

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,7 @@ checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "code-intel"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "serde_json",
  "tiny_http",

--- a/crates/code-intel-cli/Cargo.toml
+++ b/crates/code-intel-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "code-intel"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 description = "Local Code Intel Pipeline CLI for artifact resume and contract checks"
 license = "MIT"

--- a/crates/code-intel-cli/tests/fixtures/cli-head-parity.v2.json
+++ b/crates/code-intel-cli/tests/fixtures/cli-head-parity.v2.json
@@ -32,7 +32,7 @@
         "--json"
       ],
       "exitCode": 0,
-      "stdoutUtf8": "{\"name\":\"code-intel\",\"schema\":\"code-intel-version.v1\",\"version\":\"0.7.0\"}\n",
+      "stdoutUtf8": "{\"name\":\"code-intel\",\"schema\":\"code-intel-version.v1\",\"version\":\"0.7.1\"}\n",
       "stderrUtf8": ""
     },
     {
@@ -42,7 +42,7 @@
         "--json"
       ],
       "exitCode": 0,
-      "stdoutUtf8": "{\"name\":\"code-intel\",\"schema\":\"code-intel-version.v1\",\"version\":\"0.7.0\"}\n",
+      "stdoutUtf8": "{\"name\":\"code-intel\",\"schema\":\"code-intel-version.v1\",\"version\":\"0.7.1\"}\n",
       "stderrUtf8": ""
     },
     {

--- a/orchestration/toolchain-versions.v1.json
+++ b/orchestration/toolchain-versions.v1.json
@@ -93,7 +93,7 @@
     },
     {
       "name": "code-intel",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "scope": "runtime",
       "required": true,
       "rationale": "The pipeline's own binary. An installed copy that lags the tree is invisible without a version surface: a v0.6.0 build answered `snapshot identity` in 10.9s where the current tree answers in 0.28s.",


### PR DESCRIPTION
## 目的

切 v0.7.1 补丁版。v0.7.0 GA（2026-08-07）之后 main 上唯一改动是 #228 的安装 discovery 修复（#218），值得单独出补丁——干净安装 v0.7.0 会报 ~40 条假的入口缺失错误。

## 变更面

- `crates/code-intel-cli/Cargo.toml`：0.7.0 → 0.7.1
- `Cargo.lock`：同步
- `CHANGELOG.md`：0.7.1 条目（安装 discovery 修复摘要）
- `crates/code-intel-cli/tests/fixtures/cli-head-parity.v2.json`：`--version` / `-V` 两处 stdout 版本串同步（惯例：fixture 与二进制输出同步，contract id 不升版）

## 验证

- 本地 `cargo test --test cli_head_parity`：3 passed
- 本地权威 self-scan：sentrux 棘轮未触发；evidence.graph 因本地 `.claude/worktrees/` 编译垃圾超 64MB 上限报 process fail，CI 干净环境不受影响

合并后打 tag `v0.7.1` 触发 release workflow 三平台发布。

Refs #218
