### PR TITLE
feat(retirement-gate): static-unreachability substitute for usage/compatibility-window evidence

### DIFF
--- a/crates/code-intel-cli/src/compatibility_retirement_gate.rs
+++ b/crates/code-intel-cli/src/compatibility_retirement_gate.rs
@@ -323,6 +323,11 @@ fn check_compatibility_window(
         referenced,
         blockers,
         |d| {
+            if d["proofMode"] == "static_unreachability" {
+                return static_unreachability_proof(d)
+                    && d["checkedAt"].as_u64().is_some_and(|c| c <= evaluated_at)
+                    && d["expiresAt"].as_u64().is_some_and(|e| e >= evaluated_at);
+            }
             let start = d["startedAt"].as_u64().unwrap_or(u64::MAX);
             let end = d["observedThrough"].as_u64().unwrap_or(0);
             let days = d["minimumDays"].as_u64().unwrap_or(u64::MAX);
@@ -343,6 +348,9 @@ fn check_compatibility_window(
             "compatibilityWindow ref",
         )?)
         .ok_or_else(|| AdapterError::Contract("compatibility window evidence is absent".into()))?;
+    if compatibility["details"]["proofMode"] == "static_unreachability" {
+        return Ok((u64::MAX, u64::MAX));
+    }
     let compatibility_start = compatibility["details"]["startedAt"]
         .as_u64()
         .unwrap_or(u64::MAX);
@@ -350,6 +358,26 @@ fn check_compatibility_window(
         .as_u64()
         .unwrap_or(0);
     Ok((compatibility_start, compatibility_end))
+}
+
+/// A branch already proven unreachable in source (a CI-enforced absence
+/// assertion, not a runtime sample) makes `legacyInvocations` structurally
+/// zero forever -- see DR-0006. Scoped to that narrow claim only: this does
+/// not attest replacement adoption or elapsed time.
+fn static_unreachability_proof(d: &Value) -> bool {
+    d["outcome"] == "passed"
+        && !d["staticProof"]["testFile"]
+            .as_str()
+            .unwrap_or("")
+            .is_empty()
+        && !d["staticProof"]["testName"]
+            .as_str()
+            .unwrap_or("")
+            .is_empty()
+        && !d["staticProof"]["assertsAbsenceOf"]
+            .as_str()
+            .unwrap_or("")
+            .is_empty()
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -392,6 +420,11 @@ fn check_rollback_and_usage(
         referenced,
         blockers,
         |d| {
+            if compatibility_start == u64::MAX && compatibility_end == u64::MAX {
+                return d["proofMode"] == "static_unreachability"
+                    && static_unreachability_proof(d)
+                    && d["legacyInvocations"].as_u64() == Some(0);
+            }
             let start = d["startedAt"].as_u64().unwrap_or(u64::MAX);
             let end = d["endedAt"].as_u64().unwrap_or(0);
             let total = d["totalInvocations"].as_u64().unwrap_or(0);
@@ -886,5 +919,75 @@ mod tests {
             .as_array()
             .unwrap()
             .contains(&json!("unproven_independent_approval")));
+    }
+
+    #[test]
+    fn static_unreachability_proof_satisfies_usage_and_compatibility_window() {
+        let (manifest, mut evidence) = fixture();
+        let window_digest = evidence_digest(&manifest, "/approvalSubject/compatibilityWindow");
+        evidence.get_mut(&window_digest).unwrap()["details"] = json!({
+            "outcome":"passed",
+            "proofMode":"static_unreachability",
+            "staticProof":{
+                "testFile":"scripts/tests/test-workflow-recommendation-brief.ps1",
+                "testName":"asserts inline recommender absent",
+                "assertsAbsenceOf":"Invoke-WorkflowStackDetector"
+            },
+            "checkedAt":2_600_000,
+            "expiresAt":NOW + 100
+        });
+        let usage_digest = evidence_digest(&manifest, "/approvalSubject/usageObservation");
+        evidence.get_mut(&usage_digest).unwrap()["details"] = json!({
+            "outcome":"passed",
+            "proofMode":"static_unreachability",
+            "staticProof":{
+                "testFile":"scripts/tests/test-workflow-recommendation-brief.ps1",
+                "testName":"asserts inline recommender absent",
+                "assertsAbsenceOf":"Invoke-WorkflowStackDetector"
+            },
+            "legacyInvocations":0
+        });
+        let decision = evaluate(&manifest, &evidence, NOW).unwrap();
+        assert_eq!(decision["decision"], "approved");
+        assert_eq!(decision["blockers"], json!([]));
+    }
+
+    #[test]
+    fn static_compatibility_window_cannot_pair_with_telemetry_usage_evidence() {
+        let (manifest, mut evidence) = fixture();
+        let window_digest = evidence_digest(&manifest, "/approvalSubject/compatibilityWindow");
+        evidence.get_mut(&window_digest).unwrap()["details"] = json!({
+            "outcome":"passed",
+            "proofMode":"static_unreachability",
+            "staticProof":{
+                "testFile":"scripts/tests/test-repowise-adapter-contract.ps1",
+                "testName":"fails if direct call site returns",
+                "assertsAbsenceOf":"test-code-intel-provider.ps1"
+            },
+            "checkedAt":2_600_000,
+            "expiresAt":NOW + 100
+        });
+        // usageObservation evidence is left as the fixture's telemetry-shaped
+        // details, which no longer matches the sentinel compatibility window.
+        let decision = evaluate(&manifest, &evidence, NOW).unwrap();
+        assert!(decision["blockers"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("unproven_usage_observation")));
+    }
+
+    #[test]
+    fn e04_e07_e08_shaped_evidence_without_proof_mode_is_unaffected() {
+        // No proofMode field at all -- the default/legacy telemetry shape
+        // used by branches whose replacement is still incomplete (E04/E07/E08)
+        // must keep failing closed exactly as before this change.
+        let (manifest, mut evidence) = fixture();
+        let usage_digest = evidence_digest(&manifest, "/approvalSubject/usageObservation");
+        evidence.get_mut(&usage_digest).unwrap()["details"]["legacyInvocations"] = json!(3);
+        let decision = evaluate(&manifest, &evidence, NOW).unwrap();
+        assert!(decision["blockers"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("unproven_usage_observation")));
     }
 }

--- a/orchestration/integrations.json
+++ b/orchestration/integrations.json
@@ -938,7 +938,7 @@
           "id": "compatibility.retirement-gate.compat",
           "version": "1.0.0",
           "toolchainDigests": [
-            "2d2b38c4650795e2bba99e8ec38ca21adcb204042e9289577c535f7087e899d8",
+            "bb7afda3d56cf7d5b8a055c617bd6845f8a8795717ec094762ab3fc1eaba88f8",
             "bb3591c34ec9e6791da78fcf1a24d464be5faea0ec5eeddb84169a889e590c9e",
             "9fad4644b8cfb88fbec6f4603e7fcb099dc296fdf29286a6909279fab1450d0e"
           ]


### PR DESCRIPTION
Implements DR-0006 (#338). `check_compatibility_window` / `check_rollback_and_usage`'s `usage_observation` predicate now accept an alternate evidence shape when `details.proofMode == "static_unreachability"`: a named, currently-green CI test asserting the legacy call path's absence, instead of `startedAt`/`observedThrough`/telemetry counts.

Scoped narrowly:
- Default/omitted `proofMode` keeps existing runtime-telemetry behavior unchanged -- verified by a new regression test using E04/E07/E08-shaped evidence (`legacyInvocations: 3` still blocks exactly as before).
- A static `compatibility_window` returns a sentinel `(u64::MAX, u64::MAX)` pair, so `usage_observation` can only take the static branch when paired with a static window -- new test proves a static window can't pair with telemetry-shaped usage evidence (still blocks with `unproven_usage_observation`).
- New test proves the paired static path produces `decision: "approved"` with no blockers.

Also re-synced `orchestration/integrations.json`'s `toolchainDigests[0]` pin for `compatibility.retirement-gate.compat` to this file's new sha256 by literal string replacement (per AGENTS.md) -- the other two pinned inputs (`artifact_ref.rs`, `capability_inventory.rs`) are untouched and their digests are unchanged.

Verification:
- `cargo build -p code-intel`: success
- `cargo test -p code-intel --bin code-intel compatibility_retirement_gate::`: 12 passed (9 existing + 3 new)
- `cargo test -p code-intel --bin code-intel` (full sweep): 957/957 passed
- `cargo fmt -p code-intel -- --check`: clean
- `code-intel lint hardcoded-paths`: OK (291 files)

Does not itself flip E02/E03's `decision` to approved -- their `evidence/compatibility-window.json` and `evidence/usage-observation.json` are still the unpopulated `blocked` stubs and need to be regenerated in this new shape as a follow-up. `independent_approval` for E02/E03 is unrelated to this PR (see DR-0006's retraction note).

Closes #339.
