### PR TITLE
fix(release): expose installed tool path to doctor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,7 +240,7 @@ jobs:
           $finalName = "release-packaged-sentrux-$env:GITHUB_RUN_ID"
           $manifestPath = Join-Path $payload (Join-Path "orchestration" "integrations.json")
           New-Item -ItemType Directory -Force -Path $authority | Out-Null
-          & $packagedBinary run execute --repo $payload --out $staging --authority-root $authority --final-name $finalName --manifest $manifestPath --doctor-require-repowise false
+          & $packagedBinary run execute --repo $payload --out $staging --authority-root $authority --final-name $finalName --manifest $manifestPath --doctor-tool-path-prefix (Join-Path $installedRoot "bin") --doctor-require-repowise false
           if ($LASTEXITCODE -ne 0) { throw "packaged release run execute failed with exit ${LASTEXITCODE}" }
 
           $repoName = (Get-Item -LiteralPath $payload).Name
@@ -481,7 +481,7 @@ jobs:
           $finalName = "release-packaged-sentrux-$env:GITHUB_RUN_ID"
           $manifestPath = Join-Path $payload (Join-Path "orchestration" "integrations.json")
           New-Item -ItemType Directory -Force -Path $authority | Out-Null
-          & $packagedBinary run execute --repo $payload --out $staging --authority-root $authority --final-name $finalName --manifest $manifestPath --doctor-require-repowise false
+          & $packagedBinary run execute --repo $payload --out $staging --authority-root $authority --final-name $finalName --manifest $manifestPath --doctor-tool-path-prefix (Join-Path $installedRoot "bin") --doctor-require-repowise false
           if ($LASTEXITCODE -ne 0) { throw "packaged release run execute failed with exit ${LASTEXITCODE}" }
 
           $repoName = (Get-Item -LiteralPath $payload).Name

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2-beta.5] — 2026-08-19
+
+### Fixed
+
+- 发布包的 packaged Sentrux closure 显式把安装后的 `bin` 作为 doctor tool-path prefix，确保 doctor/capability executor 发现同一套安装内置 Sentrux binary。
+
 ## [0.7.2-beta.4] — 2026-08-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,7 @@ checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "code-intel"
-version = "0.7.2-beta.4"
+version = "0.7.2-beta.5"
 dependencies = [
  "serde_json",
  "tiny_http",

--- a/crates/code-intel-cli/Cargo.toml
+++ b/crates/code-intel-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "code-intel"
-version = "0.7.2-beta.4"
+version = "0.7.2-beta.5"
 edition = "2021"
 description = "Local Code Intel Pipeline CLI for artifact resume and contract checks"
 license = "MIT"

--- a/crates/code-intel-cli/tests/fixtures/cli-head-parity.v2.json
+++ b/crates/code-intel-cli/tests/fixtures/cli-head-parity.v2.json
@@ -33,7 +33,7 @@
         "--json"
       ],
       "exitCode": 0,
-      "stdoutUtf8": "{\"name\":\"code-intel\",\"schema\":\"code-intel-version.v1\",\"version\":\"0.7.2-beta.4\"}\n",
+      "stdoutUtf8": "{\"name\":\"code-intel\",\"schema\":\"code-intel-version.v1\",\"version\":\"0.7.2-beta.5\"}\n",
       "stderrUtf8": ""
     },
     {
@@ -44,7 +44,7 @@
         "--json"
       ],
       "exitCode": 0,
-      "stdoutUtf8": "{\"name\":\"code-intel\",\"schema\":\"code-intel-version.v1\",\"version\":\"0.7.2-beta.4\"}\n",
+      "stdoutUtf8": "{\"name\":\"code-intel\",\"schema\":\"code-intel-version.v1\",\"version\":\"0.7.2-beta.5\"}\n",
       "stderrUtf8": ""
     },
     {

--- a/orchestration/toolchain-versions.v1.json
+++ b/orchestration/toolchain-versions.v1.json
@@ -93,7 +93,7 @@
     },
     {
       "name": "code-intel",
-      "version": "0.7.2-beta.4",
+      "version": "0.7.2-beta.5",
       "comparison": "minimum",
       "scope": "runtime",
       "required": true,


### PR DESCRIPTION
## Summary\n- pass the installed release bin directory as --doctor-tool-path-prefix in Windows and Unix packaged closure validation\n- make the release doctor's built-in Sentrux detection use the same installed topology as the packaged binary\n- prepare v0.7.2-beta.5 after beta.4 validation exposed the remaining doctor readiness gap\n\n## Verification\n- cargo fmt -p code-intel -- --check\n- cargo check -p code-intel --locked\n- cargo test -q -p code-intel --locked --test cli_head_parity\n- repository and Skill package tests\n- lint hardcoded-paths\n- repin clean\n- Sentrux session_end passed\n\nThe three pre-existing untracked research/decision documents were preserved and are not part of this PR.