### PR TITLE
docs(decisions): DR-0006 solo-operator retirement gate alternatives

### DIFF
--- a/docs/decisions/DR-0006-solo-operator-retirement-gate.md
+++ b/docs/decisions/DR-0006-solo-operator-retirement-gate.md
@@ -1,15 +1,11 @@
-# DR-0006 单人仓库下退休闸的独立审批与遥测替代路径
+# DR-0006 已证死代码分支的遥测窗口静态证明替代路径
 
 Status: active
 Date: 2026-08-25
 
 ## Decision
 
-`compatibility_retirement_gate.rs` 的两条检查在单人仓库（本仓库：单一 owner，无独立评审池）下按以下方式满足，不再要求原始形态：
-
-1. **`independent_approval`**：原逻辑要求 `reviewer != legacy.owner` 且有第二身份的签名 authority event（`check_independent_approval`, `compatibility_retirement_gate.rs:504-523`）。单人仓库里这个身份不存在，是结构性死锁，不是"还没找人签"。替代路径：作者本人签署，但必须是**两次相隔 ≥7 个自然日的独立签名事件**（cooldown 自证，不是同一 session 内一次签两次）。`independent-approval.json` 的 evidence schema 增加 `mode: "solo-operator-cooldown"` 字段区分两种满足路径；`reviewer == legacy.owner` 允许，但 `secondSignatureAt - firstSignatureAt >= 7*86400` 强制检查。
-
-2. **`unproven_usage_observation` / `unproven_compatibility_window`**：原逻辑只接受运行时遥测计数 + 30 天窗口。新增替代路径：**静态不可达性证明**——如果测试套件里已有断言"该函数/调用点在源码中不存在"（如 #323 investigation 记录的 E02/E03：`scripts/tests/test-workflow-recommendation-brief.ps1:59-61` 断言 inline 函数不存在，`test-repowise-adapter-contract.ps1:9-13` 断言直接调用不存在），且该断言在 CI 中跑绿，视为 `totalInvocations`/`legacyInvocations` 结构性恒为零，等价于遥测窗口的最强形式（永远通过），不需要再等 30 个日历日去观测一个数学上已经是零的东西。此路径**只适用于代码路径已被证明完全移除**的分支（当前已知：E02、E03），不适用于代码仍然存在只是"看起来没人调用"的分支（E04/E07/E08 不适用，它们的替代能力本身还在开发或未接入默认路径）。
+`check_rollback_and_usage`/`check_compatibility_window`（`compatibility_retirement_gate.rs`）原逻辑只接受运行时遥测计数 + 30 天窗口来满足 `usage_observation`/`compatibility_window`。新增替代路径：**静态不可达性证明**——如果 CI 里已有跑绿的断言"该调用点在源码中不存在"（如 #323 investigation 记录的 E02/E03：`test-workflow-recommendation-brief.ps1:59-61` 断言 inline 函数不存在，`test-repowise-adapter-contract.ps1:9-13` 断言直接调用不存在），视为 `totalInvocations`/`legacyInvocations` 结构性恒为零，等价于遥测窗口的最强形式（永远通过），不需要再等 30 个日历日去观测一个数学上已经是零的量。此路径**只适用于代码路径已被证明完全移除**的分支（当前已知：E02、E03），不适用于 E04/E07/E08（代码仍在、替代能力未完工或未接默认路径）。
 
 ## Why
 
@@ -20,10 +16,17 @@ Date: 2026-08-25
 
 对这两条分支要求"遥测 30 天"是在测量一个已经被静态证明为零的量——闸门设计假设的前提（"需要运行时观测才能知道用量"）在这两条分支上不成立，等窗口不会产生新信息。
 
-`independent_approval` 的问题更基础：`reviewer != legacy["owner"]` 这个检查（`compatibility_retirement_gate.rs:514`）在只有一个 owner 身份的仓库里**永远无法为真**，不管等多久、遥测多完整。这不是"证据不够"，是闸门设计时假设了一个多人评审团队（issue #14 的 self-dogfood 意图是防"agent 自己批自己"，这个意图本身是对的），但没有为单人 + AI-agent 协作这种拓扑留退路，导致这条闸永久锁死，与产品是否真的安全无关。
+## 已撤回的错误结论（留痕，不删除）
 
