### PR TITLE
fix: reject unrecognized verify arguments instead of silently ignoring them

### DIFF
--- a/crates/code-intel-cli/src/verify.rs
+++ b/crates/code-intel-cli/src/verify.rs
@@ -46,8 +46,23 @@ struct SubCheck {
 
 pub(crate) fn run_raw(raw: &[String]) -> i32 {
     let json_output = raw.iter().any(|argument| argument == "--json");
-    let repo_arg = raw.iter().find(|argument| !argument.starts_with('-'));
-    let repo = match repo_arg {
+    let mut positionals: Vec<&String> = Vec::new();
+    for argument in raw {
+        if argument == "--json" {
+            continue;
+        } else if argument.starts_with('-') {
+            return report_usage_error(
+                json_output,
+                &format!("verify: unrecognized argument: {argument}"),
+            );
+        } else {
+            positionals.push(argument);
+        }
+    }
+    if positionals.len() > 1 {
+        return report_usage_error(json_output, "verify accepts exactly one path argument");
+    }
+    let repo = match positionals.first() {
         Some(path) => PathBuf::from(path),
         None => return report_usage_error(json_output, "verify requires a <path> argument"),
     };

--- a/crates/code-intel-cli/tests/verify.rs
+++ b/crates/code-intel-cli/tests/verify.rs
@@ -252,12 +252,12 @@ fn missing_path_argument_is_a_usage_error_not_a_false_ok() {
 }
 
 #[test]
-fn verify_never_passes_a_mutating_flag_to_its_sub_checks() {
+fn verify_rejects_write_flag_as_a_usage_error_without_mutating_the_repo() {
     // Adversarial code-review-style assertion (AGENTS.md #7's "check anyway"
     // instruction): the compiled binary's argv contract for `verify` must
-    // not accept or forward `--write`. A stray `--write` on the `verify`
-    // invocation itself is simply an unrecognized positional/ignored flag,
-    // not a mutating switch, because `run_raw` never reads it.
+    // not accept or silently forward `--write`. A stray `--write` on the
+    // `verify` invocation is an unrecognized argument and must be rejected
+    // as a usage error (exit 64), not silently ignored into a false OK.
     let tree = clean_fixture("no-write-flag");
     save_baseline(&tree.0);
     let before = fs::read(tree.0.join("lib.rs")).unwrap();
@@ -269,7 +269,25 @@ fn verify_never_passes_a_mutating_flag_to_its_sub_checks() {
         .arg("--json")
         .output()
         .unwrap();
-    assert_eq!(output.status.code(), Some(0), "{output:?}");
+    assert_eq!(output.status.code(), Some(64), "{output:?}");
+    assert!(String::from_utf8_lossy(&output.stderr)
+        .contains("unrecognized argument")
+        || String::from_utf8_lossy(&output.stdout).contains("unrecognized argument"));
 
     assert_eq!(fs::read(tree.0.join("lib.rs")).unwrap(), before);
+}
+
+#[test]
+fn extra_positional_argument_is_a_usage_error_not_a_false_ok() {
+    let tree = clean_fixture("extra-positional");
+    save_baseline(&tree.0);
+
+    let output = common::cli()
+        .arg("verify")
+        .arg(&tree.0)
+        .arg("extra-arg")
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(64), "{output:?}");
+    assert!(String::from_utf8_lossy(&output.stderr).contains("exactly one path"));
 }

--- a/crates/code-intel-cli/tests/verify.rs
+++ b/crates/code-intel-cli/tests/verify.rs
@@ -270,9 +270,10 @@ fn verify_rejects_write_flag_as_a_usage_error_without_mutating_the_repo() {
         .output()
         .unwrap();
     assert_eq!(output.status.code(), Some(64), "{output:?}");
-    assert!(String::from_utf8_lossy(&output.stderr)
-        .contains("unrecognized argument")
-        || String::from_utf8_lossy(&output.stdout).contains("unrecognized argument"));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("unrecognized argument")
+            || String::from_utf8_lossy(&output.stdout).contains("unrecognized argument")
+    );
 
     assert_eq!(fs::read(tree.0.join("lib.rs")).unwrap(), before);
 }


### PR DESCRIPTION
Closes #369

## Bug

`code-intel verify <path> [--json]`'s `run_raw` (added in #368 / #367) silently ignored any unrecognized dash-prefixed argument, so `code-intel verify . --write` exited 0 as though `--write` had been accepted, instead of rejecting it as unknown.

## Fix

- `run_raw` now classifies every raw argument as `--json`, a positional `<path>` candidate, or an unrecognized dash-prefixed flag.
- Exactly one positional argument is accepted; zero is the existing "missing path" usage error, more than one is a new "extra argument" usage error.
- Any unrecognized dash-prefixed token (`--write`, `--foo`, stray `-`/`--`) is now rejected via the existing `report_usage_error`, exit `64`.
- `--json` still works in either order relative to `<path>`.

## Tests

- Renamed `verify_never_passes_a_mutating_flag_to_its_sub_checks` -> `verify_rejects_write_flag_as_a_usage_error_without_mutating_the_repo`; it now asserts exit `64` and an "unrecognized argument" message, keeping the byte-identical repo-contents assertion (now true because the command errors out before touching anything).
- Added `extra_positional_argument_is_a_usage_error_not_a_false_ok` covering `verify . extra-arg`.

## Verification

- `cargo test -p code-intel --test verify` — 11 passed.
- `cargo test -p code-intel --bin code-intel` — 1006 passed, 1 ignored.
- `cargo test -p code-intel` (full suite) — 100% green on a clean run; two isolated reruns each hit a different pre-existing timing-sensitive flake in `perf_optimize::weco_process` (matches the family of known flakes called out in AGENTS.md/issue triage) plus a same-second-clock race in `friction_log::log_cmd`, all of which pass individually and are unrelated to this diff (verify.rs / verify tests only).
- Release build: `cargo build --release --bin code-intel -p code-intel`.
- `./target/release/code-intel.exe lint hardcoded-paths .` — OK (284 files).
- `./target/release/code-intel.exe sentrux gate .` — no degradation detected.
- `./target/release/code-intel.exe repin --repo .` — clean, no stale pins.
- Manual smoke test:
  - `verify . --write` -> `verify: ERROR: verify: unrecognized argument: --write`, exit `64` (previously exit `0`).
  - `verify .` -> exit `0`, human report, all three sub-checks PASS.
  - `verify . --json` -> exit `0`, `{"ok": true, ...}` JSON report.
