### PR TITLE
fix(release): keep packaged sentrux on built-in route

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -249,15 +249,14 @@ jobs:
       - name: Install ripgrep
         shell: pwsh
         run: |
-          if (Get-Command rg -ErrorAction SilentlyContinue) {
-            rg --version
+          $rg = Get-Command rg -ErrorAction SilentlyContinue
+          if (-not $rg -and (Test-Path "/usr/bin/rg")) {
+            $rg = Get-Command "/usr/bin/rg"
           }
-          else {
-            sudo apt-get install -y ripgrep
-            if ($LASTEXITCODE -ne 0) {
-              throw "ripgrep bootstrap failed with exit $LASTEXITCODE"
-            }
+          if (-not $rg) {
+            throw "ripgrep is required on ubuntu-latest but was not present"
           }
+          & $rg.Source --version
 
       - name: Build Rust CLI
         shell: pwsh

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -252,12 +252,17 @@ jobs:
           $rgPath = (Get-Command rg -ErrorAction SilentlyContinue).Source
           if (-not $rgPath) {
             $version = '14.1.0'
+            $expectedSha256 = 'f84757b07f425fe5cf11d87df6644691c644a5cd2348a2c670894272999d3ba7'
             $archiveName = "ripgrep-$version-x86_64-unknown-linux-musl.tar.gz"
             $archivePath = Join-Path $env:RUNNER_TEMP $archiveName
             $extractRoot = Join-Path $env:RUNNER_TEMP "ripgrep-$version"
             $uri = "https://github.com/BurntSushi/ripgrep/releases/download/$version/$archiveName"
             New-Item -ItemType Directory -Force -Path $extractRoot | Out-Null
-            Invoke-WebRequest -Uri $uri -OutFile $archivePath
+            Invoke-WebRequest -Uri $uri -OutFile $archivePath -TimeoutSec 60
+            $actualSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $archivePath).Hash.ToLowerInvariant()
+            if ($actualSha256 -ne $expectedSha256) {
+              throw "ripgrep archive SHA-256 mismatch: expected $expectedSha256, got $actualSha256"
+            }
             tar -xzf $archivePath -C $extractRoot
             $rgPath = (Get-ChildItem -Path $extractRoot -Filter rg -File -Recurse | Select-Object -First 1).FullName
           }

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -253,8 +253,10 @@ jobs:
             rg --version
           }
           else {
-            sudo apt-get update
             sudo apt-get install -y ripgrep
+            if ($LASTEXITCODE -ne 0) {
+              throw "ripgrep bootstrap failed with exit $LASTEXITCODE"
+            }
           }
 
       - name: Build Rust CLI

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -249,14 +249,24 @@ jobs:
       - name: Install ripgrep
         shell: pwsh
         run: |