-本项目非量化交易类高风险系统（对比：仓库里 sextant/katana-data-doctor 类项目才是有真实资金后果的场景），删除已证明死掉的 PowerShell 分支的下行风险是"删错了要 revert"，不是资金损失或数据损坏，7 天冷静期 + 静态证明的组合已经对称覆盖原闸门想防的"仓促自批"风险。
+本 DR 最初起草时（同一 session）还主张 `independent_approval` 对单人仓库结构性死锁，理由是"`reviewer != legacy.owner` 在只有一个 owner 身份的仓库里永远无法为真"。**这个结论是错的**，被同一 session 后续读代码推翻，证据：
+
+- `legacy["owner"]` 在真实 manifest 里是能力角色 id（如 `"executor-recommender"`），不是人类身份；测试 fixture 的 owner 是 `"owner-team"`，reviewer 通过的是 `"code-intel-maintainers"`——两者本来就是不同的字符串,不是同一个人扮演两个角色的冲突。
+- 信任锚点 `authority.rs::TRUSTED_APPROVERS` 本身就是仓库自签的角色白名单（`[("code-intel-maintainers","repository_governance")]`），文档注释明写"trust comes only from the checked-in id/role allow-list"——设计上就是**仓库治理自证**，不要求第二个独立人类。
+- 现有测试 `self_reported_independence_cannot_override_owner_or_authority_policy` 显式验证的是"owner 角色 id 和 reviewer 角色 id 相同时才拦"，不是"同一个人不能签"。
+- E02 当前的 `evidence/independent-approval.json` 是纯占位 stub（`reviewer: "independent-verifier-required"`, `authorityEvent: {}`），从未真正尝试构造过签名事件——不是"试了签不了"，是"没人真的走过这个流程"。
+
+**结论**：`independent_approval` 对 E02/E03 不需要任何闸门代码改动，只需要真的生成一份合法的 `code-intel-maintainers`/`repository_governance` 签名 evidence（sha256 摘要 + attestation digest 按 `authority.rs::authority_event_digest` 规则算）。这是数据生成工作，不是决策工作。
 
 ## Enforcement
 
-Convention only，本 DR 落账口径；**代码尚未改**。`compatibility_retirement_gate.rs::check_independent_approval` 和 `check_compatibility_and_usage` 仍是原始行为，本 DR 生效前任何 session 想真的让 E02/E03 的 `decision` 从 `blocked` 变成非 blocked，必须先把这条 DR 描述的替代路径实现进闸代码 + 更新对应 packet 的 evidence json，并跑 `test-retirement-packets.ps1` 证明其余未满足替代条件的分支（E04/E07/E08）行为不变。跟踪实现的 issue：待开（本 session 未开，下一 session 开工前先查 `gh issue list` 是否已存在再开新的，避免重复）。
+Convention only，静态证明路径尚未写进 `compatibility_retirement_gate.rs`，跟踪实现见 issue #339。E02/E03 的 `independent_approval` 证据本身不受本 DR 约束——按现有闸门逻辑真实生成即可，属于 #323 下的执行工作，不是决策工作。

--- a/docs/decisions/DR-0006-solo-operator-retirement-gate.md
+++ b/docs/decisions/DR-0006-solo-operator-retirement-gate.md
@@ -1,0 +1,29 @@
+# DR-0006 单人仓库下退休闸的独立审批与遥测替代路径
+
+Status: active
+Date: 2026-08-25
+
+## Decision
+
+`compatibility_retirement_gate.rs` 的两条检查在单人仓库（本仓库：单一 owner，无独立评审池）下按以下方式满足，不再要求原始形态：
+
+1. **`independent_approval`**：原逻辑要求 `reviewer != legacy.owner` 且有第二身份的签名 authority event（`check_independent_approval`, `compatibility_retirement_gate.rs:504-523`）。单人仓库里这个身份不存在，是结构性死锁，不是"还没找人签"。替代路径：作者本人签署，但必须是**两次相隔 ≥7 个自然日的独立签名事件**（cooldown 自证，不是同一 session 内一次签两次）。`independent-approval.json` 的 evidence schema 增加 `mode: "solo-operator-cooldown"` 字段区分两种满足路径；`reviewer == legacy.owner` 允许，但 `secondSignatureAt - firstSignatureAt >= 7*86400` 强制检查。
+
+2. **`unproven_usage_observation` / `unproven_compatibility_window`**：原逻辑只接受运行时遥测计数 + 30 天窗口。新增替代路径：**静态不可达性证明**——如果测试套件里已有断言"该函数/调用点在源码中不存在"（如 #323 investigation 记录的 E02/E03：`scripts/tests/test-workflow-recommendation-brief.ps1:59-61` 断言 inline 函数不存在，`test-repowise-adapter-contract.ps1:9-13` 断言直接调用不存在），且该断言在 CI 中跑绿，视为 `totalInvocations`/`legacyInvocations` 结构性恒为零，等价于遥测窗口的最强形式（永远通过），不需要再等 30 个日历日去观测一个数学上已经是零的东西。此路径**只适用于代码路径已被证明完全移除**的分支（当前已知：E02、E03），不适用于代码仍然存在只是"看起来没人调用"的分支（E04/E07/E08 不适用，它们的替代能力本身还在开发或未接入默认路径）。
+
+## Why
+
+2026-08-25 实证，来自本仓库自己的调查记录（issue #323 前两条评论）：
+
+- E02（recommender）：inline 函数在 `legacy/run-code-intel.ps1` 里**已经不存在**，默认路径 100% 走 Rust capability，`totalInvocations` 结构性为零，不是"暂未观测到"。
+- E03（provider-preflight）：同型，`test-repowise-adapter-contract.ps1` 主动 fail 若走回旧路径。
+
+对这两条分支要求"遥测 30 天"是在测量一个已经被静态证明为零的量——闸门设计假设的前提（"需要运行时观测才能知道用量"）在这两条分支上不成立，等窗口不会产生新信息。
+
+`independent_approval` 的问题更基础：`reviewer != legacy["owner"]` 这个检查（`compatibility_retirement_gate.rs:514`）在只有一个 owner 身份的仓库里**永远无法为真**，不管等多久、遥测多完整。这不是"证据不够"，是闸门设计时假设了一个多人评审团队（issue #14 的 self-dogfood 意图是防"agent 自己批自己"，这个意图本身是对的），但没有为单人 + AI-agent 协作这种拓扑留退路，导致这条闸永久锁死，与产品是否真的安全无关。
+
+本项目非量化交易类高风险系统（对比：仓库里 sextant/katana-data-doctor 类项目才是有真实资金后果的场景），删除已证明死掉的 PowerShell 分支的下行风险是"删错了要 revert"，不是资金损失或数据损坏，7 天冷静期 + 静态证明的组合已经对称覆盖原闸门想防的"仓促自批"风险。
+
+## Enforcement
+
+Convention only，本 DR 落账口径；**代码尚未改**。`compatibility_retirement_gate.rs::check_independent_approval` 和 `check_compatibility_and_usage` 仍是原始行为，本 DR 生效前任何 session 想真的让 E02/E03 的 `decision` 从 `blocked` 变成非 blocked，必须先把这条 DR 描述的替代路径实现进闸代码 + 更新对应 packet 的 evidence json，并跑 `test-retirement-packets.ps1` 证明其余未满足替代条件的分支（E04/E07/E08）行为不变。跟踪实现的 issue：待开（本 session 未开，下一 session 开工前先查 `gh issue list` 是否已存在再开新的，避免重复）。

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -25,5 +25,6 @@ Enforcement: 谁在什么时机强制它（gate / 测试 / 评审规约），没
 | [DR-0003](DR-0003-manifest-discovery-precedence.md) | manifest 发现优先级与 probe 语义 | active |
 | [DR-0004](DR-0004-issue-claim-protocol.md) | issue 认领协议：开工先打 claimed label | active |
 | [DR-0005](DR-0005-integration-debt-ceiling.md) | 整合债上限：修复 PR 积压时停产新 feature | active |
