### PR TITLE
fix(perf-optimize): deterministic weco_process timeout tests, fix Windows fixture spawn storm (#349)

### DIFF
--- a/crates/code-intel-cli/src/perf_optimize/weco_process.rs
+++ b/crates/code-intel-cli/src/perf_optimize/weco_process.rs
@@ -13,7 +13,7 @@
 //! timeout fires is available in time to use for the graceful stop.
 
 use std::io::{BufRead, BufReader};
-use std::process::{Command, ExitStatus, Stdio};
+use std::process::{Child, Command, ExitStatus, Stdio};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -30,6 +30,15 @@ pub(crate) struct WecoRunOutcome {
     pub(crate) exit_status: Option<ExitStatus>,
     pub(crate) timed_out: bool,
     pub(crate) graceful_stop_invoked: bool,
+    /// #349: `graceful_stop_invoked` only means the `weco run stop` command
+    /// was *issued* -- it stays true whether the child then actually exits
+    /// on its own within `grace_period` or has to be hard-killed at the end
+    /// of it. A test asserting "no hard kill happened" needs this explicit
+    /// bit, not a timing proxy: under CPU contention severe enough to
+    /// starve the fixture's own polling loop, the graceful path can
+    /// legitimately take over a second, which a tight elapsed-time
+    /// assertion cannot distinguish from "fell through to hard-kill."
+    pub(crate) hard_killed: bool,
     pub(crate) run_id: Option<String>,
 }
 
@@ -111,6 +120,51 @@ fn spawn_line_reader(
     })
 }
 
+/// #349: abstracts "has the process exited yet" so
+/// `resolve_after_timeout`'s decision logic can be driven by a synthetic
+/// mock in tests instead of a real `std::process::Child` racing real OS
+/// scheduling -- the actual source of #349's flakiness. The real
+/// implementation is a one-line passthrough.
+trait TimeoutChild {
+    fn try_wait(&mut self) -> std::io::Result<Option<ExitStatus>>;
+}
+
+impl TimeoutChild for Child {
+    fn try_wait(&mut self) -> std::io::Result<Option<ExitStatus>> {
+        Child::try_wait(self)
+    }
+}
+
+/// #349: the graceful-stop/hard-kill decision, isolated from
+/// `run_weco_with_wall_clock_backstop`'s real process spawning and real
+/// wall-clock waits so it can be exercised deterministically. `issue_stop`,
+/// `deadline_reached`, and `wait_a_bit` abstract the three real-world waits
+/// this decision depends on (spawning `weco run stop`, the grace-period
+/// clock, and the between-polls sleep); production wires all three to real
+/// behavior below, tests drive them synthetically and instantly. Returns
+/// `(graceful_stop_invoked, hard_killed, exit_status_if_graceful)`.
+fn resolve_after_timeout(
+    child: &mut impl TimeoutChild,
+    run_id: Option<&str>,
+    mut issue_stop: impl FnMut(&str) -> bool,
+    mut deadline_reached: impl FnMut() -> bool,
+    mut wait_a_bit: impl FnMut(),
+) -> std::io::Result<(bool, bool, Option<ExitStatus>)> {
+    let graceful_stop_invoked = match run_id {
+        Some(id) => issue_stop(id),
+        None => false,
+    };
+    loop {
+        if let Some(status) = child.try_wait()? {
+            return Ok((graceful_stop_invoked, false, Some(status)));
+        }
+        if deadline_reached() {
+            return Ok((graceful_stop_invoked, true, None));
+        }
+        wait_a_bit();
+    }
+}
+
 /// Runs `command` (a fully-configured `weco run ...` invocation) to
 /// completion, or until `wall_clock_timeout` elapses. On timeout, attempts
 /// `<weco_binary> run stop <run-id>` if a run id was ever seen on stdout,
@@ -166,6 +220,7 @@ pub(crate) fn run_weco_with_wall_clock_backstop(
                 exit_status: Some(status),
                 timed_out,
                 graceful_stop_invoked,
+                hard_killed: false,
                 run_id,
             });
         }
