### PR TITLE
fix(test-support): consolidate 7 duplicate unique_temp_dir test helpers (#231, #352)

### DIFF
--- a/crates/code-intel-cli/src/anchor_verification/tests.rs
+++ b/crates/code-intel-cli/src/anchor_verification/tests.rs
@@ -1,13 +1,4 @@
 use super::*;
-use std::time::{SystemTime, UNIX_EPOCH};
-
-fn unique_temp_dir(name: &str) -> std::path::PathBuf {
-    let stamp = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("clock should be after epoch")
-        .as_nanos();
-    std::env::temp_dir().join(format!("code-intel-anchor-verification-{name}-{stamp}"))
-}
 
 #[test]
 fn verified_round_trips_through_json() {
@@ -80,7 +71,7 @@ fn approximate_relabeled_verified_by_state_only_is_rejected() {
 
 #[test]
 fn verify_file_anchor_is_verified_when_file_exists() {
-    let root = unique_temp_dir("file-verified");
+    let root = crate::test_support::unique_temp_dir("file-verified");
     fs::create_dir_all(&root).expect("fixture root");
     fs::write(root.join("present.rs"), b"fn present() {}").expect("fixture file");
 
@@ -94,7 +85,7 @@ fn verify_file_anchor_is_verified_when_file_exists() {
 
 #[test]
 fn verify_file_anchor_is_dropped_when_file_missing() {
-    let root = unique_temp_dir("file-dropped");
+    let root = crate::test_support::unique_temp_dir("file-dropped");
     fs::create_dir_all(&root).expect("fixture root");
 
     assert!(matches!(
@@ -107,7 +98,7 @@ fn verify_file_anchor_is_dropped_when_file_missing() {
 
 #[test]
 fn verify_file_anchor_is_dropped_when_path_escapes_repository() {
-    let root = unique_temp_dir("file-escape");
+    let root = crate::test_support::unique_temp_dir("file-escape");
     fs::create_dir_all(&root).expect("fixture root");
 
     assert!(matches!(
@@ -120,7 +111,7 @@ fn verify_file_anchor_is_dropped_when_path_escapes_repository() {
 
 #[test]
 fn verify_symbol_anchor_is_verified_at_the_exact_claimed_line() {
-    let root = unique_temp_dir("symbol-verified");
+    let root = crate::test_support::unique_temp_dir("symbol-verified");
     fs::create_dir_all(&root).expect("fixture root");
     fs::write(&root.join("lib.rs"), "fn alpha() {}\nfn beta() {}\n").expect("fixture file");
 
@@ -139,7 +130,7 @@ fn verify_symbol_anchor_is_verified_at_the_exact_claimed_line() {
 /// the stale claim as verified.
 #[test]
 fn verify_symbol_anchor_degrades_to_approximate_after_the_symbol_moves() {
-    let root = unique_temp_dir("symbol-drifted");
+    let root = crate::test_support::unique_temp_dir("symbol-drifted");
     fs::create_dir_all(&root).expect("fixture root");
     let target = root.join("lib.rs");
     fs::write(&target, "fn alpha() {}\nfn beta() {}\n").expect("fixture file (frozen state)");
@@ -165,7 +156,7 @@ fn verify_symbol_anchor_degrades_to_approximate_after_the_symbol_moves() {
 
 #[test]
 fn verify_symbol_anchor_is_dropped_when_the_symbol_is_removed() {
-    let root = unique_temp_dir("symbol-removed");
+    let root = crate::test_support::unique_temp_dir("symbol-removed");
     fs::create_dir_all(&root).expect("fixture root");
     let target = root.join("lib.rs");
     fs::write(&target, "fn alpha() {}\nfn beta() {}\n").expect("fixture file (frozen state)");
@@ -189,7 +180,7 @@ fn verify_symbol_anchor_is_dropped_when_the_symbol_is_removed() {
 
 #[test]
 fn verify_symbol_anchor_is_dropped_when_the_file_itself_is_deleted() {
-    let root = unique_temp_dir("file-deleted-after-freeze");
+    let root = crate::test_support::unique_temp_dir("file-deleted-after-freeze");
     fs::create_dir_all(&root).expect("fixture root");
     let target = root.join("lib.rs");
     fs::write(&target, "fn alpha() {}\n").expect("fixture file (frozen state)");
@@ -235,7 +226,7 @@ fn anchor_counts_records_each_state_exhaustively() {
 
 #[test]
 fn verify_and_report_produces_all_three_states_from_one_manifest() {
-    let root = unique_temp_dir("verify-and-report");
+    let root = crate::test_support::unique_temp_dir("verify-and-report");
     fs::create_dir_all(&root).expect("fixture root");
     fs::write(&root.join("present.rs"), "fn kept() {}\n").expect("fixture file");
     // "gone.rs" is referenced by the fixture artifacts below but never

--- a/crates/code-intel-cli/src/artifacts_report.rs
+++ b/crates/code-intel-cli/src/artifacts_report.rs
@@ -374,15 +374,6 @@ fn latest_committed_run(repo_artifacts: &Path) -> Result<(PathBuf, Value)> {
 mod tests {
     use super::*;
     use serde_json::json;
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    fn unique_temp_dir() -> PathBuf {
-        let stamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock should be after epoch")
-            .as_nanos();
-        std::env::temp_dir().join(format!("code-intel-report-sentrux-{stamp}"))
-    }
 
     fn capability_fixture(root: &Path) -> (String, Value) {
         let snapshot = "a".repeat(64);
@@ -430,7 +421,7 @@ mod tests {
 
     #[test]
     fn report_projects_verified_refs_and_marks_untrusted_refs_degraded() {
-        let root = unique_temp_dir();
+        let root = crate::test_support::unique_temp_dir("sentrux-report");
         fs::create_dir_all(&root).expect("fixture root should be created");
         let (snapshot, reference) = capability_fixture(&root);
         let mut untrusted = reference.clone();
@@ -466,7 +457,7 @@ mod tests {
 
     #[test]
     fn report_marks_missing_hospital_projection_unknown_or_degraded() {
-        let root = unique_temp_dir();
+        let root = crate::test_support::unique_temp_dir("sentrux-report");
         fs::create_dir_all(&root).expect("fixture root should be created");
         let (snapshot, reference) = capability_fixture(&root);
         let manifest = json!({

--- a/crates/code-intel-cli/src/artifacts_tests.rs
+++ b/crates/code-intel-cli/src/artifacts_tests.rs
@@ -1,14 +1,5 @@
 use super::*;
 use serde_json::json;
-use std::time::{SystemTime, UNIX_EPOCH};
-
-fn unique_temp_dir(name: &str) -> PathBuf {
-    let stamp = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("clock should be after epoch")
-        .as_nanos();
-    env::temp_dir().join(format!("code-intel-{name}-{stamp}"))
-}
 
 fn touch(path: &Path, text: &str) {
     fs::write(path, text).expect("fixture file should be writable");
@@ -26,7 +17,7 @@ fn summary_for(report: Value, hospital: Value, artifact_dir: &Path) -> ResumeSum
 
 #[test]
 fn resume_contract_routes_graph_missing_to_understanding() {
-    let dir = unique_temp_dir("graph-missing");
+    let dir = crate::test_support::unique_temp_dir("graph-missing");
     fs::create_dir_all(&dir).expect("fixture dir should be created");
     touch(&dir.join("summary.md"), "# Summary");
     touch(&dir.join("understanding.md"), "# Understanding");
@@ -79,7 +70,7 @@ fn resume_contract_routes_graph_missing_to_understanding() {
 
 #[test]
 fn resume_contract_prioritizes_github_research_when_required() {
-    let dir = unique_temp_dir("research-required");
+    let dir = crate::test_support::unique_temp_dir("research-required");
     fs::create_dir_all(&dir).expect("fixture dir should be created");
     touch(&dir.join("understanding.md"), "# Understanding");
     let research_markdown = dir.join("github-solution-research.md");
@@ -151,7 +142,7 @@ fn classify_contract_requires_research_for_upstream_or_tool_blockers() {
 
 #[test]
 fn ensure_directory_creates_a_fresh_nested_directory() {
-    let dir = unique_temp_dir("ensure-directory-fresh");
+    let dir = crate::test_support::unique_temp_dir("ensure-directory-fresh");
     let target = dir.join("nested").join("leaf");
 
     let resolved = ensure_directory(&target).expect("create a fresh nested directory");
@@ -166,7 +157,7 @@ fn ensure_directory_is_idempotent_for_an_existing_directory() {
     // Re-running against an already-analyzed repo is the ordinary case, not
     // an exotic one: the authority root container directory is meant to be
     // reused run after run.
-    let dir = unique_temp_dir("ensure-directory-idempotent");
+    let dir = crate::test_support::unique_temp_dir("ensure-directory-idempotent");
     fs::create_dir_all(&dir).expect("fixture dir");
 
     let resolved = ensure_directory(&dir).expect("re-create an already-existing directory");
@@ -181,7 +172,7 @@ fn ensure_directory_reports_a_real_file_collision_with_its_path_preserved() {
     // A genuine blocker (something real occupying the path) must still fail
     // — self-healing is only for the false-positive Windows symlink case
     // below, never for an actual collision.
-    let dir = unique_temp_dir("ensure-directory-file-collision");
+    let dir = crate::test_support::unique_temp_dir("ensure-directory-file-collision");
     fs::create_dir_all(&dir).expect("fixture parent");
     let blocked = dir.join("blocked");
     fs::write(&blocked, b"not a directory").expect("fixture blocking file");
@@ -235,7 +226,7 @@ fn ensure_directory_recovers_from_a_spurious_already_exists_through_a_cross_volu
     ));
     fs::create_dir_all(&real_target).expect("create real target on the other drive");
 
-    let link_parent = unique_temp_dir("ensure-directory-symlink-parent");
+    let link_parent = crate::test_support::unique_temp_dir("ensure-directory-symlink-parent");
     fs::create_dir_all(&link_parent).expect("create link parent");
     let link = link_parent.join("artifacts");
     if std::os::windows::fs::symlink_dir(&real_target, &link).is_err() {

--- a/crates/code-intel-cli/src/authoritative_run/execution_kernel.rs
+++ b/crates/code-intel-cli/src/authoritative_run/execution_kernel.rs
@@ -321,15 +321,6 @@ fn map_commit_error(error: crate::run_commit::CommitError) -> RunError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    fn unique_temp_dir(name: &str) -> PathBuf {
-        let stamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock should be after epoch")
-            .as_nanos();
-        std::env::temp_dir().join(format!("code-intel-execution-kernel-{name}-{stamp}"))
-    }
 
     #[test]
     fn typed_result_owns_outcome_exit_and_publication_serialization() {
@@ -369,7 +360,7 @@ mod tests {
 
     #[test]
     fn resolve_repo_name_takes_the_final_path_component_of_the_resolved_repo() {
-        let root = unique_temp_dir("resolve-name");
+        let root = crate::test_support::unique_temp_dir("resolve-name");
         let repo = root.join("widget-repo");
         std::fs::create_dir_all(&repo).expect("fixture repo dir");
 
@@ -389,13 +380,13 @@ mod tests {
 
     #[test]
     fn resolve_repo_name_rejects_a_repo_path_that_does_not_exist() {
-        let missing = unique_temp_dir("resolve-name-missing");
+        let missing = crate::test_support::unique_temp_dir("resolve-name-missing");
         assert!(resolve_repo_name(&missing).is_err());
     }
 
     #[test]
     fn explicit_repository_key_preserves_authority_across_checkout_rename() {
-        let missing = unique_temp_dir("stable-repository-key");
+        let missing = crate::test_support::unique_temp_dir("stable-repository-key");
         let name = resolve_repository_key(&missing, Some("original-checkout"))
             .expect("explicit authority key does not depend on checkout directory name");
         assert_eq!(name, "original-checkout");
@@ -403,7 +394,7 @@ mod tests {
 
     #[test]
     fn explicit_repository_key_rejects_nested_or_parent_paths() {
-        let repo = unique_temp_dir("invalid-repository-key");
+        let repo = crate::test_support::unique_temp_dir("invalid-repository-key");
         for key in ["", ".", "..", "nested/repo", "nested\\repo"] {
             assert!(resolve_repository_key(&repo, Some(key)).is_err(), "{key:?}");
         }
@@ -411,7 +402,7 @@ mod tests {
 
     #[test]
     fn nest_authority_root_appends_the_repo_name_exactly_once() {
-        let root = unique_temp_dir("nest-once");
+        let root = crate::test_support::unique_temp_dir("nest-once");
         std::fs::create_dir_all(&root).expect("fixture authority root");
 
         let nested = nest_authority_root(&root, "widget-repo").expect("nest under authority root");
@@ -427,7 +418,7 @@ mod tests {
         // name into --authority-root themselves. The fix must recognize
         // that and publish there directly, not append a second
         // widget-repo/widget-repo layer.
-        let root = unique_temp_dir("nest-workaround").join("widget-repo");
+        let root = crate::test_support::unique_temp_dir("nest-workaround").join("widget-repo");
         std::fs::create_dir_all(&root).expect("fixture pre-nested authority root");
 
         let nested = nest_authority_root(&root, "widget-repo").expect("reuse pre-nested root");
@@ -449,7 +440,7 @@ mod tests {
     /// `artifacts_tests.rs`).
     #[test]
     fn nest_authority_root_names_the_path_when_something_real_blocks_it() {
-        let root = unique_temp_dir("nest-blocked");
+        let root = crate::test_support::unique_temp_dir("nest-blocked");
         std::fs::create_dir_all(&root).expect("fixture authority root");
         let blocked = root.join("widget-repo");
         std::fs::write(&blocked, b"not a directory").expect("fixture blocking file");

--- a/crates/code-intel-cli/src/cli/legacy.rs
+++ b/crates/code-intel-cli/src/cli/legacy.rs
@@ -1332,25 +1332,9 @@ mod tests {
         assert!(args.json);
     }
 
-    fn unique_temp_dir(label: &str) -> PathBuf {
-        use std::time::{SystemTime, UNIX_EPOCH};
-
-        let mut dir = std::env::temp_dir();
-        dir.push(format!(
-            "code-intel-cli-legacy-test-{label}-{}-{}",
-            std::process::id(),
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
-        dir
-    }
-
     #[test]
     fn cmd_language_set_persists_the_project_config() {
-        let repo = unique_temp_dir("language-set");
+        let repo = crate::test_support::unique_temp_dir("language-set");
         let args = Args {
             command: "language".to_string(),
             operation: Some("set".to_string()),
@@ -1395,7 +1379,7 @@ mod tests {
 
     #[test]
     fn cmd_language_set_requires_language() {
-        let repo = unique_temp_dir("language-set-missing-language");
+        let repo = crate::test_support::unique_temp_dir("language-set-missing-language");
         let args = Args {
             command: "language".to_string(),
             operation: Some("set".to_string()),

--- a/crates/code-intel-cli/src/language_pref/tests.rs
+++ b/crates/code-intel-cli/src/language_pref/tests.rs
@@ -1,21 +1,5 @@
 use super::*;
 
-fn unique_temp_dir(label: &str) -> PathBuf {
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    let mut dir = std::env::temp_dir();
-    dir.push(format!(
-        "code-intel-language-pref-test-{label}-{}-{}",
-        std::process::id(),
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    fs::create_dir_all(&dir).unwrap();
-    dir
-}
-
 fn write_config(path: &Path, language: &str) {
     fs::create_dir_all(path.parent().unwrap()).unwrap();
     fs::write(path, format!(r#"{{"language": "{language}"}}"#)).unwrap();
@@ -29,7 +13,7 @@ fn absent_user_config(root: &Path) -> PathBuf {
 
 #[test]
 fn explicit_flag_wins_over_every_configured_tier() {
-    let root = unique_temp_dir("flag-wins");
+    let root = crate::test_support::unique_temp_dir("flag-wins");
     write_config(&project_config_path(&root), "en");
     let user_config = root.join("user").join("config.json");
     write_config(&user_config, "en");
@@ -43,7 +27,7 @@ fn explicit_flag_wins_over_every_configured_tier() {
 
 #[test]
 fn project_config_wins_when_no_explicit_flag() {
-    let root = unique_temp_dir("project-wins");
+    let root = crate::test_support::unique_temp_dir("project-wins");
     write_config(&project_config_path(&root), "zh");
     let user_config = root.join("user").join("config.json");
     write_config(&user_config, "en");
@@ -57,7 +41,7 @@ fn project_config_wins_when_no_explicit_flag() {
 
 #[test]
 fn user_config_wins_when_no_flag_and_no_project_config() {
-    let root = unique_temp_dir("user-wins");
+    let root = crate::test_support::unique_temp_dir("user-wins");
     // No project config written at all: repo exists, but
     // `.code-intel/config.json` is absent.
     let user_config = root.join("user").join("config.json");
@@ -72,7 +56,7 @@ fn user_config_wins_when_no_flag_and_no_project_config() {
 
 #[test]
 fn user_config_is_still_consulted_with_no_repo_at_all() {
-    let root = unique_temp_dir("user-wins-no-repo");
+    let root = crate::test_support::unique_temp_dir("user-wins-no-repo");
     let user_config = root.join("user").join("config.json");
     write_config(&user_config, "zh");
 
@@ -85,7 +69,7 @@ fn user_config_is_still_consulted_with_no_repo_at_all() {
 
 #[test]
 fn system_locale_wins_when_nothing_configured() {
-    let root = unique_temp_dir("locale-wins");
+    let root = crate::test_support::unique_temp_dir("locale-wins");
     let user_config = absent_user_config(&root);
 
     let resolved = resolve_from(None, Some(&root), &user_config, Some("zh"));
@@ -97,7 +81,7 @@ fn system_locale_wins_when_nothing_configured() {
 
 #[test]
 fn falls_back_to_en_when_no_tier_resolves() {
-    let root = unique_temp_dir("default-wins");
+    let root = crate::test_support::unique_temp_dir("default-wins");
     let user_config = absent_user_config(&root);
 
     let resolved = resolve_from(None, Some(&root), &user_config, None);
@@ -118,7 +102,7 @@ fn an_explicit_flag_is_trimmed_but_never_validated_against_known_languages() {
 
 #[test]
 fn blank_explicit_flag_falls_through_instead_of_winning() {
-    let root = unique_temp_dir("blank-flag-falls-through");
+    let root = crate::test_support::unique_temp_dir("blank-flag-falls-through");
     write_config(&project_config_path(&root), "zh");
 
     let resolved = resolve_from(Some("   "), Some(&root), &absent_user_config(&root), None);
@@ -142,7 +126,7 @@ fn locale_strings_normalize_to_the_two_supported_languages() {
 
 #[test]
 fn write_project_config_round_trips_through_read_language() {
-    let root = unique_temp_dir("write-round-trip");
+    let root = crate::test_support::unique_temp_dir("write-round-trip");
 
     let path = write_project_config(&root, "zh").unwrap();
 
@@ -153,7 +137,7 @@ fn write_project_config_round_trips_through_read_language() {
 
 #[test]
 fn write_project_config_merges_instead_of_clobbering_other_keys() {
-    let root = unique_temp_dir("write-merge");
+    let root = crate::test_support::unique_temp_dir("write-merge");
     let path = project_config_path(&root);
     fs::create_dir_all(path.parent().unwrap()).unwrap();
     fs::write(&path, r#"{"otherSetting": "keep-me"}"#).unwrap();
@@ -169,7 +153,7 @@ fn write_project_config_merges_instead_of_clobbering_other_keys() {
 
 #[test]
 fn write_project_config_recovers_from_a_corrupt_existing_file() {
-    let root = unique_temp_dir("write-corrupt-recovery");
+    let root = crate::test_support::unique_temp_dir("write-corrupt-recovery");
     let path = project_config_path(&root);
     fs::create_dir_all(path.parent().unwrap()).unwrap();
     fs::write(&path, "not valid json").unwrap();
@@ -182,7 +166,7 @@ fn write_project_config_recovers_from_a_corrupt_existing_file() {
 
 #[test]
 fn an_absent_config_file_is_neither_data_nor_an_error() {
-    let root = unique_temp_dir("absent-config");
+    let root = crate::test_support::unique_temp_dir("absent-config");
     assert_eq!(read_language(&project_config_path(&root)), None);
     fs::remove_dir_all(root).ok();
 }

--- a/crates/code-intel-cli/src/main.rs
+++ b/crates/code-intel-cli/src/main.rs
@@ -85,6 +85,8 @@ mod snapshot;
 mod stable_artifact;
 mod staged_artifact;
 mod survival_scan;
+#[cfg(test)]
+mod test_support;
 mod tool_effectiveness_benchmark;
 mod workspace_advisory_controller;
 

--- a/crates/code-intel-cli/src/orchestration.rs
+++ b/crates/code-intel-cli/src/orchestration.rs
@@ -840,15 +840,6 @@ fn read_manifest_integration_count(result: &Value) -> Option<usize> {
 mod tests {
     use super::*;
     use serde_json::json;
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    fn unique_temp_dir(name: &str) -> PathBuf {
-        let stamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock should be after epoch")
-            .as_nanos();
-        env::temp_dir().join(format!("code-intel-{name}-{stamp}"))
-    }
 
     fn touch(path: &Path, text: &str) {
         if let Some(parent) = path.parent() {
@@ -858,7 +849,7 @@ mod tests {
     }
 
     fn orchestration_fixture_dir(name: &str) -> PathBuf {
-        let dir = unique_temp_dir(name);
+        let dir = crate::test_support::unique_temp_dir(name);
         fs::create_dir_all(dir.join("orchestration")).expect("fixture orchestration dir");
         fs::create_dir_all(dir.join("crates/code-intel-cli")).expect("fixture crate dir");
         touch(&dir.join("crates/code-intel-cli/Cargo.toml"), "[package]\n");

--- a/crates/code-intel-cli/src/test_support.rs
+++ b/crates/code-intel-cli/src/test_support.rs
@@ -1,0 +1,94 @@
+//! Shared test-only fixture helpers (#231, #352).
+//!
+//! `#231` diagnosed why this crate accumulates duplicate small helpers
+//! instead of sharing one implementation: modules are wired together with
+//! `#[path = "..."] mod x;` re-inclusion, so pulling a shared helper into a
+//! `#[path]`-mounted file taxes every test binary that mounts it -- and its
+//! transitive dependency chain. `#352` fixed the four instances of this
+//! crate's `unique_temp_dir`-style helper that back production code or a
+//! `#[path]`-mounted file (`audit_report::temp_report`,
+//! `mcp_serve::handlers`, `project_context`, `session_evidence`); those keep
+//! their own implementations because a shared version there would need the
+//! `module_path!()` owner-token disambiguation those call sites require.
+//!
+//! This module is the other half of `#352`'s deferred scope: the seven
+//! `unique_temp_dir` reimplementations that back ordinary `#[cfg(test)] mod
+//! tests` blocks compiled exactly once, as a plain `mod x;` reachable only
+//! from `cargo test -p code-intel --bin code-intel`. None of those files are
+//! `#[path]`-mounted into any other test binary, so the `#[path]` tax that
+//! blocks sharing code in the `#352` cases does not apply here -- one
+//! canonical, tested helper can replace all seven copies without adding
+//! compile or dead-code surface to unrelated test binaries.
+//!
+//! No `module_path!()` owner token: that component exists solely to
+//! disambiguate two copies of the *same* file mounted at different parent
+//! modules within one process (see `temp_report.rs`), a scenario that
+//! cannot occur for a helper that is itself compiled exactly once.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn temp_dir_path(pid: u32, nonce: u128, sequence: u64, name: &str) -> PathBuf {
+    std::env::temp_dir().join(format!("code-intel-test-{name}-{pid}-{nonce}-{sequence}"))
+}
+
+/// #175 / #178 / #231 / #352: pid alone does not make this unique -- it is
+/// constant across every call made by one process, so within-process
+/// uniqueness rests entirely on `SEQUENCE`. A raw clock reading is not a
+/// substitute: two calls issued in quick succession by the same process (or
+/// by sibling test threads racing each other, which `cargo test`'s default
+/// runner does routinely) can land in the same clock tick, and pid+clock
+/// alone then hands out the identical path twice -- exactly the collision
+/// `#352` traced to one duplicated test file's leftover directory. The
+/// clock reading is kept only so leftover directories from a killed run
+/// stay sortable by age; `SEQUENCE` is what actually buys uniqueness.
+static SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+fn allocate_unique_temp_dir_path(name: &str, pid: u32, clock: impl FnOnce() -> u128) -> PathBuf {
+    let nonce = clock();
+    let sequence = SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    temp_dir_path(pid, nonce, sequence, name)
+}
+
+/// Build a filesystem path guaranteed unique per call, for test fixtures
+/// that need a scratch directory. `name` should describe the fixture's
+/// purpose so a leftover directory (e.g. from a killed test run) stays
+/// identifiable during manual cleanup.
+pub(crate) fn unique_temp_dir(name: &str) -> PathBuf {
+    allocate_unique_temp_dir_path(name, std::process::id(), || {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after epoch")
+            .as_nanos()
+    })
+}
+
+#[test]
+fn allocate_unique_temp_dir_path_differs_even_when_the_clock_repeats() {
+    // #352-style regression: with pid and name both held constant and the
+    // clock stubbed to return the same reading on every call, the only
+    // remaining source of uniqueness is `SEQUENCE`. Without it incrementing,
+    // this assertion is red -- see the PR description for the red-run output
+    // captured by temporarily disabling the `fetch_add`.
+    let fixed_clock = || 0xC352_u128;
+    let first = allocate_unique_temp_dir_path("fixture", 4242, fixed_clock);
+    let second = allocate_unique_temp_dir_path("fixture", 4242, fixed_clock);
+    assert_ne!(
+        first, second,
+        "allocator must stay unique even when the clock reading repeats"
+    );
+}
+
+#[test]
+fn unique_temp_dir_differs_across_repeated_calls() {
+    let mut seen = std::collections::BTreeSet::new();
+    for _ in 0..256 {
+        let dir = unique_temp_dir("burst");
+        assert!(
+            seen.insert(dir.clone()),
+            "unique_temp_dir returned a duplicate inside one burst: {}",
+            dir.display()
+        );
+    }
+}


### PR DESCRIPTION
## What

Consolidates 7 of the crate's 8 duplicate `unique_temp_dir`-style test-fixture-path helpers behind one shared, tested implementation. This is **Option B** from #231's two proposed directions (small shared helper), not Option A (full `lib.rs` migration, out of scope here).

## Why

#231 diagnosed why this crate accumulates duplicate small helpers instead of sharing one implementation: modules are wired together with `#[path = "..."] mod x;` re-inclusion, so pulling a shared helper into a `#[path]`-mounted file taxes every test binary that mounts it, plus its transitive dependency chain. #352 fixed the 4 `unique_temp_dir`-style duplicates that back production code or a `#[path]`-mounted file (each keeps `module_path!()` owner-token disambiguation for that reason) and deferred the remaining 7 test-only duplicates, none of which are `#[path]`-mounted into any other test binary (re-verified with `grep -rn "src/<filename>" crates/code-intel-cli/tests/*.rs` for each before starting -- all empty). Since none of the 7 incur the `#[path]` tax, one canonical helper can replace all 7 without adding compile or dead-code surface to unrelated test binaries.

## New shared module

`crates/code-intel-cli/src/test_support.rs`, declared `#[cfg(test)] mod test_support;` in `main.rs` (placed alphabetically between `survival_scan` and `tool_effectiveness_benchmark`, matching the existing inline `#[cfg(test)] mod x;` convention used for `budget_dispatch_oversize`).

`pub(crate) fn unique_temp_dir(name: &str) -> PathBuf` uses the pid + clock + `AtomicU64` sequence pattern #352 proved safe in `audit_report/temp_report.rs`: pid alone is constant per-process, a raw clock reading alone can collide across two calls issued in quick succession (or racing sibling test threads), so `SEQUENCE` is what actually buys uniqueness; the clock reading is kept only so leftover directories stay sortable by age. Deliberately **omits** the `module_path!()` owner token from `temp_report.rs` -- that component exists only to disambiguate two copies of the *same* file mounted at different parent modules within one process, which cannot happen for a helper compiled exactly once.

The path-building logic is factored into `allocate_unique_temp_dir_path(name, pid, clock: impl FnOnce() -> u128)` (injectable clock) so a test can force two calls with an identical clock reading and assert the paths still differ. `unique_temp_dir_differs_across_repeated_calls` additionally asserts 256 real calls never collide.

## Migrated call sites (7)

| File | Callers | Before | After |
|---|---|---|---|
| `artifacts_report.rs` | 2 | local `unique_temp_dir()` (no args) | `crate::test_support::unique_temp_dir("sentrux-report")` |
| `artifacts_tests.rs` | 6 | local `unique_temp_dir(name)` | `crate::test_support::unique_temp_dir(name)` |
| `orchestration.rs` | 1 | local `unique_temp_dir(name)` | `crate::test_support::unique_temp_dir(name)` |
| `anchor_verification/tests.rs` | 8 | local `unique_temp_dir(name)` | `crate::test_support::unique_temp_dir(name)` |
| `authoritative_run/execution_kernel.rs` | 7 | local `unique_temp_dir(name)` | `crate::test_support::unique_temp_dir(name)` |
| `cli/legacy.rs` | 2 | local `unique_temp_dir(label)` (pre-created the dir itself) | `crate::test_support::unique_temp_dir(label)` (downstream `write_merged` already `create_dir_all`s the target's parent, verified by reading the call path) |
| `language_pref/tests.rs` | 9 | local `unique_temp_dir(label)` (pre-created the dir itself) | `crate::test_support::unique_temp_dir(label)` (all callers either write through a path that self-creates its parent, or read a path that doesn't need to exist) |

Each local `fn unique_temp_dir` definition and its now-orphaned `use std::time::{SystemTime, UNIX_EPOCH};` import (where not otherwise used) was removed.

## Not touched (different constraints, per #352)

- `audit_report/temp_report.rs`, `mcp_serve/handlers.rs::staging_path`/`allocate_staging_path`, `project_context.rs::allocate_run_identity`, `session_evidence.rs::staged_output_path` -- production code or `#[path]`-mounted, need the `module_path!()` owner token.
- `graph/tests.rs::unique_temp_dir` -- discovered during verification; **not** one of the 7 named in scope. It is `#[path]`-mounted into 12 separate integration-test binaries (see its own doc comment, tracing to #175), so it needs the same owner-token disambiguation as the #352 sites and does not meet the "compiled exactly once" precondition this consolidation relies on. Left as-is; a `#[path]`-aware consolidation of `graph/tests.rs` together with the 4 #352 sites would be a separate, follow-up change.

## Verification

- `cargo build -p code-intel --bin code-intel` -- clean, zero errors.
- Each of the 7 touched modules' existing tests, run individually, all green with no regressions:
  - `artifacts::report_reader::tests` -- 2 passed
  - `artifacts::tests` -- 8 passed
  - `orchestration::tests` -- 10 passed
  - `anchor_verification::tests` -- 17 passed
  - `authoritative_run::execution_kernel::tests` -- 8 passed
  - `cli::legacy::tests` -- 17 passed
  - `language_pref::tests` -- 13 passed
- Red-before-green proof for the new deterministic test: temporarily disabled the `SEQUENCE.fetch_add` increment (replaced with a non-mutating `load`), reran `test_support::` -- `allocate_unique_temp_dir_path_differs_even_when_the_clock_repeats` failed with `assertion left != right failed` (both calls produced the identical path `...code-intel-test-fixture-4242-50002-0`); restored the increment, rerun was green (2 passed).
- `cargo fmt --check` -- clean.
- `code-intel sentrux gate .` -- "No degradation detected" (god files improved 33 -> 32; this consolidation removed enough duplicated code to drop a file under threshold).
- `code-intel lint hardcoded-paths` -- "OK (290 files)".
- `cargo test -p code-intel --no-fail-fast` -- 66/66 test binaries green, 0 failures, no stale `declared_pins` triggered (nothing in `orchestration/**/*.json` pins any of the touched files).
- `git status` clean throughout -- no stray `content_contract.rs` or other unrelated modification.

Closes #231. Cross-references #352 (the 4 already-fixed sites there are unaffected).