-          $rg = Get-Command rg -ErrorAction SilentlyContinue
-          if (-not $rg -and (Test-Path "/usr/bin/rg")) {
-            $rg = Get-Command "/usr/bin/rg"
+          $rgPath = (Get-Command rg -ErrorAction SilentlyContinue).Source
+          if (-not $rgPath) {
+            $version = '14.1.0'
+            $archiveName = "ripgrep-$version-x86_64-unknown-linux-musl.tar.gz"
+            $archivePath = Join-Path $env:RUNNER_TEMP $archiveName
+            $extractRoot = Join-Path $env:RUNNER_TEMP "ripgrep-$version"
+            $uri = "https://github.com/BurntSushi/ripgrep/releases/download/$version/$archiveName"
+            New-Item -ItemType Directory -Force -Path $extractRoot | Out-Null
+            Invoke-WebRequest -Uri $uri -OutFile $archivePath
+            tar -xzf $archivePath -C $extractRoot
+            $rgPath = (Get-ChildItem -Path $extractRoot -Filter rg -File -Recurse | Select-Object -First 1).FullName
           }
-          if (-not $rg) {
-            throw "ripgrep is required on ubuntu-latest but was not present"
+          if (-not $rgPath) {
+            throw "ripgrep bootstrap failed"
           }
-          & $rg.Source --version
+          $rgDirectory = Split-Path -Parent $rgPath
+          Add-Content -Path $env:GITHUB_PATH -Value $rgDirectory
+          & $rgPath --version
 
       - name: Build Rust CLI
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,6 +231,12 @@ jobs:
           # input; using it as --repo bypasses the installed topology that the
           # release gate is required to prove.
           $payload = $installedRoot
+          # Let doctor validate the installed topology through PATH while
+          # keeping the Rust built-in Sentrux provider authoritative. Passing
+          # this directory as the provider prefix would force the optional
+          # external shim route on Unix and make packaged Sentrux disappear.
+          $installedBin = Join-Path $installedRoot "bin"
+          $env:PATH = "$installedBin$([IO.Path]::PathSeparator)$env:PATH"
           # The packaged binary must publish a committed, snapshot-bound
           # Sentrux closure. The manifest and content-addressed artifacts are
           # authoritative; command stdout is intentionally not inspected.
@@ -240,7 +246,7 @@ jobs:
           $finalName = "release-packaged-sentrux-$env:GITHUB_RUN_ID"
           $manifestPath = Join-Path $payload (Join-Path "orchestration" "integrations.json")
           New-Item -ItemType Directory -Force -Path $authority | Out-Null
-          & $packagedBinary run execute --repo $payload --out $staging --authority-root $authority --final-name $finalName --manifest $manifestPath --doctor-tool-path-prefix (Join-Path $installedRoot "bin") --doctor-require-repowise false
+          & $packagedBinary run execute --repo $payload --out $staging --authority-root $authority --final-name $finalName --manifest $manifestPath --doctor-require-repowise false
           if ($LASTEXITCODE -ne 0) { throw "packaged release run execute failed with exit ${LASTEXITCODE}" }
 
           $repoName = (Get-Item -LiteralPath $payload).Name
@@ -470,6 +476,12 @@ jobs:
           # input; using it as --repo bypasses the installed topology that the
           # release gate is required to prove.
           $payload = $installedRoot
+          # Let doctor validate the installed topology through PATH while
+          # keeping the Rust built-in Sentrux provider authoritative. Passing
+          # this directory as the provider prefix would force the optional
+          # external shim route on Unix and make packaged Sentrux disappear.
+          $installedBin = Join-Path $installedRoot "bin"
+          $env:PATH = "$installedBin$([IO.Path]::PathSeparator)$env:PATH"
           $packagedBinary = Join-Path $installedRoot "bin/code-intel"
           bash -c "test -x '$packagedBinary'"
           if ($LASTEXITCODE -ne 0) { throw "packaged binary lost its executable bit in the zip round trip: $packagedBinary" }
@@ -481,7 +493,7 @@ jobs:
           $finalName = "release-packaged-sentrux-$env:GITHUB_RUN_ID"
           $manifestPath = Join-Path $payload (Join-Path "orchestration" "integrations.json")
           New-Item -ItemType Directory -Force -Path $authority | Out-Null
-          & $packagedBinary run execute --repo $payload --out $staging --authority-root $authority --final-name $finalName --manifest $manifestPath --doctor-tool-path-prefix (Join-Path $installedRoot "bin") --doctor-require-repowise false
+          & $packagedBinary run execute --repo $payload --out $staging --authority-root $authority --final-name $finalName --manifest $manifestPath --doctor-require-repowise false
           if ($LASTEXITCODE -ne 0) { throw "packaged release run execute failed with exit ${LASTEXITCODE}" }
 
           $repoName = (Get-Item -LiteralPath $payload).Name

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2-beta.6] — 2026-08-19
+
+### Fixed
+
+- 发布包验证把安装后的 `bin` 加入进程 `PATH`，让 doctor 校验安装拓扑，同时保持 Rust 内置 Sentrux provider 在 Unix 上可用。
+
 ## [0.7.2-beta.5] — 2026-08-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,7 @@ checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "code-intel"
-version = "0.7.2-beta.5"
+version = "0.7.2-beta.6"
 dependencies = [
  "serde_json",
  "tiny_http",

--- a/crates/code-intel-cli/Cargo.toml
+++ b/crates/code-intel-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "code-intel"
-version = "0.7.2-beta.5"
+version = "0.7.2-beta.6"
 edition = "2021"
 description = "Local Code Intel Pipeline CLI for artifact resume and contract checks"
 license = "MIT"

--- a/crates/code-intel-cli/tests/fixtures/cli-head-parity.v2.json
+++ b/crates/code-intel-cli/tests/fixtures/cli-head-parity.v2.json
@@ -33,7 +33,7 @@
         "--json"
       ],
       "exitCode": 0,
-      "stdoutUtf8": "{\"name\":\"code-intel\",\"schema\":\"code-intel-version.v1\",\"version\":\"0.7.2-beta.5\"}\n",
+      "stdoutUtf8": "{\"name\":\"code-intel\",\"schema\":\"code-intel-version.v1\",\"version\":\"0.7.2-beta.6\"}\n",
       "stderrUtf8": ""
     },
     {
@@ -44,7 +44,7 @@
         "--json"
       ],
       "exitCode": 0,
-      "stdoutUtf8": "{\"name\":\"code-intel\",\"schema\":\"code-intel-version.v1\",\"version\":\"0.7.2-beta.5\"}\n",
+      "stdoutUtf8": "{\"name\":\"code-intel\",\"schema\":\"code-intel-version.v1\",\"version\":\"0.7.2-beta.6\"}\n",
       "stderrUtf8": ""
     },
     {

--- a/orchestration/toolchain-versions.v1.json
+++ b/orchestration/toolchain-versions.v1.json
@@ -93,7 +93,7 @@
     },
     {
       "name": "code-intel",
-      "version": "0.7.2-beta.5",
+      "version": "0.7.2-beta.6",
       "comparison": "minimum",
       "scope": "runtime",
       "required": true,


### PR DESCRIPTION
## Summary
- prepend the installed release bin directory to PATH during packaged validation on Windows and Unix
- let doctor validate the installed topology without forcing the optional external Sentrux shim route
- bump the release candidate to v0.7.2-beta.6 and update parity/changelog

## Verification
- local YAML, cargo check, parity, repository/Skill contracts, hardcoded-path scan, repin, and Sentrux session gate pass
- beta5 macOS packaged validation reproduced the failure: Sentrux became not_applicable and Hospital returned domain_unknown

Fixes #293