@@ -175,36 +230,48 @@ pub(crate) fn run_weco_with_wall_clock_backstop(
             // lag the buffer write, so re-check the buffer directly before
             // deciding there's no run id to stop.
             observed_run_id = run_id_from(observed_run_id, &snapshot(&stdout_buffer));
-            if let Some(run_id) = &observed_run_id {
-                let stop_status = Command::new(weco_binary)
-                    .args(["run", "stop", run_id])
-                    .stdin(Stdio::null())
-                    .stdout(Stdio::null())
-                    .stderr(Stdio::null())
-                    .status();
-                graceful_stop_invoked = stop_status.is_ok();
-            }
             let stop_deadline = Instant::now() + grace_period;
-            while Instant::now() < stop_deadline {
-                if let Some(status) = child.try_wait().map_err(WecoRunError::Io)? {
-                    // Exited on its own within the grace period (the
-                    // graceful-stop path) -- same reasoning as the clean-exit
-                    // case above: safe to join before snapshotting.
-                    join_best_effort(stdout_reader);
-                    join_best_effort(stderr_reader);
-                    let stdout = snapshot(&stdout_buffer);
-                    let run_id = run_id_from(observed_run_id, &stdout);
-                    return Ok(WecoRunOutcome {
-                        stdout,
-                        stderr: snapshot(&stderr_buffer),
-                        exit_status: Some(status),
-                        timed_out,
-                        graceful_stop_invoked,
-                        run_id,
-                    });
-                }
-                thread::sleep(Duration::from_millis(5));
+            let (graceful, hard_killed, exited_gracefully) = resolve_after_timeout(
+                &mut child,
+                observed_run_id.as_deref(),
+                |run_id| {
+                    Command::new(weco_binary)
+                        .args(["run", "stop", run_id])
+                        .stdin(Stdio::null())
+                        .stdout(Stdio::null())
+                        .stderr(Stdio::null())
+                        .status()
+                        .is_ok()
+                },
+                || Instant::now() >= stop_deadline,
+                || thread::sleep(Duration::from_millis(5)),
+            )
+            .map_err(WecoRunError::Io)?;
+            graceful_stop_invoked = graceful;
+
+            if let Some(status) = exited_gracefully {
+                // Exited on its own within the grace period -- same
+                // reasoning as the clean-exit case above: safe to join
+                // before snapshotting.
+                join_best_effort(stdout_reader);
+                join_best_effort(stderr_reader);
+                let stdout = snapshot(&stdout_buffer);
+                let run_id = run_id_from(observed_run_id, &stdout);
+                return Ok(WecoRunOutcome {
+                    stdout,
+                    stderr: snapshot(&stderr_buffer),
+                    exit_status: Some(status),
+                    timed_out,
+                    graceful_stop_invoked,
+                    hard_killed: false,
+                    run_id,
+                });
             }
+
+            debug_assert!(
+                hard_killed,
+                "resolve_after_timeout always hard-kills when it does not return a graceful exit status"
+            );
             crate::node_timeout::terminate_process_tree(&mut child);
             let status = child.wait().ok();
             // Deliberately does not join the reader threads: a descendant of
@@ -223,6 +290,7 @@ pub(crate) fn run_weco_with_wall_clock_backstop(
                 exit_status: status,
                 timed_out,
                 graceful_stop_invoked,
+                hard_killed: true,
                 run_id,
             });
         }

