### PR TITLE
chore(release): prepare v0.7.2-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2-beta.2] — 2026-08-19
+
+### Added
+
+- **Sentrux capability automation**：能力矩阵、自动发现与执行、lite fallback、统一 artifact/schema 和结果闭环接入报告、影响分析、测试选择、PR gate 与 release gate；发布包增加能力级 smoke 验收。
+- **安装拓扑 smoke**：跨平台 CI 通过真实安装后的 graph binary 验证 `doctor bootstrap`，覆盖安装后路径与能力发现边界。
+
+### Fixed
+
+- 刷新合并后受 frozen source set 约束的 E04/E07/E08 compatibility retirement packets，避免 Windows 发布门禁因 stale snapshot 误报。
+
 ## [0.7.2-beta.1] — 2026-08-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,7 @@ checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "code-intel"
-version = "0.7.2-beta.1"
+version = "0.7.2-beta.2"
 dependencies = [
  "serde_json",
  "tiny_http",

--- a/crates/code-intel-cli/Cargo.toml
+++ b/crates/code-intel-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "code-intel"
-version = "0.7.2-beta.1"
+version = "0.7.2-beta.2"
 edition = "2021"
 description = "Local Code Intel Pipeline CLI for artifact resume and contract checks"
 license = "MIT"

--- a/crates/code-intel-cli/tests/fixtures/cli-head-parity.v2.json
+++ b/crates/code-intel-cli/tests/fixtures/cli-head-parity.v2.json
@@ -33,7 +33,7 @@
         "--json"
       ],
       "exitCode": 0,
-      "stdoutUtf8": "{\"name\":\"code-intel\",\"schema\":\"code-intel-version.v1\",\"version\":\"0.7.2-beta.1\"}\n",
+      "stdoutUtf8": "{\"name\":\"code-intel\",\"schema\":\"code-intel-version.v1\",\"version\":\"0.7.2-beta.2\"}\n",
       "stderrUtf8": ""
     },
     {
@@ -44,7 +44,7 @@
         "--json"
       ],
       "exitCode": 0,
-      "stdoutUtf8": "{\"name\":\"code-intel\",\"schema\":\"code-intel-version.v1\",\"version\":\"0.7.2-beta.1\"}\n",
+      "stdoutUtf8": "{\"name\":\"code-intel\",\"schema\":\"code-intel-version.v1\",\"version\":\"0.7.2-beta.2\"}\n",
       "stderrUtf8": ""
     },
     {

--- a/orchestration/toolchain-versions.v1.json
+++ b/orchestration/toolchain-versions.v1.json
@@ -93,7 +93,7 @@
     },
     {
       "name": "code-intel",
-      "version": "0.7.2-beta.1",
+      "version": "0.7.2-beta.2",
       "comparison": "minimum",
       "scope": "runtime",
       "required": true,


### PR DESCRIPTION
Prepare v0.7.2-beta.2 after merging the Sentrux capability automation and installed-topology fixes. Includes version pins, CLI parity fixture, toolchain metadata, and changelog.