### PR TITLE
fix(installer): honor explicit Code Intel root (#363)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -697,6 +697,7 @@ jobs:
           $env:CODE_INTEL_SMOKE_BIN = Get-CodeIntelBinDir -Platform $platform
           cargo test -p code-intel --test install_smoke --locked packaged_install_runs_relocated_sentrux_shim -- --ignored --nocapture
           if ($LASTEXITCODE -ne 0) { throw "packaged sentrux-shim install smoke failed with exit ${LASTEXITCODE}" }
+
           # #232 / DR-0001: the doctor bootstrap node reads
           # <bin>/legacy/run-code-intel.ps1 and <bin>/pipeline.config.json
           # unconditionally; a from-release install that skips deploying them
@@ -705,6 +706,28 @@ jobs:
           # cannot see this topology either.
           cargo test -p code-intel --test install_smoke --locked packaged_install_deploys_legacy_pipeline_entrypoint -- --ignored --nocapture
           if ($LASTEXITCODE -ne 0) { throw "packaged legacy-pipeline-entrypoint install smoke failed with exit ${LASTEXITCODE}" }
+
+      - name: Packaged installer stale-home smoke
+        shell: pwsh
+        run: |
+          # DR-0001: invoke the packaged installer with an existing stale
+          # `$env:CODE_INTEL_HOME` and prove the explicit release root wins.
+          $bootstrap = Get-Content -Raw -LiteralPath (Join-Path $env:RUNNER_TEMP "code-intel-smoketest-bootstrap.json") | ConvertFrom-Json
+          $releaseRoot = [IO.Path]::GetFullPath([string]$bootstrap.release_root)
+          $staleHome = Join-Path $env:RUNNER_TEMP "code-intel-stale-home"
+          New-Item -ItemType Directory -Force -Path $staleHome | Out-Null
+          $env:CODE_INTEL_HOME = $staleHome
+          $installer = Join-Path $releaseRoot "legacy/install-code-intel-pipeline.ps1"
+          $raw = & pwsh -NoProfile -File $installer -RepoPath $releaseRoot -SkipSentruxVlangOverlay -RequireRepowise:$false -Json
+          if ($LASTEXITCODE -ne 0) {
+            throw "packaged installer stale-home smoke failed with exit code ${LASTEXITCODE}:`n$($raw -join [Environment]::NewLine)"
+          }
+          $result = ($raw -join [Environment]::NewLine) | ConvertFrom-Json
+          $actualHome = [IO.Path]::GetFullPath([string]$result.paths.codeIntelHome)
+          if ($actualHome -ne $releaseRoot) {
+            throw "packaged installer kept stale $env:CODE_INTEL_HOME '$actualHome' instead of release root '$releaseRoot'"
+          }
+          Write-Host "Packaged installer explicit-root smoke passed: $actualHome"
 
       - name: Packaged Sentrux capability closure smoke
         shell: pwsh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `sentrux gate` 在全新 checkout 上因缺基线硬崩溃：missing-baseline 前置检查原本查的是 native baseline 路径，实际 `sentrux gate` 读的是 lite 引擎的 `.sentrux/cache/lite-baseline.json`，现已对齐，缺失时正确落回 `manual_required`（fixes #322）。
+- 安装器在显式传入新的仓库或发布根目录时不再被陈旧的 `$env:CODE_INTEL_HOME` 覆盖，避免新二进制读取旧的 Provider manifest（fixes #363）。
 - 修复 workflow recommendation 的 Rust 侧 parity 回归（#314）。
 - `sentrux_gate` 全量并行测试踩踏两处根因分开修：(1) `tool_path.rs` 的 `path_search_skips_relative_entries` 探测目录名只用 `module_path!()`，在被 `#[path]` 编入多个 `cargo test` 二进制（`run_commit`/`survival_scan` 等）时对同名父模块编译时相同，跨进程共享同一 `target/tool-path-*` 目录并互相踩踏；现补上 `std::process::id()` + 进程内 `AtomicU64` 计数器，与 #175 的 `unique_temp_dir()` 同一套 pid+nonce 写法（fixes #178）。(2) `sentrux_gate.rs`/`boundary_rules_tests.rs` 里 9 处 `run_check(...).expect(...)`/`run_gate(...).expect(...)` 把"引擎子进程没跑起来"和"仓库真的检测到规则违规"报成同一个红灯；新增仅测试用的 `expect_check_ran`/`expect_gate_ran` helper，`Err` 分支 panic 出明确区分于业务断言的文案，并配 `#[should_panic]` regression 测试直接执行 `Err` 路径验证文案本身（fixes #192）。
 

--- a/legacy/scripts/tests/test-regression-fixes.ps1
+++ b/legacy/scripts/tests/test-regression-fixes.ps1
@@ -935,6 +935,8 @@ Test-Case "check-code-intel-tools.ps1 fails CODE_INTEL_HOME pointing at a missin
 # ---------------------------------------------------------------------------
 . (Get-ScriptFunctionsSource -Path (Join-Path $root "tools\code-intel-platform.psm1") -Only @(
     "Get-CodeIntelPlatform",
+    "Get-CodeIntelHome",
+    "Resolve-CodeIntelPath",
     "Get-CodeIntelPosixProfileInstruction",
     "ConvertTo-CodeIntelPosixEnvLine",
     "Update-CodeIntelPosixEnvContent",
@@ -942,6 +944,25 @@ Test-Case "check-code-intel-tools.ps1 fails CODE_INTEL_HOME pointing at a missin
     "Set-CodeIntelUserEnv",
     "Add-UserPathPrefix"
 ))
+
+Test-Case "explicit installer root wins over a stale CODE_INTEL_HOME override" {
+    $dir = New-ScratchDir "explicit-home"
+    $legacy = Join-Path $dir "legacy-release"
+    $current = Join-Path $dir "current-release"
+    New-Item -ItemType Directory -Force -Path $legacy, $current | Out-Null
+    $previousHome = $env:CODE_INTEL_HOME
+    try {
+        $env:CODE_INTEL_HOME = $legacy
+        $resolved = Get-CodeIntelHome -Root $current
+        Assert-Equal (Get-Item -LiteralPath $current).FullName $resolved "installer root must not be shadowed by a stale ambient CODE_INTEL_HOME"
+        Assert-Equal (Get-Item -LiteralPath $legacy).FullName (Get-CodeIntelHome) "ambient CODE_INTEL_HOME must remain the fallback without an explicit root"
+        Assert-Equal (Get-Item -LiteralPath $legacy).FullName (Get-CodeIntelHome -Root " ") "a whitespace root must use the ambient fallback"
+    }
+    finally {
+        $env:CODE_INTEL_HOME = $previousHome
+        Remove-Item -Recurse -Force $dir -ErrorAction SilentlyContinue
+    }
+}
 
 Test-Case "posix env: profile instruction is the single copy-paste source line per platform" {
     Assert-Equal "echo 'source ~/.config/code-intel/env.sh' >> ~/.zshrc" (Get-CodeIntelPosixProfileInstruction -Platform macos) "macos instruction must target ~/.zshrc"

--- a/legacy/tools/code-intel-platform.psm1
+++ b/legacy/tools/code-intel-platform.psm1
@@ -18,11 +18,11 @@ function Get-CodeIntelPlatform {
 function Get-CodeIntelHome {
     param([string]$Root = "")
 
-    if (-not [string]::IsNullOrWhiteSpace($env:CODE_INTEL_HOME)) {
-        return (Resolve-CodeIntelPath $env:CODE_INTEL_HOME)
-    }
     if (-not [string]::IsNullOrWhiteSpace($Root)) {
         return (Resolve-CodeIntelPath $Root)
+    }
+    if (-not [string]::IsNullOrWhiteSpace($env:CODE_INTEL_HOME)) {
+        return (Resolve-CodeIntelPath $env:CODE_INTEL_HOME)
     }
     return (Resolve-CodeIntelPath (Get-Location).Path)
 }


### PR DESCRIPTION
## Summary

Fixes the installed-topology failure where a newer Code Intel binary can read an older Provider manifest because a stale environment override shadows the explicit release root.

- Make an explicit installer/release root take precedence over the ambient `CODE_INTEL_HOME` value; preserve the ambient value when no explicit root is supplied.
- Add isolated regression coverage for explicit, ambient, and whitespace-root resolution.
- Add a packaged-install CI smoke that invokes the extracted installer with a stale environment override and asserts it uses the packaged release root.
- Document the fix in the Unreleased changelog.

Closes #363.

## Verification

- `pwsh -NoProfile -File legacy/scripts/tests/test-regression-fixes.ps1` — 51 passed, 0 failed.
- `cargo test -p code-intel --locked` — 5215 passed, 3 ignored.
- `cargo run -p code-intel -- lint hardcoded-paths` — OK (284 files).
- `cargo run -p code-intel -- sentrux gate .` — no degradation detected.
- Independent final code review — clean, no actionable findings.

## Scope

This PR changes only installer path resolution, its regression coverage, the required packaged-install smoke, and the Unreleased changelog. It does not change Provider capability semantics or install a new dependency.

## Notes

The original failure was reproduced with the installed binary at `0.7.2` and `CODE_INTEL_HOME` pointing at the `v0.7.0` release root. The stale manifest lacked the current `capabilityExec` registration for `provider.codenexus-adapt`.