### PR TITLE
fix(session-evidence): deterministic unique-path allocator for write_new_artifact staging

### DIFF
--- a/crates/code-intel-cli/src/session_evidence.rs
+++ b/crates/code-intel-cli/src/session_evidence.rs
@@ -978,6 +978,26 @@ fn read_bounded_regular(path: &Path, max_bytes: u64, label: &str) -> Result<Vec<
     fs::read(path).map_err(|error| AdapterError::Io(format!("cannot read {label}: {error}")))
 }
 
+static STAGING_SEQUENCE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// #352: the previous temp-file name was `pid + a raw clock read`, nothing
+/// else. Two concurrent writes whose clock reads land in the same
+/// resolution window would target the identical staging path; `create_new`
+/// would then make the second writer fail loud (lowest-severity instance
+/// of the #352 family -- a spurious error, not silent data loss -- but a
+/// real bug all the same). `clock` is a parameter so a test can force that
+/// exact condition instead of hoping a real collision occurs.
+fn staged_output_path(
+    parent: &Path,
+    name: &str,
+    pid: u32,
+    clock: impl FnOnce() -> Result<u128, AdapterError>,
+) -> Result<PathBuf, AdapterError> {
+    let nonce = clock()?;
+    let sequence = STAGING_SEQUENCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    Ok(parent.join(format!(".{name}.tmp-{pid}-{nonce}-{sequence}")))
+}
+
 fn write_new_artifact(path: &Path, bytes: &[u8]) -> Result<(), AdapterError> {
     if path.exists() {
         return Err(AdapterError::Usage(format!(
@@ -993,11 +1013,12 @@ fn write_new_artifact(path: &Path, bytes: &[u8]) -> Result<(), AdapterError> {
         .file_name()
         .and_then(|name| name.to_str())
         .ok_or_else(|| AdapterError::Usage("output file name is invalid".into()))?;
-    let nonce = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_err(|error| AdapterError::Io(error.to_string()))?
-        .as_nanos();
-    let temporary = parent.join(format!(".{name}.tmp-{}-{nonce}", std::process::id()));
+    let temporary = staged_output_path(parent, name, std::process::id(), || {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .map_err(|error| AdapterError::Io(error.to_string()))
+    })?;
     let result = (|| {
         let mut file = OpenOptions::new()
             .write(true)
@@ -1015,3 +1036,7 @@ fn write_new_artifact(path: &Path, bytes: &[u8]) -> Result<(), AdapterError> {
     }
     result
 }
+
+#[cfg(test)]
+#[path = "session_evidence_tests.rs"]
+mod tests;

--- a/crates/code-intel-cli/src/session_evidence_tests.rs
+++ b/crates/code-intel-cli/src/session_evidence_tests.rs
@@ -1,0 +1,35 @@
+use super::*;
+
+#[test]
+fn staged_output_path_differs_even_when_the_clock_repeats() {
+    // #352 regression: the previous temp-file name was pid + a raw clock
+    // read, nothing else. `clock` is stubbed to return the exact same
+    // reading twice in a row -- the condition #352 already confirmed
+    // causes silent data corruption in `audit_report::TempReport` -- so
+    // this collision case is exercised deterministically instead of
+    // waiting for a real one. `create_new(true)` at the call site turns a
+    // collision into a loud `AlreadyExists` error rather than silent
+    // overwrite, but a spurious error under legitimate concurrent use is
+    // still a real bug worth fixing.
+    let fixed_clock = || Ok(0xC352_u128);
+    let parent = Path::new("/tmp");
+    let first = staged_output_path(parent, "artifact.json", 4242, fixed_clock).expect("allocate");
+    let second = staged_output_path(parent, "artifact.json", 4242, fixed_clock).expect("allocate");
+    assert_ne!(
+        first, second,
+        "staged output path must stay unique even when the clock reading repeats"
+    );
+}
+
+#[test]
+fn staged_output_path_propagates_a_clock_failure() {
+    // The allocator's contract with its caller: a clock error must still
+    // surface as `AdapterError::Io`, not be swallowed. Pins that widening
+    // the allocator to take an injectable clock did not change this.
+    let parent = Path::new("/tmp");
+    let error = staged_output_path(parent, "artifact.json", 4242, || {
+        Err(AdapterError::Io("clock unavailable".to_string()))
+    })
+    .expect_err("clock failure must propagate");
+    assert!(matches!(error, AdapterError::Io(message) if message == "clock unavailable"));
+}

--- a/orchestration/internalization/mindwalk.json
+++ b/orchestration/internalization/mindwalk.json
@@ -42,7 +42,7 @@
     },
     "conformanceEvidence": {
       "evidenceIds": [
-        "local:mindwalk:adapter-source-sha256:d5ce744b0d85a867e97b0d866c135aca0c1457dafc1374e7f8047fe3167ab586",
+        "local:mindwalk:adapter-source-sha256:5df967f77cca36b12c0fa734a1bbb0059a0fe373fee4b0f57774db8a2c9dcb07",
         "local:mindwalk:adapter-tests-sha256:e22021400f4dc468231a4ede76e68dbc189eb85e0580f3d86ddf96d99acec53e",
         "local:mindwalk:production-smoke-sha256:33c3c0c28e3c6b7d06ff53043606641c38c3a4890edcd3f2c7bddfc0f737aa45"
       ],
@@ -62,7 +62,7 @@
       },
       "source": {
         "path": "crates/code-intel-cli/src/session_evidence.rs",
-        "sha256": "d5ce744b0d85a867e97b0d866c135aca0c1457dafc1374e7f8047fe3167ab586"
+        "sha256": "5df967f77cca36b12c0fa734a1bbb0059a0fe373fee4b0f57774db8a2c9dcb07"
       },
       "conformance": {
         "path": "crates/code-intel-cli/tests/session_evidence.rs",
@@ -136,7 +136,7 @@
       "path": "crates/code-intel-cli/src/session_evidence.rs",
       "description": "Pipeline-owned native Rust privacy, snapshot, normalization, structural join, and advisory signal boundary",
       "evidenceIds": [
-        "local:mindwalk:adapter-source-sha256:d5ce744b0d85a867e97b0d866c135aca0c1457dafc1374e7f8047fe3167ab586"
+        "local:mindwalk:adapter-source-sha256:5df967f77cca36b12c0fa734a1bbb0059a0fe373fee4b0f57774db8a2c9dcb07"
       ]
     },
     {


### PR DESCRIPTION
## Summary

Fixes the last of #352's four originally-identified concurrency sites: `session_evidence::write_new_artifact`, the mildest of the four (fails loud via `create_new(true)` rather than silently overwriting), but still a real bug.

## What changed

Extracted `staged_output_path` with an injectable clock (error path unchanged -- a clock failure still surfaces as `AdapterError::Io`) plus an `AtomicU64` sequence, matching the pattern from #353 (`TempReport`, `mcp_serve::staging_path`, `project_context::run`).

Tests live in a new `session_evidence_tests.rs` rather than growing `session_evidence.rs` (already the largest file in the crate). Proven red-before-fix / green-after by temporarily reverting the sequence counter and re-running.

Resynced the `session_evidence.rs` source-sha256 pin in `orchestration/internalization/mindwalk.json` (3 occurrences) by literal string replacement.

## Explicitly NOT in scope

The ~7 other independently reimplemented `unique_temp_dir`-style test helpers catalogued in #352. They have no demonstrated caller collision (every current call site uses a distinct label; nothing has ever been observed to fail), and #352's own acceptance criteria scoped them to wait for #231's consolidation decision. I initially started fixing two of them speculatively in this branch, then reverted -- that would have been different, lower-confidence work riding on this PR rather than the confirmed pattern this one completes.

## Verification

- New tests proven red against the pre-fix allocator, green after.
- `cargo test -p code-intel --no-fail-fast`: clean (the only flake observed, `perf_optimize::weco_process`, is #349, unrelated).
- `sentrux gate .`: clean, no degradation.
- `lint hardcoded-paths`: OK.
