### PR TITLE
fix(concurrency): deterministic unique-path allocators for TempReport + 2 production staging paths

### DIFF
--- a/crates/code-intel-cli/src/audit_report/cli_tests.rs
+++ b/crates/code-intel-cli/src/audit_report/cli_tests.rs
@@ -56,28 +56,8 @@ fn synthetic_enabled_registry() -> DepartmentRegistry {
     DepartmentRegistry::from_value(&value).unwrap()
 }
 
-struct TempReport(PathBuf);
-
-impl TempReport {
-    fn write(value: &Value) -> Self {
-        let nonce = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        let path = std::env::temp_dir().join(format!(
-            "code-intel-audit-cli-test-{}-{nonce}.json",
-            std::process::id()
-        ));
-        fs::write(&path, serde_json::to_vec(value).unwrap()).unwrap();
-        Self(path)
-    }
-}
-
-impl Drop for TempReport {
-    fn drop(&mut self) {
-        let _ = fs::remove_file(&self.0);
-    }
-}
+mod temp_report;
+use temp_report::TempReport;
 
 #[test]
 fn parse_requires_repo_for_validate_and_for_render() {
@@ -150,7 +130,7 @@ fn validate_rejects_a_disabled_run_status_against_the_real_registry() {
         }
     }
     let temp = TempReport::write(&value);
-    let error = validate(&repo_root(), &temp.0).unwrap_err();
+    let error = validate(&repo_root(), temp.path()).unwrap_err();
     assert!(error.contains("run status is \"disabled\""), "{error}");
 }
 
@@ -165,7 +145,7 @@ fn run_raw_exits_nonzero_on_a_failing_validate() {
         "--repo".to_string(),
         repo_root().to_string_lossy().into_owned(),
         "--report".to_string(),
-        temp.0.to_string_lossy().into_owned(),
+        temp.path().to_string_lossy().into_owned(),
     ];
     assert_eq!(run_raw(&raw), 65);
 }
@@ -199,7 +179,7 @@ fn render_rejects_a_report_that_fails_validation() {
         }
     }
     let temp = TempReport::write(&value);
-    let error = render(&repo_root(), &temp.0, RenderFormat::Markdown).unwrap_err();
+    let error = render(&repo_root(), temp.path(), RenderFormat::Markdown).unwrap_err();
     assert!(error.contains("run status is \"disabled\""), "{error}");
 }
 

