### PR TITLE
fix(release): validate packaged closure after install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,10 +220,16 @@ jobs:
             }
           }
           python (Join-Path $payload "skills\code-intel-pipeline\scripts\bootstrap.py") --help
+          $installRoot = Join-Path $env:RUNNER_TEMP "code-intel-release-install-$env:GITHUB_RUN_ID"
+          $bootstrapRaw = & python (Join-Path $payload "skills\code-intel-pipeline\scripts\bootstrap.py") --local-asset $asset --version $tag --repo-path $payload --install-root $installRoot --install-missing --json
+          if ($LASTEXITCODE -ne 0) { throw "release bootstrap install failed:`n$bootstrapRaw" }
+          $bootstrap = $bootstrapRaw | ConvertFrom-Json
+          if ($bootstrap.status -notin @("installed", "repaired", "already_installed")) { throw "Unexpected release bootstrap status '$($bootstrap.status)':`n$bootstrapRaw" }
+          $installedRoot = [IO.Path]::GetFullPath([string]$bootstrap.release_root)
           # The packaged binary must publish a committed, snapshot-bound
           # Sentrux closure. The manifest and content-addressed artifacts are
           # authoritative; command stdout is intentionally not inspected.
-          $packagedBinary = Join-Path $payload "bin\code-intel.exe"
+          $packagedBinary = Join-Path $installedRoot "bin\code-intel.exe"
           $staging = Join-Path $env:RUNNER_TEMP "code-intel-release-packaged-sentrux-staging-$env:GITHUB_RUN_ID"
           $authority = Join-Path $env:RUNNER_TEMP "code-intel-release-packaged-sentrux-authority-$env:GITHUB_RUN_ID"
           $finalName = "release-packaged-sentrux-$env:GITHUB_RUN_ID"
@@ -448,7 +454,13 @@ jobs:
             }
           }
           python (Join-Path $payload "skills/code-intel-pipeline/scripts/bootstrap.py") --help
-          $packagedBinary = Join-Path $payload "bin/code-intel"
+          $installRoot = Join-Path $env:RUNNER_TEMP "code-intel-release-install-$env:GITHUB_RUN_ID"
+          $bootstrapRaw = & python (Join-Path $payload "skills/code-intel-pipeline/scripts/bootstrap.py") --local-asset $asset --version $tag --repo-path $payload --install-root $installRoot --install-missing --json
+          if ($LASTEXITCODE -ne 0) { throw "release bootstrap install failed:`n$bootstrapRaw" }
+          $bootstrap = $bootstrapRaw | ConvertFrom-Json
+          if ($bootstrap.status -notin @("installed", "repaired", "already_installed")) { throw "Unexpected release bootstrap status '$($bootstrap.status)':`n$bootstrapRaw" }
+          $installedRoot = [IO.Path]::GetFullPath([string]$bootstrap.release_root)
+          $packagedBinary = Join-Path $installedRoot "bin/code-intel"
           bash -c "test -x '$packagedBinary'"
           if ($LASTEXITCODE -ne 0) { throw "packaged binary lost its executable bit in the zip round trip: $packagedBinary" }
           # The packaged binary must publish a committed, snapshot-bound

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2-beta.3] — 2026-08-19
+
+### Fixed
+
+- 发布包验收现在先通过本地 zip 走 bootstrap 安装拓扑，再使用安装后的 binary 执行 packaged Sentrux closure；修复 release workflow 直接从解压目录运行导致 doctor readiness 误报失败的问题。
+
 ## [0.7.2-beta.2] — 2026-08-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,7 @@ checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "code-intel"
-version = "0.7.2-beta.2"
+version = "0.7.2-beta.3"
 dependencies = [
  "serde_json",
  "tiny_http",

--- a/crates/code-intel-cli/Cargo.toml
+++ b/crates/code-intel-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "code-intel"
-version = "0.7.2-beta.2"
+version = "0.7.2-beta.3"
 edition = "2021"
 description = "Local Code Intel Pipeline CLI for artifact resume and contract checks"
 license = "MIT"

--- a/crates/code-intel-cli/tests/fixtures/cli-head-parity.v2.json
+++ b/crates/code-intel-cli/tests/fixtures/cli-head-parity.v2.json
@@ -33,7 +33,7 @@
         "--json"
       ],
       "exitCode": 0,
-      "stdoutUtf8": "{\"name\":\"code-intel\",\"schema\":\"code-intel-version.v1\",\"version\":\"0.7.2-beta.2\"}\n",
+      "stdoutUtf8": "{\"name\":\"code-intel\",\"schema\":\"code-intel-version.v1\",\"version\":\"0.7.2-beta.3\"}\n",
       "stderrUtf8": ""
     },
     {
@@ -44,7 +44,7 @@
         "--json"
       ],
       "exitCode": 0,
-      "stdoutUtf8": "{\"name\":\"code-intel\",\"schema\":\"code-intel-version.v1\",\"version\":\"0.7.2-beta.2\"}\n",
+      "stdoutUtf8": "{\"name\":\"code-intel\",\"schema\":\"code-intel-version.v1\",\"version\":\"0.7.2-beta.3\"}\n",
       "stderrUtf8": ""
     },
     {

--- a/orchestration/toolchain-versions.v1.json
+++ b/orchestration/toolchain-versions.v1.json
@@ -93,7 +93,7 @@
     },
     {
       "name": "code-intel",
-      "version": "0.7.2-beta.2",
+      "version": "0.7.2-beta.3",
       "comparison": "minimum",
       "scope": "runtime",
       "required": true,


### PR DESCRIPTION
Prepare v0.7.2-beta.3. Fix release package validation to install each local zip through bootstrap.py before executing the packaged Sentrux closure, matching the installed-topology smoke that already passes in CI. Bump version metadata and changelog.