### PR TITLE
chore(release): make version floors explicit

### DIFF
--- a/crates/code-intel-cli/tests/cli_head_parity.rs
+++ b/crates/code-intel-cli/tests/cli_head_parity.rs
@@ -77,14 +77,25 @@ fn assert_exact_process_result(
         expected["exitCode"].as_i64().map(|code| code as i32),
         "{label} exit"
     );
-    assert_eq!(
-        output.stdout,
-        expected["stdoutUtf8"]
-            .as_str()
-            .expect("stdoutUtf8")
-            .as_bytes(),
-        "{label} stdout bytes"
-    );
+    if expected["stdoutSemantics"] == "version-minimum" {
+        assert_version_at_least(
+            label,
+            &output.stdout,
+            expected["stdoutUtf8"]
+                .as_str()
+                .expect("stdoutUtf8")
+                .as_bytes(),
+        );
+    } else {
+        assert_eq!(
+            output.stdout,
+            expected["stdoutUtf8"]
+                .as_str()
+                .expect("stdoutUtf8")
+                .as_bytes(),
+            "{label} stdout bytes"
+        );
+    }
     assert_eq!(
         output.stderr,
         expected["stderrUtf8"]
@@ -93,6 +104,33 @@ fn assert_exact_process_result(
             .as_bytes(),
         "{label} stderr bytes"
     );
+}
+
+fn assert_version_at_least(label: &str, actual: &[u8], minimum: &[u8]) {
+    let parse = |bytes: &[u8]| {
+        let value: serde_json::Value = serde_json::from_slice(bytes)
+            .unwrap_or_else(|error| panic!("{label} version output is not JSON: {error}"));
+        value["version"]
+            .as_str()
+            .unwrap_or_else(|| panic!("{label} version output omits version"))
+            .split(['.', '-'])
+            .take(3)
+            .map(|part| part.parse::<u64>().ok())
+            .collect::<Option<Vec<_>>>()
+            .unwrap_or_else(|| panic!("{label} version is not numeric"))
+    };
+    let actual = parse(actual);
+    let minimum = parse(minimum);
+    let at_least = (0..3)
+        .map(|index| {
+            (
+                actual.get(index).copied().unwrap_or_default(),
+                minimum.get(index).copied().unwrap_or_default(),
+            )
+        })
+        .find(|(actual, minimum)| actual != minimum)
+        .is_none_or(|(actual, minimum)| actual > minimum);
+    assert!(at_least, "{label} version is below the fixture floor");
 }
 
 #[test]