--- a/crates/code-intel-cli/src/audit_report/temp_report.rs
+++ b/crates/code-intel-cli/src/audit_report/temp_report.rs
@@ -1,0 +1,108 @@
+//! Extracted from `cli_tests.rs` to keep that file under the god-file
+//! threshold (#352 added ~80 lines here; folding them into the parent file
+//! would have crossed `functions>25 && loc>400`). `TempReport` itself is
+//! used throughout `cli_tests.rs`; only its allocator, the two regression
+//! tests pinning that allocator's uniqueness contract, and their doc
+//! commentary live here.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+use std::{env, fs};
+
+use serde_json::Value;
+
+pub(super) struct TempReport(PathBuf);
+
+fn temp_report_path(owner: &str, pid: u32, nonce: u128, sequence: u64) -> PathBuf {
+    env::temp_dir().join(format!(
+        "code-intel-audit-cli-test-{owner}-{pid}-{nonce}-{sequence}.json"
+    ))
+}
+
+/// #352: the previous allocator was `pid + a raw clock read`, nothing else.
+/// Its whole job is "never hand out the same path twice," but pid is
+/// constant within a process and the clock is the only other input, so a
+/// clock-resolution collision (two calls landing in the same tick) was an
+/// unconditional path collision. `clock` is a parameter, not a direct
+/// `SystemTime::now()` call, so a test can force exactly that condition --
+/// an identical reading on consecutive calls -- instead of hoping a real
+/// collision happens to occur.
+///
+/// `SEQUENCE` alone is not enough to survive this crate's `#[path]`
+/// topology (the same class of gap #178 closed for `tool_path.rs`): this
+/// file is `#[path]`-mounted into roughly ten separate `cargo test`
+/// integration binaries today, each with its own independent copy of this
+/// `static` starting at 0. If `audit_report` is ever additionally
+/// re-mounted a *second* time within one of those binaries under a
+/// different parent module -- exactly what happened to `tool_path.rs` --
+/// two copies in the same process, same pid, could still emit an identical
+/// `(pid, nonce, sequence)` triple. `owner` (`module_path!()`, unique per
+/// mount point) closes that gap; the clock reading itself is kept only so
+/// leftover files stay sortable by age.
+static SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+fn allocate_unique_report_path(owner: &str, pid: u32, clock: impl FnOnce() -> u128) -> PathBuf {
+    let nonce = clock();
+    let sequence = SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    temp_report_path(owner, pid, nonce, sequence)
+}
+
+impl TempReport {
+    pub(super) fn write(value: &Value) -> Self {
+        let owner = module_path!().replace("::", "-");
+        let path = allocate_unique_report_path(&owner, std::process::id(), || {
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        });
+        fs::write(&path, serde_json::to_vec(value).unwrap()).unwrap();
+        Self(path)
+    }
+
+    pub(super) fn path(&self) -> &std::path::Path {
+        &self.0
+    }
+}
+
+impl Drop for TempReport {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.0);
+    }
+}
+
+#[test]
+fn allocate_unique_report_path_differs_even_when_the_clock_repeats() {
+    // #352 regression. Before `SEQUENCE` existed, this was red: pid and
+    // owner are both constant across the two calls and the clock is stubbed
+    // to return the exact same reading both times, so with pid+nonce alone
+    // the two calls produced an identical path -- the same condition that
+    // let one test's temp file silently become another test's temp file.
+    // The allocator's contract is "never collide, even under a repeated
+    // clock reading," not merely "format pid and nonce into a string."
+    let fixed_clock = || 0xC352_u128;
+    let first = allocate_unique_report_path("owner", 4242, fixed_clock);
+    let second = allocate_unique_report_path("owner", 4242, fixed_clock);
+    assert_ne!(
+        first, second,
+        "allocator must stay unique even when the clock reading repeats"
+    );
+}
+
+#[test]
+fn temp_report_path_partitions_by_owner_token() {
+    // Mirrors #178: with pid, nonce, and sequence all held identical, two
+    // different owner tokens (the disambiguator for two copies of this file
+    // mounted at different parent modules within one process) must still
+    // resolve to different paths. Deliberately does not go through
+    // `allocate_unique_report_path` -- that would let the ever-incrementing
+    // `SEQUENCE` make the paths differ for free without owner ever being
+    // exercised.
+    let path_a = temp_report_path("owner-a", 4242, 0xC352, 0);
+    let path_b = temp_report_path("owner-b", 4242, 0xC352, 0);
+    assert_ne!(
+        path_a, path_b,
+        "different owner tokens must not collide even with identical pid/nonce/sequence"
+    );
+}

--- a/crates/code-intel-cli/src/mcp_serve/handlers.rs
+++ b/crates/code-intel-cli/src/mcp_serve/handlers.rs
@@ -474,15 +474,40 @@ pub(super) fn rerun_command(context: &ServeContext) -> String {
     }
 }
 
+fn temp_staging_path(pid: u32, nonce: u128, sequence: u64) -> PathBuf {
+    env::temp_dir().join(format!("code-intel-mcp-plan-{pid}-{nonce}-{sequence}"))
+}
+
+static STAGING_SEQUENCE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// #352: the previous allocator was `pid + a raw clock read`, nothing else.
+/// A server handling two tool calls whose clock reads land in the same
+/// resolution window would hand out the identical staging directory to
+/// both. `clock` is a parameter (not a direct `SystemTime::now()` call) so
+/// a test can force that exact condition -- an identical reading on
+/// consecutive calls -- instead of depending on a real collision to occur.
+/// `STAGING_SEQUENCE` is what actually buys uniqueness; the clock reading
+/// is kept only so leftover directories stay sortable by age. This
+/// production path has no `#[path]`-remounting exposure (unlike the
+/// `audit_report`/`tool_path` test helpers): `handlers.rs` compiles exactly
+/// once, as part of the `code-intel` binary, so pid + sequence alone is a
+/// complete fix here.
+pub(super) fn allocate_staging_path(
+    pid: u32,
+    clock: impl FnOnce() -> Result<u128, ProjectError>,
+) -> Result<PathBuf, ProjectError> {
+    let nonce = clock()?;
+    let sequence = STAGING_SEQUENCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    Ok(temp_staging_path(pid, nonce, sequence))
+}
+
 fn staging_path() -> Result<PathBuf, ProjectError> {
-    let nonce = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_err(|error| ProjectError::host_io(format!("resolve staging nonce: {error}")))?
-        .as_nanos();
-    Ok(env::temp_dir().join(format!(
-        "code-intel-mcp-plan-{}-{nonce}",
-        std::process::id()
-    )))
+    allocate_staging_path(std::process::id(), || {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .map_err(|error| ProjectError::host_io(format!("resolve staging nonce: {error}")))
+    })
 }
 
 /// A closed argument set, checked before anything is read.

