### PR TITLE
fix(doctor): resolve packaged graph binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,28 @@ jobs:
         # breaks — was unreachable from the step named "release gate parity".
         run: code-intel doctor bootstrap --repo-path . --no-require-repowise --require-provider-conformance
 
+      - name: Installed graph binary smoke
+        shell: pwsh
+        run: |
+          $installed = (Get-Command code-intel -ErrorAction Stop).Source
+          $installBin = Split-Path -Parent $installed
+          $installRoot = Split-Path -Parent $installBin
+          $json = & $installed doctor bootstrap --pipeline-root $installRoot --repo-path (Resolve-Path .) --no-require-repowise --json
+          if ($LASTEXITCODE -notin @(0, 1)) {
+            throw "installed Doctor process failed with exit code $LASTEXITCODE"
+          }
+          $observation = ($json -join [Environment]::NewLine) | ConvertFrom-Json
+          $graph = $observation.checks.graphProvider
+          if (-not $graph.binaryFound) {
+            throw "installed Doctor did not find its packaged graph binary: $($graph | ConvertTo-Json -Compress)"
+          }
+          $expected = [IO.Path]::GetFullPath((Join-Path $installBin (if ($IsWindows) { "code-intel.exe" } else { "code-intel" })))
+          $actual = [IO.Path]::GetFullPath([string]$graph.binaryPath)
+          if ($actual -ne $expected) {
+            throw "installed Doctor resolved $actual instead of the installed graph binary $expected"
+          }
+          Write-Host "Installed graph binary smoke passed: $actual"
+
       - name: GitHub research contract tests
         shell: pwsh
         run: .\legacy/scripts/tests/test-github-solution-research.ps1 -RepoPath .
@@ -541,6 +563,28 @@ jobs:
         # the self-scan runs before the install, so this is the only place the
         # installed-overlay branch is reachable.
         run: code-intel doctor bootstrap --repo-path . --no-require-repowise --require-provider-conformance --json
+
+      - name: Installed graph binary smoke
+        shell: pwsh
+        run: |
+          $installed = (Get-Command code-intel -ErrorAction Stop).Source
+          $installBin = Split-Path -Parent $installed
+          $installRoot = Split-Path -Parent $installBin
+          $json = & $installed doctor bootstrap --pipeline-root $installRoot --repo-path (Resolve-Path .) --no-require-repowise --json
+          if ($LASTEXITCODE -notin @(0, 1)) {
+            throw "installed Doctor process failed with exit code $LASTEXITCODE"
+          }
+          $observation = ($json -join [Environment]::NewLine) | ConvertFrom-Json
+          $graph = $observation.checks.graphProvider
+          if (-not $graph.binaryFound) {
+            throw "installed Doctor did not find its packaged graph binary: $($graph | ConvertTo-Json -Compress)"
+          }
+          $expected = [IO.Path]::GetFullPath((Join-Path $installBin (if ($IsWindows) { "code-intel.exe" } else { "code-intel" })))
+          $actual = [IO.Path]::GetFullPath([string]$graph.binaryPath)
+          if ($actual -ne $expected) {
+            throw "installed Doctor resolved $actual instead of the installed graph binary $expected"
+          }
+          Write-Host "Installed graph binary smoke passed: $actual"
 
       # The steps above install from the local checkout, never exercising the
       # actual release artifact a real user downloads (#59 proposal 6: this

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,7 @@ jobs:
           if ($LASTEXITCODE -notin @(0, 1)) {
             throw "installed Doctor process failed with exit code $LASTEXITCODE"
           }