+| [DR-0006](DR-0006-solo-operator-retirement-gate.md) | 单人仓库退休闸：独立审批用冷静期自证，可证死代码用静态证明替代遥测窗口 | active |
 
 平行 session 开工前先扫本目录（一次 `ls docs/decisions/` + 读 README 表格，30 秒）。与已有决策相悖的工作，先开 issue 挑战决策本身，不要直接实现相反语义。

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -25,6 +25,6 @@ Enforcement: 谁在什么时机强制它（gate / 测试 / 评审规约），没
 | [DR-0003](DR-0003-manifest-discovery-precedence.md) | manifest 发现优先级与 probe 语义 | active |
 | [DR-0004](DR-0004-issue-claim-protocol.md) | issue 认领协议：开工先打 claimed label | active |
 | [DR-0005](DR-0005-integration-debt-ceiling.md) | 整合债上限：修复 PR 积压时停产新 feature | active |
-| [DR-0006](DR-0006-solo-operator-retirement-gate.md) | 单人仓库退休闸：独立审批用冷静期自证，可证死代码用静态证明替代遥测窗口 | active |
+| [DR-0006](DR-0006-solo-operator-retirement-gate.md) | 已证死代码分支（E02/E03）可用静态不可达证明替代 30 天遥测窗口 | active |
 
 平行 session 开工前先扫本目录（一次 `ls docs/decisions/` + 读 README 表格，30 秒）。与已有决策相悖的工作，先开 issue 挑战决策本身，不要直接实现相反语义。


### PR DESCRIPTION
Records the decision, per DR-0004 protocol, that this repo's compatibility retirement gate (`compatibility_retirement_gate.rs`) requires 30 days of runtime telemetry (`usage_observation`/`compatibility_window`) even for branches already statically proven unreachable (E02/E03, per issue #323's investigation comments).

DR-0006 records a narrow substitute evidence path: static unreachability proof (an existing, CI-green test asserting the call path's absence) satisfies `usage_observation`/`compatibility_window` for branches already proven code-removed. Scoped to E02/E03 only -- E04/E07/E08 still need their real replacements finished first and are unaffected.

**Correction (see commit history):** this PR originally also claimed `independent_approval` was structurally unsatisfiable in a single-owner repo. That claim was wrong and has been retracted in a follow-up commit -- `authority.rs`'s trust anchor is a checked-in role allowlist (`code-intel-maintainers`/`repository_governance`), not a distinct-human-signature requirement, and `legacy.owner` is a capability role id, never equal to the reviewer role id. E02/E03's independent-approval evidence just needs to actually be generated (data work), not a gate redesign. DR-0006 keeps this as a visible retraction rather than silently deleting the wrong claim.

Enforcement is convention-only in this PR. Actual gate code change (the static-unreachability branch in `check_compatibility_window`/`check_rollback_and_usage`) is tracked in #339.
