### PR TITLE
fix(release): validate installed release root

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,6 +226,11 @@ jobs:
           $bootstrap = $bootstrapRaw | ConvertFrom-Json
           if ($bootstrap.status -notin @("installed", "repaired", "already_installed")) { throw "Unexpected release bootstrap status '$($bootstrap.status)':`n$bootstrapRaw" }
           $installedRoot = [IO.Path]::GetFullPath([string]$bootstrap.release_root)
+          # Continue the packaged validation from the exact release root that
+          # bootstrap installed. The extracted archive is only the installer
+          # input; using it as --repo bypasses the installed topology that the
+          # release gate is required to prove.
+          $payload = $installedRoot
           # The packaged binary must publish a committed, snapshot-bound
           # Sentrux closure. The manifest and content-addressed artifacts are
           # authoritative; command stdout is intentionally not inspected.
@@ -460,6 +465,11 @@ jobs:
           $bootstrap = $bootstrapRaw | ConvertFrom-Json
           if ($bootstrap.status -notin @("installed", "repaired", "already_installed")) { throw "Unexpected release bootstrap status '$($bootstrap.status)':`n$bootstrapRaw" }
           $installedRoot = [IO.Path]::GetFullPath([string]$bootstrap.release_root)
+          # Continue the packaged validation from the exact release root that
+          # bootstrap installed. The extracted archive is only the installer
+          # input; using it as --repo bypasses the installed topology that the
+          # release gate is required to prove.
+          $payload = $installedRoot
           $packagedBinary = Join-Path $installedRoot "bin/code-intel"
           bash -c "test -x '$packagedBinary'"
           if ($LASTEXITCODE -ne 0) { throw "packaged binary lost its executable bit in the zip round trip: $packagedBinary" }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2-beta.4] — 2026-08-19
+
+### Fixed
+
+- 发布包验收在 bootstrap 安装后继续使用实际 `release_root` 作为 repo，确保 packaged Sentrux closure 和 doctor readiness 验证覆盖真实安装拓扑。
+
 ## [0.7.2-beta.3] — 2026-08-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,7 @@ checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "code-intel"
-version = "0.7.2-beta.3"
+version = "0.7.2-beta.4"
 dependencies = [
  "serde_json",
  "tiny_http",

--- a/crates/code-intel-cli/Cargo.toml
+++ b/crates/code-intel-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "code-intel"
-version = "0.7.2-beta.3"
+version = "0.7.2-beta.4"
 edition = "2021"
 description = "Local Code Intel Pipeline CLI for artifact resume and contract checks"
 license = "MIT"

--- a/crates/code-intel-cli/tests/fixtures/cli-head-parity.v2.json
+++ b/crates/code-intel-cli/tests/fixtures/cli-head-parity.v2.json
@@ -33,7 +33,7 @@
         "--json"
       ],
       "exitCode": 0,
-      "stdoutUtf8": "{\"name\":\"code-intel\",\"schema\":\"code-intel-version.v1\",\"version\":\"0.7.2-beta.3\"}\n",
+      "stdoutUtf8": "{\"name\":\"code-intel\",\"schema\":\"code-intel-version.v1\",\"version\":\"0.7.2-beta.4\"}\n",
       "stderrUtf8": ""
     },
     {
@@ -44,7 +44,7 @@
         "--json"
       ],
       "exitCode": 0,
-      "stdoutUtf8": "{\"name\":\"code-intel\",\"schema\":\"code-intel-version.v1\",\"version\":\"0.7.2-beta.3\"}\n",
+      "stdoutUtf8": "{\"name\":\"code-intel\",\"schema\":\"code-intel-version.v1\",\"version\":\"0.7.2-beta.4\"}\n",
       "stderrUtf8": ""
     },
     {

--- a/orchestration/toolchain-versions.v1.json
+++ b/orchestration/toolchain-versions.v1.json
@@ -93,7 +93,7 @@
     },
     {
       "name": "code-intel",
-      "version": "0.7.2-beta.3",
+      "version": "0.7.2-beta.4",
       "comparison": "minimum",
       "scope": "runtime",
       "required": true,


### PR DESCRIPTION
## Summary\n- continue packaged validation from bootstrap's installed release_root on Windows, macOS, and Linux\n- keep the extracted zip only as bootstrap input so doctor readiness proves the real installed topology\n- prepare v0.7.2-beta.4 after the beta.3 release gate caught this second topology gap\n\n## Verification\n- cargo fmt -p code-intel -- --check\n- cargo check -p code-intel --locked\n- cargo test -q -p code-intel --locked --test cli_head_parity\n- repository and Skill package tests\n- lint hardcoded-paths\n- repin clean\n- Sentrux session_end passed\n\nThe three untracked research/decision documents already present in the workspace were preserved and are not part of this PR.