--- a/crates/code-intel-cli/src/mcp_serve/tests.rs
+++ b/crates/code-intel-cli/src/mcp_serve/tests.rs
@@ -481,3 +481,21 @@ fn serve_refuses_repository_keys_that_escape_the_artifact_root() {
         );
     }
 }
+
+#[test]
+fn allocate_staging_path_differs_even_when_the_clock_repeats() {
+    // #352 regression: `staging_path()`'s allocator used to be pid + a raw
+    // clock read, nothing else. Two tool calls whose clock reads land in
+    // the same resolution window would be handed the identical staging
+    // directory. `clock` is stubbed to return the exact same reading twice
+    // in a row -- the condition that caused #352's confirmed sibling bug in
+    // `audit_report`'s `TempReport` -- instead of hoping a real collision
+    // happens to occur.
+    let fixed_clock = || Ok(0xC352_u128);
+    let first = handlers::allocate_staging_path(4242, fixed_clock).expect("allocate");
+    let second = handlers::allocate_staging_path(4242, fixed_clock).expect("allocate");
+    assert_ne!(
+        first, second,
+        "allocator must stay unique even when the clock reading repeats"
+    );
+}

--- a/crates/code-intel-cli/src/project_context.rs
+++ b/crates/code-intel-cli/src/project_context.rs
@@ -30,6 +30,42 @@ fn validate_repository_key(repo: &str) -> Result<(), ProjectError> {
     Ok(())
 }
 
+static RUN_SEQUENCE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+struct RunAllocation {
+    final_name: String,
+    staging_root: PathBuf,
+}
+
+/// #352: `run()`'s identity used to be `millis + pid`, nothing else -- both
+/// the informational `RunRequest` name *and* the staging directory derived
+/// from it were built off that single colliding value, so two concurrent
+/// `run()` calls whose clock reads landed in the same millisecond (a much
+/// coarser window than nanoseconds, and therefore a much likelier
+/// collision) would be handed the identical staging root *and* publish
+/// under the identical name. `clock` is a parameter, not a direct
+/// `SystemTime::now()` call, so a test can force that exact condition. The
+/// clock reading is kept only so identities stay sortable by age;
+/// `RUN_SEQUENCE` is what actually buys uniqueness. Both fields are
+/// computed here, together, from one identity -- `run()` cannot build them
+/// independently and let them drift apart. `validate_final_name`
+/// (`run_commit.rs`) treats `final_name` as opaque -- no shape but
+/// non-empty/no-separators/no-leading-dot/no-"staging"-substring -- so
+/// widening the format here does not break that contract.
+fn allocate_run_identity(
+    pid: u32,
+    clock: impl FnOnce() -> Result<u128, ProjectError>,
+) -> Result<RunAllocation, ProjectError> {
+    let nonce = clock()?;
+    let sequence = RUN_SEQUENCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let final_name = format!("{nonce}-{pid}-{sequence}-core");
+    let staging_root = std::env::temp_dir().join(format!("code-intel-a09-{final_name}"));
+    Ok(RunAllocation {
+        final_name,
+        staging_root,
+    })
+}
+
 #[derive(Clone, Debug)]
 pub(crate) struct ProjectSelector {
     repo_path: PathBuf,
@@ -144,17 +180,17 @@ impl ProjectContext {
                 authority_root.display()
             ))
         })?;
-        let nonce = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map_err(|error| ProjectError::host_io(error.to_string()))?
-            .as_millis();
-        let final_name = format!("{nonce}-{}-core", std::process::id());
-        let staging_root = std::env::temp_dir().join(format!("code-intel-a09-{final_name}"));
+        let allocation = allocate_run_identity(std::process::id(), || {
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|duration| duration.as_millis())
+                .map_err(|error| ProjectError::host_io(error.to_string()))
+        })?;
         let request = authoritative_run::RunRequest::new(
             self.repo_path.clone(),
-            staging_root,
+            allocation.staging_root,
             authority_root,
-            final_name,
+            allocation.final_name,
             execution_policy::ExecutionPolicy::for_profile(intent.mode.profile()),
         )
         .with_repository_key(self.repo.clone())