+          $global:LASTEXITCODE = 0
           $observation = ($json -join [Environment]::NewLine) | ConvertFrom-Json
           $graph = $observation.checks.graphProvider
           if (-not $graph.binaryFound) {
@@ -575,6 +576,7 @@ jobs:
           if ($LASTEXITCODE -notin @(0, 1)) {
             throw "installed Doctor process failed with exit code $LASTEXITCODE"
           }
+          $global:LASTEXITCODE = 0
           $observation = ($json -join [Environment]::NewLine) | ConvertFrom-Json
           $graph = $observation.checks.graphProvider
           if (-not $graph.binaryFound) {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,7 +228,8 @@ jobs:
           if (-not $graph.binaryFound) {
             throw "installed Doctor did not find its packaged graph binary: $($graph | ConvertTo-Json -Compress)"
           }
-          $expected = [IO.Path]::GetFullPath((Join-Path $installBin (if ($IsWindows) { "code-intel.exe" } else { "code-intel" })))
+          $binaryName = if ($IsWindows) { "code-intel.exe" } else { "code-intel" }
+          $expected = [IO.Path]::GetFullPath((Join-Path $installBin $binaryName))
           $actual = [IO.Path]::GetFullPath([string]$graph.binaryPath)
           if ($actual -ne $expected) {
             throw "installed Doctor resolved $actual instead of the installed graph binary $expected"
@@ -579,7 +580,8 @@ jobs:
           if (-not $graph.binaryFound) {
             throw "installed Doctor did not find its packaged graph binary: $($graph | ConvertTo-Json -Compress)"
           }
-          $expected = [IO.Path]::GetFullPath((Join-Path $installBin (if ($IsWindows) { "code-intel.exe" } else { "code-intel" })))
+          $binaryName = if ($IsWindows) { "code-intel.exe" } else { "code-intel" }
+          $expected = [IO.Path]::GetFullPath((Join-Path $installBin $binaryName))
           $actual = [IO.Path]::GetFullPath([string]$graph.binaryPath)
           if ($actual -ne $expected) {
             throw "installed Doctor resolved $actual instead of the installed graph binary $expected"

--- a/crates/code-intel-cli/src/doctor_bootstrap/mod.rs
+++ b/crates/code-intel-cli/src/doctor_bootstrap/mod.rs
@@ -260,11 +260,12 @@ pub(crate) fn observe(options: &Options) -> Result<Value, String> {
     }))
 }
 
-/// `target/release` then `target/debug`, with the platform-correct name — the
-/// order the retired script probed and the order `binaryPath` reports.
-fn binary_candidates(pipeline_root: &Path, platform: &str) -> [PathBuf; 2] {
+/// The packaged release binary first, then a source checkout's
+/// `target/release` and `target/debug`, with the platform-correct name.
+fn binary_candidates(pipeline_root: &Path, platform: &str) -> [PathBuf; 3] {
     let name = paths::binary_name(platform);
     [
+        pipeline_root.join("bin").join(&name),
         pipeline_root.join("target").join("release").join(&name),
         pipeline_root.join("target").join("debug").join(&name),
     ]
@@ -877,9 +878,10 @@ mod tests {
     }
 
     #[test]
-    fn binary_candidates_prefer_release_over_debug() {
+    fn binary_candidates_prefer_packaged_release_over_checkout_builds() {
         let candidates = binary_candidates(Path::new("root"), "windows");
-        assert!(candidates[0].ends_with(Path::new("target/release/code-intel.exe")));
-        assert!(candidates[1].ends_with(Path::new("target/debug/code-intel.exe")));
+        assert!(candidates[0].ends_with(Path::new("bin/code-intel.exe")));
+        assert!(candidates[1].ends_with(Path::new("target/release/code-intel.exe")));
+        assert!(candidates[2].ends_with(Path::new("target/debug/code-intel.exe")));
     }
 }

--- a/crates/code-intel-cli/tests/doctor_bootstrap_cli.rs
+++ b/crates/code-intel-cli/tests/doctor_bootstrap_cli.rs
@@ -293,6 +293,57 @@ fn the_pipeline_root_defaults_to_the_checkout_the_caller_stands_in() {
     fs::remove_dir_all(root).ok();
 }
 
+/// A release payload has the compiled graph provider in `bin/`, not in a
+/// source checkout's `target/{release,debug}` directories. Doctor must report
+/// that installed binary instead of describing a path every release install
+/// necessarily lacks (issue #232).
+#[test]
+fn release_layout_reports_the_packaged_graph_provider_binary() {
+    let release = temp_dir("release-layout");
+    let repo = temp_dir("release-repo");
+    let binary = release.join("bin").join("code-intel");
+    fs::create_dir_all(release.join("legacy")).unwrap();
+    fs::create_dir_all(binary.parent().unwrap()).unwrap();
+    fs::write(release.join("legacy").join("run-code-intel.ps1"), b"").unwrap();
+    fs::write(release.join("pipeline.config.json"), b"{}").unwrap();
+    fs::write(&binary, b"packaged binary").unwrap();
+    let binary_path = binary.to_string_lossy().into_owned();
+
+    let output = common::cli()
+        .args(["doctor", "bootstrap", "--pipeline-root"])
+        .arg(&release)
+        .args([
+            "--repo-path",
+            repo.to_str().unwrap(),
+            "--platform",
+            "macos",
+            "--no-require-repowise",
+            "--json",
+        ])
+        .output()
+        .expect("run doctor bootstrap against release layout");
+    let observation: Value =
+        serde_json::from_slice(&output.stdout).expect("observation is one JSON document");
+
+    assert_eq!(
+        observation["checks"]["graphProvider"]["binaryFound"],
+        json!(true),
+        "release layout must discover its packaged binary: {observation}"
+    );
+    assert_eq!(
+        observation["checks"]["graphProvider"]["binaryPath"],
+        json!(binary_path.clone())
+    );
+    assert!(
+        observation["checks"]["graphProvider"]["command"]
+            .as_str()
+            .is_some_and(|command| command.contains(&binary_path)),
+        "doctor must recommend the packaged binary: {observation}"
+    );
+    fs::remove_dir_all(release).ok();
+    fs::remove_dir_all(repo).ok();
+}
+
 /// Regression (F4): `orchestration/integrations.json` ships
 /// `edit.ast-grep-plan` with a `runtimeAdapter`, and that adapter resolves
 /// `ast-grep` through `tool_path` before shelling out to it. The doctor's

--- a/legacy/scripts/tests/test-regression-fixes.ps1
+++ b/legacy/scripts/tests/test-regression-fixes.ps1
@@ -1347,7 +1347,7 @@ Test-Case "doctor graph provider: a target/release platform binary satisfies the
     }
 }
 
-Test-Case "doctor graph provider: debug fallback still detected; absent binary reports a platform-correct hint" {
+Test-Case "doctor graph provider: debug fallback still detected; absent binary reports the packaged-release hint" {
     $dir = New-ScratchDir "doctor-graph-debug"
     try {
         New-DoctorScratchRoot $dir
@@ -1364,8 +1364,8 @@ Test-Case "doctor graph provider: debug fallback still detected; absent binary r
         $json = Invoke-DoctorScratch $dir
         Assert-False $json.checks.graphProvider.binaryFound "no built binary must report binaryFound=false"
         Assert-Equal "" ([string]$json.checks.graphProvider.binaryPath) "binaryPath must be empty when nothing is built"
-        $expectedHint = Join-Path (Join-Path (Join-Path $dir "target") "release") $binaryName
-        Assert-True ($json.checks.graphProvider.command.Contains($expectedHint)) "the command hint must fall back to the platform-correct release candidate path"
+        $expectedHint = Join-Path (Join-Path $dir "bin") $binaryName
+        Assert-True ($json.checks.graphProvider.command.Contains($expectedHint)) "the command hint must prefer the packaged release candidate path"
     }
     finally {
         Remove-Item -Recurse -Force $dir -ErrorAction SilentlyContinue

--- a/orchestration/integrations.json
+++ b/orchestration/integrations.json
@@ -286,7 +286,7 @@
           "version": "1.0.0",
           "toolchainDigests": [
             "6e4f0aa754b8ba54ec7b2eaa450869067b6d9dcf292deccf48e8a3aae0dee1da",
-            "afbb80c6f4d8e4b20c175c69e51aae84a1c99a9b842c17f6b346aea87ffca350",
+            "95ad9995e51eead4de0e2686afde06c518384fe33820394636bd3c05e9408ff2",
             "3d2ed512528a3dfa9e5deb60b361a26b9e5dab2f5509be7774c46f69db2789a0",
             "7db9e80857f3c65aada25041986cb5cb3b50b95fa69de794d55ad38fd4a8d8d4",
             "1ea59e6fc535572f1bf6ec93fd3ed0857c6b1dcc03db8370c060eec4741da415",


### PR DESCRIPTION
Refs #232.

Doctor now resolves a released CLI from `bin/code-intel` or `bin/code-intel.exe` before checkout build paths, so the graph provider points to a real packaged binary. This is the graph-binary sub-fix only; #232 remains open for the missing packaged `bin/legacy` and `bin/pipeline.config.json` paths. The hash-bound doctor declaration is refreshed with the changed bootstrap source.

Validation:
- `cargo fmt --check`
- `cargo test -p code-intel --test doctor_bootstrap_cli`
- `cargo test -p code-intel --locked`

Required before merge (DR-0001): add the installed-topology reproduction to the packaged-install smoke gate and verify the installed Doctor resolves an existing graph binary.