--- a/crates/code-intel-cli/src/perf_optimize/weco_process_tests.rs
+++ b/crates/code-intel-cli/src/perf_optimize/weco_process_tests.rs
@@ -31,7 +31,16 @@ fn extract_run_id_reads_a_labelled_line_case_and_separator_insensitively() {
 fn write_fixture(dir: &Path, name: &str, run_id: &str, responds_to_stop: bool) -> PathBuf {
     let script = dir.join(name);
     let loop_body = if responds_to_stop {
-        "if exist \"%~dp0stop-requested.marker\" exit /b 0\r\nping -n 1 -w 20 127.0.0.1 >nul\r\ngoto loop\r\n"
+        // #349: was `ping -n 1 -w 20 127.0.0.1`. `-w` bounds how long ping
+        // waits for a reply, not a guaranteed delay: 127.0.0.1 replies in
+        // under 1ms, so `-w 20` never waited its intended 20ms (measured:
+        // 10 iterations of the old line took ~74ms total). The loop was
+        // spawning a fresh `ping.exe` as fast as the OS could create one --
+        // a process-spawn storm that self-inflicted the contention this
+        // test's flakiness was blamed on. `-n 2` with no `-w` uses ping's
+        // own ~1.1s default inter-ping interval instead (measured), the
+        // same technique the sibling branch below already uses correctly.
+        "if exist \"%~dp0stop-requested.marker\" exit /b 0\r\nping -n 2 127.0.0.1 >nul\r\ngoto loop\r\n"
     } else {
         // `-w` bounds how long ping waits for a reply, not a guaranteed
         // delay: 127.0.0.1 replies instantly, so `-w 60000` returns almost
@@ -109,12 +118,25 @@ fn a_run_that_completes_within_budget_is_not_treated_as_timed_out() {
 
     assert!(!outcome.timed_out);
     assert!(!outcome.graceful_stop_invoked);
+    assert!(!outcome.hard_killed);
     assert_eq!(outcome.run_id.as_deref(), Some("fixture-run-id-789"));
     assert!(outcome.exit_status.is_some_and(|status| status.success()));
 
     fs::remove_dir_all(&dir).ok();
 }
 
+/// #349: two independent issues here. (1) The Windows fixture polled its
+/// stop marker via `ping -n 1 -w 20`, which never actually waited its
+/// intended 20ms (127.0.0.1 replies before the timeout is reached) -- a
+/// process-spawn storm, fixed alongside this test by switching to `-n 2`
+/// (ping's own ~1.1s default interval). (2) `wall_clock_timeout` (`50ms`
+/// originally) left too little margin over the fixture's own
+/// process-spawn-and-echo latency for `observed_run_id` to be set before
+/// the timeout check fires under real concurrent-build contention (verified
+/// against two genuinely concurrent full `cargo test -p code-intel` runs);
+/// widened to `2s`. `grace_period` is platform-specific: Windows now polls
+/// every ~1.1s and needs room for at least two cycles; Unix's `sleep 0.02`
+/// fixture already polls every 20ms and needs none of that margin.
 #[test]
 fn a_timed_out_run_that_honors_the_graceful_stop_exits_without_a_hard_kill() {
     let dir = temp_dir("graceful");
@@ -124,27 +146,31 @@ fn a_timed_out_run_that_honors_the_graceful_stop_exits_without_a_hard_kill() {
         "fixture-run-id-123",
         true,
     );
+    let grace_period = if cfg!(windows) {
+        Duration::from_secs(3)
+    } else {
+        Duration::from_millis(500)
+    };
 
-    let started = Instant::now();
     let outcome = run_weco_with_wall_clock_backstop(
         run_command(&weco_binary),
-        Duration::from_millis(50),
+        Duration::from_secs(2),
         &weco_binary,
-        Duration::from_millis(500),
+        grace_period,
     )
     .expect("weco run resolves after graceful stop");
-    let elapsed = started.elapsed();
 
     assert!(outcome.timed_out);
     assert!(outcome.graceful_stop_invoked);
-    assert_eq!(outcome.run_id.as_deref(), Some("fixture-run-id-123"));
-    // Grace period was generous (500ms) but the fixture checks its marker
-    // every 20ms, so it should exit almost immediately after the stop
-    // request lands -- well under the full grace period.
+    // `graceful_stop_invoked` only means the stop command was issued, not
+    // that the child exited because of it rather than being hard-killed at
+    // the end of `grace_period` -- `hard_killed` is the explicit bit for
+    // that, asserted directly instead of inferred from elapsed time.
     assert!(
-        elapsed < Duration::from_millis(400),
-        "graceful exit took too long: {elapsed:?}"
+        !outcome.hard_killed,
+        "expected a graceful exit, not a hard kill"
     );
+    assert_eq!(outcome.run_id.as_deref(), Some("fixture-run-id-123"));
 
     fs::remove_dir_all(&dir).ok();
 }
@@ -159,29 +185,150 @@ fn a_timed_out_run_that_ignores_the_graceful_stop_is_hard_killed_after_the_grace
         false,
     );
 
-    let started = Instant::now();
     let outcome = run_weco_with_wall_clock_backstop(
         run_command(&weco_binary),
-        Duration::from_millis(50),
+        Duration::from_secs(2),
         &weco_binary,
         Duration::from_millis(100),
     )
     .expect("weco run resolves via hard-kill fallback");
-    let elapsed = started.elapsed();
 
     assert!(outcome.timed_out);
     assert!(
         outcome.graceful_stop_invoked,
         "stop should still have been attempted"
     );
-    assert_eq!(outcome.run_id.as_deref(), Some("fixture-run-id-456"));
-    // Never hangs forever: timeout (50ms) + grace period (100ms) + a small
-    // margin for the hard-kill itself, well short of the fixture's own
-    // 60-second sleep.
+    // This fixture never responds to the stop request, so it must actually
+    // be hard-killed, not merely have had the stop command issued at it.
     assert!(
-        elapsed < Duration::from_secs(5),
-        "hard-kill fallback took too long: {elapsed:?}"
+        outcome.hard_killed,
+        "expected a hard kill, not a graceful exit"
     );
+    assert_eq!(outcome.run_id.as_deref(), Some("fixture-run-id-456"));
 
     fs::remove_dir_all(&dir).ok();
+}
+
+/// #349: a synthetic `TimeoutChild` -- no real process, no real clock, no
+/// real sleep anywhere near it. `exits_after_polls` counts calls to
+/// `try_wait`, not wall-clock time, so tests built on this are
+/// deterministic by construction: the same inputs always produce the same
+/// decision, on any machine, under any load.
+struct MockChild {
+    exits_after_polls: Option<u32>,
+    poll_count: u32,
+}
+
+impl MockChild {
+    fn never_exits() -> Self {
+        Self {
+            exits_after_polls: None,
+            poll_count: 0,
+        }
+    }
+
+    fn exits_after(polls: u32) -> Self {
+        Self {
+            exits_after_polls: Some(polls),
+            poll_count: 0,
+        }
+    }
+}
+
+impl TimeoutChild for MockChild {
+    fn try_wait(&mut self) -> std::io::Result<Option<ExitStatus>> {
+        self.poll_count += 1;
+        match self.exits_after_polls {
+            Some(threshold) if self.poll_count >= threshold => Ok(Some(synthetic_exit_status(0))),
+            _ => Ok(None),
+        }
+    }
+}
+
+#[cfg(windows)]
+fn synthetic_exit_status(code: u32) -> ExitStatus {
+    use std::os::windows::process::ExitStatusExt;
+    ExitStatus::from_raw(code)
+}
+
+#[cfg(not(windows))]
+fn synthetic_exit_status(code: i32) -> ExitStatus {
+    use std::os::unix::process::ExitStatusExt;
+    ExitStatus::from_raw(code)
+}
+
+#[test]
+fn resolve_after_timeout_reports_a_graceful_exit_when_the_child_exits_before_the_deadline() {
+    // #349: this is the actual decision logic the flaky real-process tests
+    // above were trying (and repeatedly failing, under real CPU/build
+    // contention) to exercise. Here it is fully deterministic: no real
+    // process, no real clock, no real sleep. `MockChild` exits on its
+    // second poll; `deadline_reached` never returns true because there is
+    // no real grace period to race against -- the child simply wins first,
+    // every single time, on every machine.
+    let mut child = MockChild::exits_after(2);
+    let mut issued_to: Option<String> = None;
+    let (graceful_stop_invoked, hard_killed, exit_status) = resolve_after_timeout(
+        &mut child,
+        Some("run-123"),
+        |run_id| {
+            issued_to = Some(run_id.to_string());
+            true
+        },
+        || false,
+        || {},
+    )
+    .expect("resolve_after_timeout does not fail on a mock child");
+
+    assert!(graceful_stop_invoked);
+    assert!(!hard_killed);
+    assert!(exit_status.is_some());
+    assert_eq!(issued_to.as_deref(), Some("run-123"));
+}
+
+#[test]
+fn resolve_after_timeout_hard_kills_when_the_child_never_exits() {
+    let mut child = MockChild::never_exits();
+    let mut deadline_checks = 0u32;
+    let (graceful_stop_invoked, hard_killed, exit_status) = resolve_after_timeout(
+        &mut child,
+        Some("run-456"),
+        |_| true,
+        || {
+            deadline_checks += 1;
+            deadline_checks >= 3
+        },
+        || {},
+    )
+    .expect("resolve_after_timeout does not fail on a mock child");
+
+    assert!(graceful_stop_invoked);
+    assert!(hard_killed);
+    assert!(exit_status.is_none());
+}
+
+#[test]
+fn resolve_after_timeout_never_issues_a_stop_when_no_run_id_was_observed() {
+    // A run whose id was never observed (the exact race #178/#349's
+    // `wall_clock_timeout` widening was about) has nothing to name in a
+    // `weco run stop <run-id>` call -- the decision logic must not attempt
+    // one, and must go straight to "will hard-kill."
+    let mut child = MockChild::never_exits();
+    let mut stop_was_called = false;
+    let (graceful_stop_invoked, hard_killed, exit_status) = resolve_after_timeout(
+        &mut child,
+        None,
+        |_| {
+            stop_was_called = true;
+            true
+        },
+        || true,
+        || {},
+    )
+    .expect("resolve_after_timeout does not fail on a mock child");
+
+    assert!(!graceful_stop_invoked);
+    assert!(hard_killed);
+    assert!(exit_status.is_none());
+    assert!(!stop_was_called, "no run id means no stop command to issue");
 }


### PR DESCRIPTION
## Summary

Closes #349 (`perf_optimize::weco_process` timeout tests flaky under CPU/build contention). Four independent fixes:

1. **Windows fixture bug** — `write_fixture`'s responding branch polled its stop marker via `ping -n 1 -w 20 127.0.0.1`. `-w` bounds how long ping waits for a *reply*, not a guaranteed delay — 127.0.0.1 replies in under 1ms, so `-w 20` never actually waited its intended 20ms. Measured directly: 10 iterations of the old line took ~74ms total (~7.4ms each), meaning the loop was spawning a fresh `ping.exe` process as fast as the OS could create one — a self-inflicted process-spawn storm that was itself contributing to the contention the flakiness was blamed on. Fixed by switching to `ping -n 2 127.0.0.1` (no `-w` override), which uses ping's own ~1.1s default inter-ping interval instead — the same technique the sibling non-responsive fixture already used correctly.

2. **Test correctness bug** — added an explicit `hard_killed: bool` field to `WecoRunOutcome`, set at all three return sites in `run_weco_with_wall_clock_backstop`. Previously `graceful_stop_invoked` (meaning only "the stop command was *issued*") was being used as a proxy for "exited gracefully, not hard-killed" via an elapsed-time assertion — those are different claims. Tests now assert `hard_killed` directly instead of inferring it from elapsed time.

3. **Evidence-based timeout widening** — `wall_clock_timeout` widened from `50ms` to `2s`, `grace_period` for the graceful-exit test is now platform-specific (`3s` on Windows to span the fixture's real ~1.1s poll cycle post-fix; `500ms` on Unix, unchanged, since that fixture already polls every 20ms via `sleep 0.02`). Verified against two genuinely concurrent full `cargo test -p code-intel` runs — the actual condition #349 was filed under, not a synthetic CPU spinner.

4. **True determinism for the actual decision logic** — extracted the post-timeout graceful-stop/hard-kill decision into a new function `resolve_after_timeout` behind a minimal `TimeoutChild` trait (one method: `try_wait`). Added a `MockChild` test double and three new tests (`resolve_after_timeout_reports_a_graceful_exit_when_the_child_exits_before_the_deadline`, `resolve_after_timeout_hard_kills_when_the_child_never_exits`, `resolve_after_timeout_never_issues_a_stop_when_no_run_id_was_observed`) that exercise the decision logic with zero real process, zero real clock, zero real sleep — deterministic by construction, verified 20/20 under real concurrent full-suite load (not just idle).

The real end-to-end tests (spawning an actual fixture process) remain as supplementary integration checks with the widened, evidence-based margins from point 3 — they are no longer the primary correctness guarantee (the deterministic tests in point 4 are), but they still provide real-world plumbing confidence.

**The deterministic mock-based tests (`resolve_after_timeout_*`) close #349's actual acceptance criteria (reliable red/green regardless of machine load) for the decision logic.** The real end-to-end fixture tests are supplementary and have measured ~90%+ reliability under realistic concurrent-build contention (not 100% — that's an inherent property of testing real OS subprocess timing, documented honestly, not hidden).

## Verification performed

- `cargo fmt --check` — clean
- `cargo test -p code-intel --bin code-intel weco_process::` — 7 passed, 0 failed
- `cargo build -p code-intel --bin code-intel` — clean build
- `./target/debug/code-intel.exe sentrux gate .` — "No degradation detected"
- `./target/debug/code-intel.exe lint hardcoded-paths` — OK
- `cargo test -p code-intel --no-fail-fast` (full suite, one pass) — zero failures anywhere, including unrelated tests
- `resolve_after_timeout_*` deterministic tests verified 20/20 under real concurrent full-suite load

## Scope

Only `crates/code-intel-cli/src/perf_optimize/weco_process.rs` and `crates/code-intel-cli/src/perf_optimize/weco_process_tests.rs` are touched. The other 7 duplicate `unique_temp_dir`-style test helpers and issue #231 are explicitly out of scope — handled separately.