--- a/crates/code-intel-cli/src/project_context/tests.rs
+++ b/crates/code-intel-cli/src/project_context/tests.rs
@@ -225,3 +225,47 @@ fn stale_status_preserves_freshness_and_prioritizes_refresh() {
         .collect::<Vec<_>>();
     assert_eq!(actions, ["refresh", "impact"]);
 }
+
+#[test]
+fn allocate_run_identity_differs_even_when_the_clock_repeats() {
+    // #352 regression: `run()`'s identity used to be millis + pid, nothing
+    // else. `clock` is stubbed to return the exact same millisecond
+    // reading twice in a row -- millisecond resolution collides far more
+    // easily under real concurrency than the nanosecond case #352 already
+    // confirmed in `audit_report::TempReport` -- instead of hoping a real
+    // collision happens to occur.
+    let fixed_clock = || Ok(0xC352_u128);
+    let first = allocate_run_identity(4242, fixed_clock).expect("allocate");
+    let second = allocate_run_identity(4242, fixed_clock).expect("allocate");
+    assert_ne!(
+        first.final_name, second.final_name,
+        "published name must stay unique even when the clock reading repeats"
+    );
+    assert_ne!(
+        first.staging_root, second.staging_root,
+        "staging root must stay unique even when the clock reading repeats"
+    );
+}
+
+#[test]
+fn allocate_run_identity_derives_staging_root_from_the_same_final_name_it_publishes() {
+    // #352: fixing only the staging path while leaving the published
+    // `RunRequest` name on the old colliding identity would just move the
+    // collision from "shared staging directory" to "two concurrent runs
+    // publish under the identical name" -- still a real bug, just a
+    // different failure mode. This inspects the actual `RunAllocation`
+    // `run()` consumes (not an independently reconstructed expectation):
+    // `staging_root` must be built from the exact `final_name` this same
+    // allocation carries, so there is one identity allocation per run, not
+    // two that could drift apart.
+    let allocation = allocate_run_identity(4242, || Ok(0xC352_u128)).expect("allocate");
+    assert!(
+        allocation
+            .staging_root
+            .to_string_lossy()
+            .ends_with(&allocation.final_name),
+        "staging_root {:?} must be derived from final_name {:?}",
+        allocation.staging_root,
+        allocation.final_name
+    );
+}


### PR DESCRIPTION
## Summary

Fixes the confirmed part of #352 via `/diagnosing-bugs`: deterministic red/green tests (clock injected as a parameter, forced to repeat) instead of waiting for a real collision, then the fix, verified red-before-green by temporarily reverting each one.

## What changed

- **`audit_report/cli_tests.rs::TempReport::write`** (the confirmed #352 symptom): extracted the allocator to `audit_report/temp_report.rs` to keep `cli_tests.rs` under the god-file threshold. Added an owner token (`module_path!()`) + pid + nonce + `AtomicU64` sequence. The owner token specifically guards against this crate's `#[path]` re-mount topology -- the same class of gap #178 closed for `tool_path.rs` -- should `audit_report` ever be mounted a second time within one test binary.
- **`mcp_serve::handlers::staging_path`** (production): pid + `AtomicU64` sequence. No `#[path]` remount exposure since this compiles once as part of the `code-intel` binary.
- **`project_context::run`** (production, highest risk of the three -- millisecond-resolution nonce): refactored into `allocate_run_identity` returning `RunAllocation { final_name, staging_root }` so `run()` consumes one allocation instead of building the two independently. Fixing only `staging_root` while leaving the published `RunRequest` name on the old colliding identity would just move the bug from "shared staging directory" to "two concurrent runs publish under the identical name."

## Deferred (not in this PR)

- `session_evidence::write_new_artifact` -- same pattern, but uses `create_new(true)` so a collision fails loud instead of silently overwriting. Lowest risk of the four identified sites.
- ~6 other independently reimplemented `unique_temp_dir`-style test helpers catalogued in #352. Root cause is structural (#231's `#[path]` test-assembly tax); fixing them one at a time perpetuates the duplication #231 needs to resolve architecturally, not patch incrementally.

## Verification

- Each new test proven **red** against the pre-fix allocator (temporarily reverted the counter/owner, confirmed failure, restored) and **green** after -- not just "green," a real regression test.
- `cargo test -p code-intel --no-fail-fast`: zero failures, full suite.
- `sentrux gate .`: clean, no degradation (extraction kept `audit_report/cli_tests.rs` under the god-file threshold: 23 functions / 412 loc, vs. the `functions>25 && loc>400` rule).
- `lint hardcoded-paths`: OK.

Closes the confirmed-repro portion of #352.
