### PR TITLE
fix(run): authority-root 跨盘 symlink 下 create_dir_all 假阳性自愈，两处消息补路径 (#279)

### DIFF
--- a/crates/code-intel-cli/src/artifacts.rs
+++ b/crates/code-intel-cli/src/artifacts.rs
@@ -320,6 +320,69 @@ pub(crate) fn resolve_artifact_root(explicit: Option<&Path>) -> Result<PathBuf> 
         .join("artifacts"))
 }
 
+/// Creates `path` (and any missing ancestors), tolerating a Windows quirk
+/// this crate's issue #279 investigation verified against a real, pre-existing
+/// cross-drive directory symlink (`$env:LOCALAPPDATA\code-intel\artifacts` on the
+/// investigating machine, symlinked onto another drive to route a cache
+/// directory to a bigger/faster disk — a normal setup, not an exotic one):
+/// `CreateDirectoryW` for a brand-new subdirectory can return
+/// `ERROR_ALREADY_EXISTS` (os error 183) when an ancestor path component is a
+/// symlink onto a *different* volume, even though the target does not exist
+/// before or after the failed call, and an immediate retry against the same
+/// unresolved path fails identically — not a race. `create_dir_all`'s own
+/// recovery (treat `AlreadyExists` as success when `path.is_dir()`) can't
+/// catch this, because `is_dir()` resolves through the very same reparse
+/// point and also reports `false`.
+///
+/// This is the root cause of "create repository authority root: … already
+/// exists (os error 183)" (exit 74): a `code-intel .` quick-start run hit it
+/// on the very first invocation, not merely "the second run." A same-drive
+/// symlink does not reproduce it. Curiously, neither does a *freshly created*
+/// cross-drive symlink within the same process that then immediately reads
+/// through it (tried against several drives, and against an external process
+/// creating the link) — only the long-settled, pre-existing one did, every
+/// time. Whatever OS-level cache this depends on evidently needs the reparse
+/// point to have existed for a while, which makes the exact trigger resist
+/// synthetic, on-demand reproduction in a test process even though it is
+/// consistently, deterministically reproducible on an affected real machine.
+///
+/// The workaround: canonicalize the nearest already-existing ancestor
+/// (resolving past the symlink) and retry the create against the resolved
+/// form. Returns the path now confirmed to exist — `path` unchanged in the
+/// common (non-symlinked) case, or the resolved replacement when the
+/// workaround fired. Callers must use the returned path for further nested
+/// creates underneath it, since `path` itself remains unusable for that.
+///
+/// A genuine collision (something real blocking the path, e.g. a file with
+/// that name) still fails, returning the underlying `io::Error` unchanged so
+/// callers can report it with full path context.
+pub(crate) fn ensure_directory(path: &Path) -> std::io::Result<PathBuf> {
+    match fs::create_dir_all(path) {
+        Ok(()) => Ok(path.to_path_buf()),
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists && !path.is_dir() => {
+            let Some(existing_ancestor) = path.ancestors().find(|candidate| candidate.is_dir())
+            else {
+                return Err(error);
+            };
+            let resolved_ancestor = fs::canonicalize(existing_ancestor)?;
+            let resolved_target = resolved_retry_target(path, existing_ancestor, &resolved_ancestor);
+            fs::create_dir_all(&resolved_target)?;
+            Ok(resolved_target)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+/// Path arithmetic for the recovery branch above, split out so it is
+/// unit-testable without depending on the Windows-only OS state that reaches
+/// it in production: rejoins the part of `path` beyond `existing_ancestor`
+/// onto `resolved_ancestor` (the canonicalized, symlink-free form of that
+/// same ancestor).
+fn resolved_retry_target(path: &Path, existing_ancestor: &Path, resolved_ancestor: &Path) -> PathBuf {
+    let remainder = path.strip_prefix(existing_ancestor).unwrap_or(Path::new(""));
+    resolved_ancestor.join(remainder)
+}
+
 /// Composes a DAG staging directory the way `resume` and `artifact index` read
 /// runs back: `<artifact root>/<repo name>/<run>`. The PowerShell launcher owned
 /// this composition until it was retired, and the failure it existed to prevent

--- a/crates/code-intel-cli/src/artifacts.rs
+++ b/crates/code-intel-cli/src/artifacts.rs
@@ -365,7 +365,8 @@ pub(crate) fn ensure_directory(path: &Path) -> std::io::Result<PathBuf> {
                 return Err(error);
             };
             let resolved_ancestor = fs::canonicalize(existing_ancestor)?;
-            let resolved_target = resolved_retry_target(path, existing_ancestor, &resolved_ancestor);
+            let resolved_target =
+                resolved_retry_target(path, existing_ancestor, &resolved_ancestor);
             fs::create_dir_all(&resolved_target)?;
             Ok(resolved_target)
         }
@@ -378,8 +379,14 @@ pub(crate) fn ensure_directory(path: &Path) -> std::io::Result<PathBuf> {
 /// it in production: rejoins the part of `path` beyond `existing_ancestor`
 /// onto `resolved_ancestor` (the canonicalized, symlink-free form of that
 /// same ancestor).
-fn resolved_retry_target(path: &Path, existing_ancestor: &Path, resolved_ancestor: &Path) -> PathBuf {
-    let remainder = path.strip_prefix(existing_ancestor).unwrap_or(Path::new(""));
+fn resolved_retry_target(
+    path: &Path,
+    existing_ancestor: &Path,
+    resolved_ancestor: &Path,
+) -> PathBuf {
+    let remainder = path
+        .strip_prefix(existing_ancestor)
+        .unwrap_or(Path::new(""));
     resolved_ancestor.join(remainder)
 }
 

--- a/crates/code-intel-cli/src/artifacts_tests.rs
+++ b/crates/code-intel-cli/src/artifacts_tests.rs
@@ -148,3 +148,175 @@ fn classify_contract_requires_research_for_upstream_or_tool_blockers() {
 
     assert!(provider_quota > 0 || local_tool_error > 0 || sentrux_fail > 0);
 }
+
+#[test]
+fn ensure_directory_creates_a_fresh_nested_directory() {
+    let dir = unique_temp_dir("ensure-directory-fresh");
+    let target = dir.join("nested").join("leaf");
+
+    let resolved = ensure_directory(&target).expect("create a fresh nested directory");
+    assert_eq!(resolved, target);
+    assert!(resolved.is_dir());
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn ensure_directory_is_idempotent_for_an_existing_directory() {
+    // Re-running against an already-analyzed repo is the ordinary case, not
+    // an exotic one: the authority root container directory is meant to be
+    // reused run after run.
+    let dir = unique_temp_dir("ensure-directory-idempotent");
+    fs::create_dir_all(&dir).expect("fixture dir");
+
+    let resolved = ensure_directory(&dir).expect("re-create an already-existing directory");
+    assert_eq!(resolved, dir);
+    assert!(resolved.is_dir());
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn ensure_directory_reports_a_real_file_collision_with_its_path_preserved() {
+    // A genuine blocker (something real occupying the path) must still fail
+    // — self-healing is only for the false-positive Windows symlink case
+    // below, never for an actual collision.
+    let dir = unique_temp_dir("ensure-directory-file-collision");
+    fs::create_dir_all(&dir).expect("fixture parent");
+    let blocked = dir.join("blocked");
+    fs::write(&blocked, b"not a directory").expect("fixture blocking file");
+
+    let error =
+        ensure_directory(&blocked).expect_err("a real file must still block directory creation");
+    assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// Issue #279's root cause, isolated from the rest of `code-intel`: on
+/// Windows, `CreateDirectoryW` for a brand-new subdirectory can return
+/// `ERROR_ALREADY_EXISTS` (os error 183) when an ancestor path component is a
+/// symlink onto a *different* volume, even though the target does not exist
+/// before or after the failed call, and an immediate retry against the same
+/// unresolved path fails identically — not a race.
+/// `create_dir_all`'s own recovery (`AlreadyExists` + `path.is_dir()` ==
+/// success) can't catch this: `is_dir()` resolves through the same reparse
+/// point and also reports `false`.
+///
+/// This was verified against a real, pre-existing cross-drive directory
+/// symlink and reproduced every time. It is deliberately *not* a hard
+/// assertion here, because it turns out not to be reliably fabricatable
+/// on demand: neither a same-drive symlink, nor a *freshly created*
+/// cross-drive symlink (this process or an external `mklink /D` process,
+/// against multiple different drives, against both a brand-new empty target
+/// and the real long-settled one) reproduced it — only the long-settled,
+/// already-existing one did. Whatever OS-level state this depends on
+/// evidently needs the reparse point to have existed for a while, which a
+/// single test process cannot manufacture. So: attempt the real thing:
+/// if this host happens to reproduce the quirk, assert `ensure_directory`
+/// recovers from it; if not (the likely outcome, including in CI, which is a
+/// freshly provisioned VM with no aged filesystem state), skip rather than
+/// assert something false. `resolved_retry_target_rejoins_the_remainder_
+/// under_the_canonicalized_ancestor` below covers the recovery arithmetic
+/// deterministically instead. Mirrors this crate's existing convention for
+/// environment-dependent symlink privilege (see `decision_record.rs`'s
+/// `symlink_file(...).is_ok()` checks) rather than requiring elevation.
+#[cfg(windows)]
+#[test]
+fn ensure_directory_recovers_from_a_spurious_already_exists_through_a_cross_volume_symlink() {
+    let Some(other_drive) = second_writable_drive() else {
+        eprintln!("skipping: no second drive available to build a cross-volume symlink");
+        return;
+    };
+
+    let real_target = other_drive.join(format!(
+        "code-intel-ensure-directory-target-{}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&real_target).expect("create real target on the other drive");
+
+    let link_parent = unique_temp_dir("ensure-directory-symlink-parent");
+    fs::create_dir_all(&link_parent).expect("create link parent");
+    let link = link_parent.join("artifacts");
+    if std::os::windows::fs::symlink_dir(&real_target, &link).is_err() {
+        eprintln!("skipping: could not create a directory symlink (Developer Mode / privilege?)");
+        let _ = fs::remove_dir_all(&real_target);
+        let _ = fs::remove_dir_all(&link_parent);
+        return;
+    }
+
+    let child = link.join("repo-name");
+
+    // First, confirm this environment actually reproduces the quirk being
+    // worked around — if it doesn't, the rest of the assertion proves
+    // nothing.
+    let raw = fs::create_dir_all(&child);
+    let reproduces_quirk = matches!(
+        &raw,
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists
+    ) && !child.is_dir();
+    if !reproduces_quirk {
+        eprintln!(
+            "skipping: this host did not reproduce the cross-volume symlink quirk: {raw:?}"
+        );
+        let _ = fs::remove_dir_all(&real_target);
+        let _ = fs::remove_dir_all(&link_parent);
+        return;
+    }
+
+    let resolved = ensure_directory(&child)
+        .unwrap_or_else(|error| panic!("did not recover from the symlink quirk: {error}"));
+    assert!(resolved.is_dir(), "resolved={}", resolved.display());
+
+    let _ = fs::remove_dir_all(&real_target);
+    let _ = fs::remove_dir_all(&link_parent);
+}
+
+/// Finds a drive letter distinct from `env::temp_dir()`'s own that exists and
+/// is writable, for building a genuinely cross-volume symlink. Returns `None`
+/// on a lone-drive machine rather than guessing or failing.
+#[cfg(windows)]
+fn second_writable_drive() -> Option<PathBuf> {
+    let own_letter = env::temp_dir()
+        .to_str()
+        .and_then(|path| path.chars().next())
+        .map(|letter| letter.to_ascii_uppercase());
+    for letter in ['D', 'E', 'F', 'G'] {
+        if Some(letter) == own_letter {
+            continue;
+        }
+        let root = PathBuf::from(format!("{letter}:\\"));
+        if !root.is_dir() {
+            continue;
+        }
+        let probe = root.join(format!("code-intel-drive-probe-{}", std::process::id()));
+        if fs::create_dir(&probe).is_ok() {
+            let _ = fs::remove_dir(&probe);
+            return Some(root);
+        }
+    }
+    None
+}
+
+/// Deterministic, platform-independent coverage for `ensure_directory`'s
+/// recovery arithmetic (rejoining the part of the original target beyond the
+/// existing ancestor onto that ancestor's canonicalized form) — the part of
+/// the fix that does not depend on fabricating the Windows-only OS quirk
+/// covered on a best-effort basis above.
+#[test]
+fn resolved_retry_target_rejoins_the_remainder_under_the_canonicalized_ancestor() {
+    let path = Path::new("artifacts").join("fixture-repo");
+    let existing_ancestor = Path::new("artifacts");
+    let resolved_ancestor = Path::new("real-drive").join("cache").join("code-intel");
+    assert_eq!(
+        resolved_retry_target(&path, existing_ancestor, &resolved_ancestor),
+        resolved_ancestor.join("fixture-repo")
+    );
+
+    // The target itself, with nothing beyond the existing ancestor, rejoins
+    // to exactly the resolved ancestor.
+    assert_eq!(
+        resolved_retry_target(existing_ancestor, existing_ancestor, &resolved_ancestor),
+        resolved_ancestor
+    );
+}

--- a/crates/code-intel-cli/src/artifacts_tests.rs
+++ b/crates/code-intel-cli/src/artifacts_tests.rs
@@ -256,9 +256,7 @@ fn ensure_directory_recovers_from_a_spurious_already_exists_through_a_cross_volu
         Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists
     ) && !child.is_dir();
     if !reproduces_quirk {
-        eprintln!(
-            "skipping: this host did not reproduce the cross-volume symlink quirk: {raw:?}"
-        );
+        eprintln!("skipping: this host did not reproduce the cross-volume symlink quirk: {raw:?}");
         let _ = fs::remove_dir_all(&real_target);
         let _ = fs::remove_dir_all(&link_parent);
         return;

--- a/crates/code-intel-cli/src/authoritative_run/execution_kernel.rs
+++ b/crates/code-intel-cli/src/authoritative_run/execution_kernel.rs
@@ -216,9 +216,12 @@ fn nest_authority_root(authority_root: &Path, repo_name: &str) -> Result<PathBuf
     } else {
         authority_root.join(repo_name)
     };
-    std::fs::create_dir_all(&nested)
-        .map_err(|error| RunError::io(format!("create repository authority root: {error}")))?;
-    Ok(nested)
+    crate::artifacts::ensure_directory(&nested).map_err(|error| {
+        RunError::io(format!(
+            "create repository authority root {}: {error}",
+            nested.display()
+        ))
+    })
 }
 
 /// Schema identity of the envelope printed on stdout when the run finished but
@@ -413,5 +416,32 @@ mod tests {
         );
 
         std::fs::remove_dir_all(root.parent().unwrap()).ok();
+    }
+
+    /// Issue #279's sibling call site (see `project_context.rs::run` and
+    /// `artifacts::ensure_directory`, which both share this message
+    /// template): "create repository authority root: <raw OS error>" used to
+    /// carry zero path context at either site. A file sitting where the
+    /// repo-nested directory needs to go is a portable, deterministic way to
+    /// exercise a *genuine* block without depending on the Windows-only
+    /// cross-volume-symlink quirk `ensure_directory` self-heals (covered by
+    /// `artifacts_tests.rs`).
+    #[test]
+    fn nest_authority_root_names_the_path_when_something_real_blocks_it() {
+        let root = unique_temp_dir("nest-blocked");
+        std::fs::create_dir_all(&root).expect("fixture authority root");
+        let blocked = root.join("widget-repo");
+        std::fs::write(&blocked, b"not a directory").expect("fixture blocking file");
+
+        let error = nest_authority_root(&root, "widget-repo")
+            .expect_err("a real file must still block authority root creation");
+        assert_eq!(error.exit_code, 74);
+        assert!(
+            error.message.contains(&blocked.display().to_string()),
+            "message omits the blocked path: {}",
+            error.message
+        );
+
+        std::fs::remove_dir_all(&root).ok();
     }
 }

--- a/crates/code-intel-cli/src/project_context.rs
+++ b/crates/code-intel-cli/src/project_context.rs
@@ -132,11 +132,18 @@ impl ProjectContext {
 
     pub(crate) fn run(&self, intent: RunIntent) -> Result<RunAnswer, ProjectError> {
         ensure_run_authority(&self.artifact_root, &self.repo, &self.repo_path)?;
-        fs::create_dir_all(&self.artifact_root)
-            .map_err(|error| ProjectError::host_io(format!("create artifact root: {error}")))?;
-        let authority_root = self.artifact_root.join(&self.repo);
-        fs::create_dir_all(&authority_root).map_err(|error| {
-            ProjectError::host_io(format!("create repository authority root: {error}"))
+        let artifact_root = artifacts::ensure_directory(&self.artifact_root).map_err(|error| {
+            ProjectError::host_io(format!(
+                "create artifact root {}: {error}",
+                self.artifact_root.display()
+            ))
+        })?;
+        let authority_root = artifact_root.join(&self.repo);
+        let authority_root = artifacts::ensure_directory(&authority_root).map_err(|error| {
+            ProjectError::host_io(format!(
+                "create repository authority root {}: {error}",
+                authority_root.display()
+            ))
         })?;
         let nonce = SystemTime::now()
             .duration_since(UNIX_EPOCH)

--- a/crates/code-intel-cli/src/project_context/tests.rs
+++ b/crates/code-intel-cli/src/project_context/tests.rs
@@ -67,6 +67,50 @@ fn resolves_native_paths_and_repository_key_when_directories_contain_spaces() {
     let _ = fs::remove_dir_all(root);
 }
 
+/// Issue #279: this call site and `execution_kernel.rs::nest_authority_root`
+/// share the exact "create repository authority root: <raw OS error>"
+/// message template — this one is what the `code-intel .` quick start
+/// actually goes through. A file sitting where the per-repo authority
+/// directory needs to go is a portable, deterministic way to exercise a
+/// *genuine* block. (The Windows-only cross-volume-symlink false positive
+/// this bug was actually filed for needs a real second drive to reproduce;
+/// it is covered by `artifacts_tests.rs`'s `ensure_directory_*` tests
+/// instead, against the shared helper directly.)
+#[test]
+fn run_names_the_authority_root_path_when_something_real_blocks_it() {
+    let root = env::temp_dir().join(format!(
+        "code-intel-project-context-authority-blocked-{}",
+        process::id()
+    ));
+    let repo = root.join("fixture-repo");
+    let artifact_root = root.join("artifacts");
+    fs::create_dir_all(&repo).expect("create repository fixture");
+    fs::create_dir_all(&artifact_root).expect("create artifact root fixture");
+    let blocked = artifact_root.join("fixture-repo");
+    fs::write(&blocked, b"not a directory").expect("fixture blocking file");
+
+    let context = ProjectContext::resolve(
+        ProjectSelector::new(repo.clone()).with_artifact_root(Some(artifact_root.clone())),
+    )
+    .expect("resolve project context");
+
+    // `RunAnswer` does not derive `Debug`, so `expect_err` (which requires it
+    // on the `Ok` side too) is not available here — match instead.
+    match context.run(RunIntent::new(RunMode::Lite)) {
+        Ok(_) => panic!("a real file must still block authority root creation"),
+        Err(error) => {
+            assert_eq!(error.exit_code(), 74);
+            assert!(
+                error.message().contains(&blocked.display().to_string()),
+                "message omits the blocked path: {}",
+                error.message()
+            );
+        }
+    }
+
+    let _ = fs::remove_dir_all(root);
+}
+
 #[test]
 fn explicit_repository_key_cannot_escape_the_artifact_root() {
     let root = env::temp_dir().join(format!("code-intel-project-context-key-{}", process::id()));

--- a/crates/code-intel-cli/tests/primary_entry.rs
+++ b/crates/code-intel-cli/tests/primary_entry.rs
@@ -124,6 +124,55 @@ fn project_query_resolves_repository_context_before_loading_evidence() {
     let _ = std::fs::remove_dir_all(root);
 }
 
+/// Issue #279: `code-intel .` (this file's
+/// `root_help_leads_with_the_compiled_primary_entry` confirms it's the
+/// documented quick start) used to fold the authority-root bootstrap's IO
+/// error — including a Windows-only false
+/// positive from a symlinked artifact root — into a bare "create repository
+/// authority root: <raw OS error>" with no path at all. Drives the exact
+/// call site (`project_context.rs::run`) end to end through the compiled
+/// binary. A file occupying the per-repo authority directory is a portable,
+/// deterministic way to force a genuine block; the symlink false positive
+/// itself needs a real second drive, so it's covered directly against the
+/// shared helper in `artifacts_tests.rs` instead.
+#[test]
+fn root_entry_names_the_authority_root_path_when_a_file_blocks_it() {
+    let root = std::env::temp_dir().join(format!(
+        "code-intel-primary-entry-authority-blocked-{}",
+        std::process::id()
+    ));
+    let repo = root.join("fixture-repo");
+    let artifacts = root.join("artifacts");
+    std::fs::create_dir_all(&repo).expect("create repository fixture");
+    std::fs::create_dir_all(&artifacts).expect("create artifact root fixture");
+    let blocked = artifacts.join("fixture-repo");
+    std::fs::write(&blocked, b"not a directory").expect("fixture blocking file");
+
+    let output = common::cli()
+        .arg(&repo)
+        .args(["--mode", "lite", "--json"])
+        .env("CODE_INTEL_ARTIFACT_ROOT", &artifacts)
+        .output()
+        .expect("run code-intel against a blocked authority root");
+
+    assert_eq!(output.status.code(), Some(74));
+    assert!(output.stderr.is_empty());
+    let result: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("error output is JSON");
+    assert_eq!(result["schema"], "code-intel-primary-result.v1");
+    assert_eq!(result["outcome"], "error");
+    assert_eq!(result["exitCode"], 74);
+    let diagnostic = result["diagnostic"]
+        .as_str()
+        .expect("diagnostic is a string");
+    assert!(
+        diagnostic.contains(&blocked.display().to_string()),
+        "diagnostic omits the blocked path: {diagnostic}"
+    );
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
 #[test]
 fn named_commands_are_not_misclassified_as_repository_paths() {
     let output = common::cli()


### PR DESCRIPTION
Fixes #279.

## 问题

README/`--help` 的 quick start——`code-intel .`（等价于 `code-intel . --mode lite --json`）——在本仓自身跑会崩：

```
{"diagnostic":"create repository authority root: 当文件已存在时，无法创建该文件。 (os error 183)","exitCode":74,"outcome":"error", ...}
```

`sentrux check .` 等窄命令完全正常，只有 authoritative-run 的 authority-root 创建这一步坏。细节、复现过程、根因排查见 #279。

## 根因

`fs::create_dir_all(path)` 在 Windows 上有一个反直觉行为：当 `path` 的某个祖先分量是**指向另一块盘**的 symlink 时，为一个从未存在过的子目录创建目录会返回 `ERROR_ALREADY_EXISTS`（os error 183）——目标在调用前后都不存在，立即重试也是同样的错误（不是竞态）。`create_dir_all` 自带的兜底（"AlreadyExists 就查 `path.is_dir()`，是目录就当成功"）救不了这个场景，因为 `is_dir()` 也是穿过同一个 reparse point 解析的，同样返回 `false`。

两处调用点用同一条消息模板把这个 IO error 直接折叠成裸文本，一个路径都不带：

- `crates/code-intel-cli/src/project_context.rs`（`ProjectContext::run()`）——quick start 实际经过的这一处
- `crates/code-intel-cli/src/authoritative_run/execution_kernel.rs`（`nest_authority_root()`，`run execute` 用的姊妹调用点）

这和 #145 修的缺陷同源：把一个具体的 IO 情况塞进一个笼统的 error 分支，吐出不可执行的裸 OS error。#145 修的是**发布一个已完成的 run** 撞到已存在的发布名；这次是**创建 authority root 目录本身**这一步——调用点不同、症状也不同（这次多数情况下目标根本不存在，说"已经发布在这里"是假话），但缺陷类是同一个。

## 改动

- `artifacts.rs` 新增 `pub(crate) fn ensure_directory(path) -> io::Result<PathBuf>`：正常情况直接 `create_dir_all` 后原样返回 `path`（对普通、非 symlink 场景零行为变化）；命中"AlreadyExists 但 `is_dir()` 也是 false"这个 Windows 症状时，对最近一层已存在的祖先目录 `canonicalize` 后重试，返回解析出的真实路径；真撞车（比如目标被同名文件占用）时原样把底层 `io::Error` 传回去，不吞。
- `project_context.rs::run()` 与 `execution_kernel.rs::nest_authority_root()` 两处都换成调用这个共享 helper，并且都把目标路径补进错误消息（之前两处都是零路径上下文的裸 OS error，同一个缺陷类）。调用方现在用 helper 返回的（可能被解析过的）路径继续走下去。
- 退出码维持 74（`ProjectError::host_io` / `RunError::io`）不变——`run_error.rs` 自己的注释已经把 74 定义为"host 侧真出问题"，这本来就是正确分类，不需要像 #145 那样新开一档退出码。

为什么不是照抄 #145 的"就是消息写清楚"：多数真实触发场景下（跨盘 symlink）目标压根不存在，"已经发布在这里，换个名字或删掉" 是假话，会把人往错误方向引导。看了 authority root 的创建/使用方式后发现：`create_dir_all` 本来就是为了"这个容器目录该被复用"这个语义选的（相对于会在已存在时报错的 `create_dir`）——bug 不是"没把已存在的 root 当可复用"，而是这份幂等性在这一种 Windows 症状下被打破了。所以修法是把幂等性真正修好，而不是把假阳性包装成一条更好看的报错。

## 测试

新增：
- `artifacts_tests.rs`：`ensure_directory` 的三个可移植单测（新建、幂等、真文件挡路时报错）+ 一个 `#[cfg(windows)]` 尽力而为单测（真实复现过一次，但发现这个 Windows 症状依赖某种"陈旧"OS 状态——同进程现建的跨盘 symlink 无论对哪块盘都摇不出来，只有长期存在的那个稳定复现；测试如实尝试，摇不出来就 skip 而不是断言假象）+ 一个纯路径运算的确定性单测覆盖恢复逻辑本身。
- `project_context/tests.rs` 与 `execution_kernel.rs` 的 `mod tests`：各一个单测，用"目标位置被同名文件占用"这个可移植、确定性的方式验证真撞车时报错仍然失败，且消息里带上了被挡住的路径。
- `tests/primary_entry.rs`：`root_entry_names_the_authority_root_path_when_a_file_blocks_it`，走编译后的二进制端到端复现 `code-intel .` 这条调用链，同样用文件占位的方式验证。

`cargo check -p code-intel --tests`：clean。所有新增/相关测试单独跑通过；`cargo test -p code-intel --locked` 全量结果见下方评论（或 CI）。`legacy/tools/check-hardcoded-paths.ps1`：OK（129 files；本 PR 未新增/修改任何 `.ps1`/`.psm1`/`.md`/`.yml`，也未触碰 `orchestration/**/*.json` 的任何 digest pin）。

## DR-0001 适用性

这不是"装不上/装上跑不了"那一类——普通 checkout + `cargo build --release` + 直接跑二进制就能稳定复现，`--help`、`sentrux check` 都正常。不需要进 install-smoke 闸；已在 #279 里写明这个判断。

## Sentrux 会话闸

`legacy/Invoke-SentruxAgentTool.ps1 session_start "."` 已在改动前跑过（baseline 已存，gate pass）；`session_end` 将在推送前跑，本 PR 不会带着未过 `session_end` 的改动。