--- a/crates/code-intel-cli/tests/fixtures/cli-head-parity.v2.json
+++ b/crates/code-intel-cli/tests/fixtures/cli-head-parity.v2.json
@@ -27,6 +27,7 @@
   "cases": [
     {
       "name": "version --version",
+      "stdoutSemantics": "version-minimum",
       "argv": [
         "--version",
         "--json"
@@ -37,6 +38,7 @@
     },
     {
       "name": "version -V",
+      "stdoutSemantics": "version-minimum",
       "argv": [
         "-V",
         "--json"

--- a/crates/code-intel-cli/tests/toolchain_versions.rs
+++ b/crates/code-intel-cli/tests/toolchain_versions.rs
@@ -9,7 +9,9 @@
 //! `declaredIn[].pattern` is checked against EVERY match in the file, not the
 //! first: `ci.yml` installs ast-grep in two independent jobs, each with its own
 //! hardcoded version, and a change that updates one and forgets the other is
-//! exactly the drift this file is meant to catch.
+//! exactly the drift this file is meant to catch. The pipeline's own entry is
+//! deliberately a minimum: Cargo.toml owns the current version, while the
+//! fixture is a historical floor rather than a second release-edit site.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -50,8 +52,9 @@ fn find_all(text: &str, pattern: &str) -> Vec<String> {
     let terminators = expand_class(&body[open + 3..close]);
     let suffix = unescape(&body[close + 3..]);
 
+    let normalized = text.replace("\\\"", "\"");
     let mut out = Vec::new();
-    for line in text.lines() {
+    for line in normalized.lines() {
         let start = match (anchored, line.find(&prefix)) {
             (true, Some(0)) => 0,
             (true, _) => continue,
@@ -96,6 +99,31 @@ fn expand_class(class: &str) -> Vec<char> {
 
 fn unescape(pattern: &str) -> String {
     pattern.replace("\\$", "$").replace("\\\\", "\\")
+}
+
+fn version_at_least(actual: &str, minimum: &str) -> bool {
+    let parse = |value: &str| {
+        value
+            .split(['.', '-'])
+            .take(3)
+            .map(|part| part.parse::<u64>().ok())
+            .collect::<Option<Vec<_>>>()
+    };
+    let Some(actual) = parse(actual) else {
+        return false;
+    };
+    let Some(minimum) = parse(minimum) else {
+        return false;
+    };
+    (0..3)
+        .map(|index| {
+            (
+                actual.get(index).copied().unwrap_or_default(),
+                minimum.get(index).copied().unwrap_or_default(),
+            )
+        })
+        .find(|(actual, minimum)| actual != minimum)
+        .is_none_or(|(actual, minimum)| actual > minimum)
 }
 
 #[test]
@@ -151,10 +179,17 @@ fn every_declared_version_matches_its_real_declaration_sites() {
                 "{name}: pattern `{pattern}` matched nothing in {file} — the declaration moved and this manifest is now stale"
             );
             for (index, actual) in found.iter().enumerate() {
-                assert_eq!(
-                    actual, expected,
-                    "{name}: match #{index} in {file} is {actual}, manifest says {expected}"
-                );
+                if tool["comparison"] == "minimum" {
+                    assert!(
+                        version_at_least(actual, expected),
+                        "{name}: match #{index} in {file} is {actual}, below minimum {expected}"
+                    );
+                } else {
+                    assert_eq!(
+                        actual, expected,
+                        "{name}: match #{index} in {file} is {actual}, manifest says {expected}"
+                    );
+                }
             }
         }
     }

--- a/orchestration/toolchain-versions.v1.json
+++ b/orchestration/toolchain-versions.v1.json
@@ -1,6 +1,6 @@
 {
   "schema": "code-intel-toolchain-versions.v1",
-  "note": "Single source for the consistency self-check: does this machine run the versions this repository declares? Every entry's `version` is asserted against its real declaration sites by tests/toolchain_versions.rs, so this file cannot silently drift from them. Upstream freshness (is the declared version behind what the ecosystem publishes?) is deliberately NOT modelled here — pinning is a supply-chain control (supply-chain-001/003) and reproducibility control (rust-toolchain.toml), and conflating the two would turn a pin into an auto-upgrade.",
+  "note": "Single source for the consistency self-check: does this machine run the versions this repository declares? Entries are exact unless `comparison` is `minimum`; the pipeline's own version is a floor so Cargo.toml remains the only current release site. Every entry is checked against its real declaration sites by tests/toolchain_versions.rs. Upstream freshness is deliberately NOT modelled here.",
   "tools": [
     {
       "name": "rust-toolchain",
@@ -94,6 +94,7 @@
     {
       "name": "code-intel",
       "version": "0.7.1",
+      "comparison": "minimum",
       "scope": "runtime",
       "required": true,
       "rationale": "The pipeline's own binary. An installed copy that lags the tree is invisible without a version surface: a v0.6.0 build answered `snapshot identity` in 10.9s where the current tree answers in 0.28s.",
@@ -101,6 +102,10 @@
         {
           "file": "crates/code-intel-cli/Cargo.toml",
           "pattern": "^version = \"([^\"]+)\""
+        },
+        {
+          "file": "crates/code-intel-cli/tests/fixtures/cli-head-parity.v2.json",
+          "pattern": "\"version\":\"([^\"]+)\""
         }
       ],
       "probe": {


### PR DESCRIPTION
Fixes #241\n\nTreats the pipeline version manifest and CLI parity fixture as minimum-version floors, records both fixture declarations, and leaves Cargo.toml plus CHANGELOG as the editable release sites.